### PR TITLE
Fixes #226, #227, #232, #236, #238, #239 - task improvements

### DIFF
--- a/monix-eval/shared/src/main/scala/monix/eval/Coeval.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Coeval.scala
@@ -127,12 +127,30 @@ sealed abstract class Coeval[+A] extends Serializable { self =>
       case Now(_) => Error(new NoSuchElementException("failed"))
     }
 
+  /** Returns a new task that upon evaluation will execute
+    * the given function for the generated element,
+    * transforming the source into a `Coeval[Unit]`.
+    *
+    * Similar in spirit with normal [[foreach]], but lazy,
+    * as obviously nothing gets executed at this point.
+    */
+  def foreachL(f: A => Unit): Coeval[Unit] =
+    self.map { a => f(a); () }
+
+  /** Triggers the evaluation of the source, executing
+    * the given function for the generated element.
+    *
+    * The application of this function has strict
+    * behavior, as the coeval is immediately executed.
+    */
+  def foreach(f: A => Unit): Unit =
+    foreachL(f).value
+
   /** Returns a new Coeval that applies the mapping function to
     * the element emitted by the source.
     */
   def map[B](f: A => B): Coeval[B] =
     flatMap(a => try Now(f(a)) catch { case NonFatal(ex) => Error(ex) })
-
 
   /** Creates a new [[Coeval]] that will expose any triggered error from
     * the source.
@@ -279,10 +297,6 @@ sealed abstract class Coeval[+A] extends Serializable { self =>
     */
   def zipMap[B,C](that: Coeval[B])(f: (A,B) => C): Coeval[C] =
     for (a <- this; b <- that) yield f(a,b)
-
-  @deprecated("Renamed, please use Coeval.zipMap", since="2.0-RC12")
-  def zipWith[B,C](that: Coeval[B])(f: (A,B) => C): Coeval[C] =
-    for (a <- this; b <- that) yield f(a,b)
 }
 
 object Coeval {
@@ -332,16 +346,23 @@ object Coeval {
   /** Alias for [[eval]]. */
   def delay[A](a: => A): Coeval[A] = eval(a)
 
-  /** Alias for [[eval]]. Deprecated. */
-  @deprecated("Renamed, please use Coeval.apply or Coeval.eval", since="2.0-RC12")
-  def evalAlways[A](a: => A): Coeval[A] = eval(a)
-
   /** A `Coeval[Unit]` provided for convenience. */
   val unit: Coeval[Unit] = Now(())
 
   /** Builds a `Coeval` out of a Scala `Try` value. */
   def fromTry[A](a: Try[A]): Coeval[A] =
     Attempt.fromTry(a)
+
+  /** Keeps calling `f` until it returns a `Right` result.
+    *
+    * Based on Phil Freeman's
+    * [[http://functorial.com/stack-safety-for-free/index.pdf Stack Safety for Free]].
+    */
+  def tailRecM[A,B](a: A)(f: A => Coeval[Either[A,B]]): Coeval[B] =
+    Coeval.defer(f(a)).flatMap {
+      case Left(continueA) => tailRecM(continueA)(f)
+      case Right(b) => Coeval.now(b)
+    }
 
   /** Transforms a `TraversableOnce` of coevals into a coeval producing
     * the same collection of gathered results.
@@ -439,27 +460,6 @@ object Coeval {
     zipMap2(fa12345, fa6) { case ((a1, a2, a3, a4, a5), a6) => f(a1, a2, a3, a4, a5, a6) }
   }
 
-  @deprecated("Renamed to Coeval.zipMap2", since="2.0-RC12")
-  def zipWith2[A1,A2,R](fa1: Coeval[A1], fa2: Coeval[A2])(f: (A1,A2) => R): Coeval[R] =
-    zipMap2(fa1, fa2)(f)
-
-  @deprecated("Renamed to Coeval.zipMap3", since="2.0-RC12")
-  def zipWith3[A1,A2,A3,R](fa1: Coeval[A1], fa2: Coeval[A2], fa3: Coeval[A3])(f: (A1,A2,A3) => R): Coeval[R] =
-    zipMap3(fa1, fa2, fa3)(f)
-
-  @deprecated("Renamed to Coeval.zipMap4", since="2.0-RC12")
-  def zipWith4[A1,A2,A3,A4,R](fa1: Coeval[A1], fa2: Coeval[A2], fa3: Coeval[A3], fa4: Coeval[A4])(f: (A1,A2,A3,A4) => R): Coeval[R] =
-    zipMap4(fa1, fa2, fa3, fa4)(f)
-
-  @deprecated("Renamed to Coeval.zipMap5", since="2.0-RC12")
-  def zipWith5[A1,A2,A3,A4,A5,R](fa1: Coeval[A1], fa2: Coeval[A2], fa3: Coeval[A3], fa4: Coeval[A4], fa5: Coeval[A5])(f: (A1,A2,A3,A4,A5) => R): Coeval[R] =
-    zipMap5(fa1, fa2, fa3, fa4, fa5)(f)
-
-  @deprecated("Renamed to Coeval.zipMap6", since="2.0-RC12")
-  def zipWith6[A1,A2,A3,A4,A5,A6,R](fa1: Coeval[A1], fa2: Coeval[A2], fa3: Coeval[A3], fa4: Coeval[A4], fa5: Coeval[A5], fa6: Coeval[A6])(f: (A1,A2,A3,A4,A5,A6) => R): Coeval[R] =
-    zipMap6(fa1, fa2, fa3, fa4, fa5, fa6)(f)
-
-
   /** The `Attempt` represents a strict, already evaluated result
     * of a [[Coeval]] that either resulted in success, wrapped in a
     * [[Now]], or in an error, wrapped in a [[Error]].
@@ -468,32 +468,39 @@ object Coeval {
     */
   sealed abstract class Attempt[+A] extends Coeval[A] with Product {
     self =>
+
+    /** Retrieve the (successful) value or throw the error.
+      *
+      * Alias for [[Coeval.value]].
+      */
+    final def get: A = value
+
     /** Returns true if value is a successful one. */
-    def isSuccess: Boolean = this match {
+    final def isSuccess: Boolean = this match {
       case Now(_) => true
       case _ => false
     }
 
     /** Returns true if result is an error. */
-    def isFailure: Boolean = this match {
+    final def isFailure: Boolean = this match {
       case Error(_) => true
       case _ => false
     }
 
-    override def failed: Attempt[Throwable] =
+    override final def failed: Attempt[Throwable] =
       self match {
         case Now(_) => Error(new NoSuchElementException("failed"))
         case Error(ex) => Now(ex)
       }
 
     /** Converts this attempt into a `scala.util.Try`. */
-    def asScala: Try[A] =
+    final def asScala: Try[A] =
       this match {
         case Now(a) => Success(a)
         case Error(ex) => Failure(ex)
       }
 
-    override def materializeAttempt: Attempt[Attempt[A]] =
+    override final def materializeAttempt: Attempt[Attempt[A]] =
       self match {
         case now@Now(_) =>
           Now(now)
@@ -501,13 +508,13 @@ object Coeval {
           Now(Error(ex))
       }
 
-    override def dematerializeAttempt[B](implicit ev: <:<[A, Attempt[B]]): Attempt[B] =
+    override final def dematerializeAttempt[B](implicit ev: <:<[A, Attempt[B]]): Attempt[B] =
       self match {
         case Now(now) => now
         case error@Error(_) => error
       }
 
-    override def memoize: Attempt[A] = this
+    override final def memoize: Attempt[A] = this
   }
 
   object Attempt {
@@ -540,9 +547,6 @@ object Coeval {
 
     override def runAttempt: Error = this
   }
-
-  @deprecated("Type renamed, use Eval.Once", since="2.0-RC12")
-  type EvalOnce[+A] = Once[A]
 
   /** Constructs a lazy [[Coeval]] instance that gets evaluated
     * only once.
@@ -586,9 +590,6 @@ object Coeval {
     def unapply[A](coeval: Once[A]): Some[() => A] =
       Some(coeval)
   }
-
-  @deprecated("Type renamed, use Eval.Always", since="2.0-RC12")
-  type EvalAlways[+A] = Always[A]
 
   /** Constructs a lazy [[Coeval]] instance.
     *
@@ -669,13 +670,14 @@ object Coeval {
   /** Implicit type-class instances of [[Coeval]]. */
   implicit val typeClassInstances: TypeClassInstances = new TypeClassInstances
 
+
   /** Groups the implementation for the type-classes defined in [[monix.types]]. */
   class TypeClassInstances
     extends DeferrableClass[Coeval]
-    with MemoizableClass[Coeval]
-    with RecoverableClass[Coeval,Throwable]
-    with ComonadClass[Coeval]
-    with MonadRecClass[Coeval] {
+      with MemoizableClass[Coeval]
+      with RecoverableClass[Coeval,Throwable]
+      with ComonadClass[Coeval]
+      with MonadRecClass[Coeval] {
 
     override def pure[A](a: A): Coeval[A] = Coeval.now(a)
     override def defer[A](fa: => Coeval[A]): Coeval[A] = Coeval.defer(fa)

--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -17,36 +17,34 @@
 
 package monix.eval
 
-import monix.types._
 import monix.eval.Coeval.{Attempt, Error, Now}
-import monix.eval.Task._
-import monix.execution.Ack.Stop
-import monix.execution.atomic.{Atomic, AtomicAny, PaddingStrategy}
-import monix.execution.cancelables.{CompositeCancelable, SingleAssignmentCancelable, StackedCancelable}
-import monix.execution.rstreams.Subscription
+import monix.eval.internal._
+import monix.execution.atomic.Atomic
+import monix.execution.cancelables.StackedCancelable
+import monix.execution.internal.Platform
+import monix.execution.misc.ThreadLocal
 import monix.execution.schedulers.ExecutionModel
 import monix.execution.{Cancelable, CancelableFuture, Scheduler}
-import org.reactivestreams.Subscriber
+import monix.types._
 
 import scala.annotation.tailrec
 import scala.collection.generic.CanBuildFrom
 import scala.collection.mutable
-import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{Future, Promise, TimeoutException}
 import scala.util.control.NonFatal
-import scala.util.{Failure, Sorting, Success, Try}
+import scala.util.{Failure, Success, Try}
 
 /** `Task` represents a specification for a possibly lazy or
-  * asynchronous computation, which when executed will produce
-  * an `A` as a result, along with possible side-effects.
+  * asynchronous computation, which when executed will produce an `A`
+  * as a result, along with possible side-effects.
   *
   * Compared with `Future` from Scala's standard library, `Task` does
   * not represent a running computation or a value detached from time,
   * as `Task` does not execute anything when working with its builders
   * or operators and it does not submit any work into any thread-pool,
-  * the execution eventually taking place only after `runAsync`
-  * is called and not before that.
+  * the execution eventually taking place only after `runAsync` is
+  * called and not before that.
   *
   * Note that `Task` is conservative in how it spawns logical threads.
   * Transformations like `map` and `flatMap` for example will default
@@ -56,23 +54,41 @@ import scala.util.{Failure, Sorting, Success, Try}
   * implementation's job to decide on the best execution model. All
   * you are guaranteed is asynchronous execution after executing
   * `runAsync`.
+  *
+  * @define runAsyncDesc Triggers the asynchronous execution.
+  *
+  *         Without invoking `runAsync` on a `Task`, nothing
+  *         gets evaluated, as a `Task` has lazy behavior.
   */
 sealed abstract class Task[+A] extends Serializable { self =>
-  /** Triggers the asynchronous execution.
+  import monix.eval.Task._
+
+  /** $runAsyncDesc
     *
     * @param cb is a callback that will be invoked upon completion.
+    *
+    * @param s is an injected [[monix.execution.Scheduler Scheduler]]
+    *        that gets used whenever asynchronous boundaries are needed
+    *        when evaluating the task
+    *
     * @return a [[monix.execution.Cancelable Cancelable]] that can
     *         be used to cancel a running task
     */
   def runAsync(cb: Callback[A])(implicit s: Scheduler): Cancelable = {
     val conn = StackedCancelable()
-    Task.unsafeStartNow[A](this, s, conn, Callback.safe(cb))
+    val context = Context(s, conn, startFrameRef(), defaultOptions)
+    Task.unsafeStartNow[A](this, context, Callback.safe(cb))
     conn
   }
 
-  /** Triggers the asynchronous execution.
+  /** $runAsyncDesc
     *
     * @param f is a callback that will be invoked upon completion.
+    *
+    * @param s is an injected [[monix.execution.Scheduler Scheduler]]
+    *        that gets used whenever asynchronous boundaries are needed
+    *        when evaluating the task
+    *
     * @return a [[monix.execution.Cancelable Cancelable]] that can
     *         be used to cancel a running task
     */
@@ -82,19 +98,25 @@ sealed abstract class Task[+A] extends Serializable { self =>
       def onError(ex: Throwable): Unit = f(Failure(ex))
     })
 
-  /** Triggers the asynchronous execution.
+  /** $runAsyncDesc
+    *
+    * @param s is an injected [[monix.execution.Scheduler Scheduler]]
+    *        that gets used whenever asynchronous boundaries are needed
+    *        when evaluating the task
     *
     * @return a [[monix.execution.CancelableFuture CancelableFuture]]
     *         that can be used to extract the result or to cancel
     *         a running task.
     */
-  def runAsync(implicit s: Scheduler): CancelableFuture[A] =
-    Task.startTrampolineForFuture(s, this, Nil)
+  def runAsync(implicit s: Scheduler): CancelableFuture[A] = {
+    val context = Context(s, StackedCancelable(), startFrameRef(), defaultOptions)
+    Task.startTrampolineForFuture(this, context, Nil)
+  }
 
-  /** Transforms a [[Task]] into a [[Coeval]] that tries to
-    * execute the source synchronously, returning either `Right(value)`
-    * in case a value is available immediately, or `Left(future)` in case
-    * we have an asynchronous boundary.
+  /** Transforms a [[Task]] into a [[Coeval]] that tries to execute the
+    * source synchronously, returning either `Right(value)` in case a
+    * value is available immediately, or `Left(future)` in case we
+    * have an asynchronous boundary.
     */
   def coeval(implicit s: Scheduler): Coeval[Either[CancelableFuture[A], A]] =
     Coeval.eval {
@@ -138,37 +160,16 @@ sealed abstract class Task[+A] extends Serializable { self =>
     * executing and mirroring the result of the source.
     */
   def delayExecution(timespan: FiniteDuration): Task[A] =
-    Async { (scheduler, conn, cb) =>
-      implicit val s = scheduler
-      val c = SingleAssignmentCancelable()
-      conn push c
-
-      c := s.scheduleOnce(timespan.length, timespan.unit, new Runnable {
-        def run(): Unit = {
-          conn.pop()
-          Task.startTrampolineRunLoop(scheduler, conn, self, Callback.async(cb), Nil)
-        }
-      })
-    }
+    TaskDelayExecution(self, timespan)
 
   /** Returns a task that waits for the specified `trigger` to succeed
     * before mirroring the result of the source.
     *
-    * If the `trigger` ends in error, then the resulting task will also
-    * end in error.
+    * If the `trigger` ends in error, then the resulting task will
+    * also end in error.
     */
   def delayExecutionWith(trigger: Task[Any]): Task[A] =
-    Async { (scheduler, conn, cb) =>
-      implicit val s = scheduler
-
-      // Async boundary forced, prevents stack-overflows
-      Task.unsafeStartAsync(trigger, scheduler, conn, new Callback[Any] {
-        def onSuccess(value: Any): Unit =
-          Task.unsafeStartAsync(self, scheduler, conn, Callback.async(cb))
-        def onError(ex: Throwable): Unit =
-          cb.asyncOnError(ex)
-      })
-    }
+    TaskDelayExecutionWith(self, trigger)
 
   /** Returns a task that executes the source immediately on `runAsync`,
     * but before emitting the `onSuccess` result for the specified
@@ -178,28 +179,7 @@ sealed abstract class Task[+A] extends Serializable { self =>
     * with no delay.
     */
   def delayResult(timespan: FiniteDuration): Task[A] =
-    Async { (scheduler, conn, cb) =>
-      implicit val s = scheduler
-
-      Task.unsafeStartAsync(self, scheduler, conn, new Callback[A] {
-        def onSuccess(value: A): Unit = {
-          val task = SingleAssignmentCancelable()
-          conn push task
-
-          // Delaying result
-          task := scheduler.scheduleOnce(timespan.length, timespan.unit,
-            new Runnable {
-              def run(): Unit = {
-                conn.pop()
-                cb.asyncOnSuccess(value)
-              }
-            })
-        }
-
-        def onError(ex: Throwable): Unit =
-          cb.asyncOnError(ex)
-      })
-    }
+    TaskDelayResult(self, timespan)
 
   /** Returns a task that executes the source immediately on `runAsync`,
     * but before emitting the `onSuccess` result for the specified
@@ -209,52 +189,145 @@ sealed abstract class Task[+A] extends Serializable { self =>
     * with no delay.
     */
   def delayResultBySelector[B](selector: A => Task[B]): Task[A] =
-    Async { (scheduler, conn, cb) =>
-      implicit val s = scheduler
+    TaskDelayResultBySelector(self, selector)
 
-      Task.unsafeStartAsync(self, scheduler, conn, new Callback[A] {
-        def onSuccess(value: A): Unit = {
-          var streamErrors = true
-          try {
-            val trigger = selector(value)
-            streamErrors = false
-            // Delaying result
-            Task.unsafeStartAsync(trigger, scheduler, conn, new Callback[B] {
-              def onSuccess(b: B): Unit = cb.asyncOnSuccess(value)
-              def onError(ex: Throwable): Unit = cb.asyncOnError(ex)
-            })
-          } catch {
-            case NonFatal(ex) if streamErrors =>
-              cb.asyncOnError(ex)
-          }
-        }
-
-        def onError(ex: Throwable): Unit =
-          cb.asyncOnError(ex)
-      })
-    }
-
-
-  /** Mirrors the given source `Task`, but upon execution ensure
-    * that evaluation forks into a separate (logical) thread.
+  /** Mirrors the given source `Task`, but upon execution ensure that
+    * evaluation forks into a separate (logical) thread spawned by the
+    * given `scheduler`.
     *
-    * The given [[monix.execution.Scheduler Scheduler]]  will be
-    * used for execution of the [[Task]], effectively overriding the
-    * `Scheduler` that's passed in `runAsync`. Thus you can
-    * execute a whole `Task` on a separate thread-pool, useful for
-    * example in case of doing I/O.
+    * The given [[monix.execution.Scheduler Scheduler]] will be used
+    * for execution of the [[Task]], effectively overriding the
+    * `Scheduler` that's passed in `runAsync`. Thus you can execute a
+    * whole `Task` on a separate thread-pool, useful for example in
+    * case of doing I/O.
     *
     * NOTE: the logic one cares about won't necessarily end up
-    * executed on the given scheduler, or for transformations
-    * that happen from here on. It all depends on what overrides
-    * or asynchronous boundaries happen. But this function
-    * guarantees that the this `Task` run-loop begins executing
-    * on the given scheduler.
+    * executed on the given scheduler, or for transformations that
+    * happen from here on. It all depends on what overrides or
+    * asynchronous boundaries happen. But this function guarantees
+    * that the this `Task` run-loop begins executing on the given
+    * scheduler.
+    *
+    * Alias for
+    * [[Task.fork[A](fa:monix\.eval\.Task[A],scheduler* Task.fork(fa,scheduler)]].
     *
     * @param s is the scheduler to use for execution
     */
   def executeOn(s: Scheduler): Task[A] =
     Task.fork(this, s)
+
+  /** Mirrors the given source `Task`, but upon execution ensure
+    * that evaluation forks into a separate (logical) thread.
+    *
+    * The [[monix.execution.Scheduler Scheduler]] used will be
+    * the one that is used to start the run-loop in `runAsync`.
+    *
+    * Alias for [[Task.fork[A](fa:monix\.eval\.Task[A])* Task.fork(fa)]].
+    */
+  def executeWithFork: Task[A] =
+    Task.fork(this)
+
+  /** Returns a new task that will execute the source with a different
+    * [[monix.execution.schedulers.ExecutionModel ExecutionModel]].
+    *
+    * This allows fine-tuning the options injected by the scheduler
+    * locally. Example:
+    *
+    * {{{
+    *   import monix.execution.schedulers.ExecutionModel.AlwaysAsyncExecution
+    *   task.executeWithModel(AlwaysAsyncExecution)
+    * }}}
+    *
+    * @param em is the
+    *        [[monix.execution.schedulers.ExecutionModel ExecutionModel]]
+    *        with which the source will get evaluated on `runAsync`
+    */
+  def executeWithModel(em: ExecutionModel): Task[A] =
+    TaskExecuteWithModel(self, em)
+
+  /** Returns a new task that will execute the source with a different
+    * set of [[Task.Options Options]].
+    *
+    * This allows fine-tuning the default options. Example:
+    *
+    * {{{
+    *   task.executeWithOptions(_.enableAutoCancelableRunLoops)
+    * }}}
+    *
+    * @param f is a function that takes the source's current set of
+    *        [[Task.Options options]] and returns a modified set of
+    *        options that will be used to execute the source
+    *        upon `runAsync`
+    */
+  def executeWithOptions(f: Options => Options): Task[A] =
+    TaskExecuteWithOptions(self, f)
+
+  /** Introduces an asynchronous boundary at the current stage in the
+    * asynchronous processing pipeline.
+    *
+    * Consider the following example:
+    *
+    * {{{
+    *   import monix.execution.Scheduler
+    *   val io = Scheduler.io()
+    *
+    *   val source = Task(1).executeOn(io).map(_ + 1)
+    * }}}
+    *
+    * That task is being forced to execute on the `io` scheduler,
+    * including the `map` transformation that follows after
+    * `executeOn`. But what if we want to jump with the execution
+    * run-loop on the default scheduler for the following
+    * transformations?
+    *
+    * Then we can do:
+    *
+    * {{{
+    *   source.asyncBoundary.map(_ + 2)
+    * }}}
+    *
+    * In this sample, whatever gets evaluated by the `source` will
+    * happen on the `io` scheduler, however the `asyncBoundary` call
+    * will make all subsequent operations to happen on the default
+    * scheduler.
+    */
+  def asyncBoundary: Task[A] =
+    self.flatMap(r => Task.forkedUnit.map(_ => r))
+
+  /** Introduces an asynchronous boundary at the current stage in the
+    * asynchronous processing pipeline, making processing to jump on
+    * the given [[monix.execution.Scheduler Scheduler]] (until the
+    * next async boundary).
+    *
+    * Consider the following example:
+    * {{{
+    *   import monix.execution.Scheduler
+    *   val io = Scheduler.io()
+    *
+    *   val source = Task(1).executeOn(io).map(_ + 1)
+    * }}}
+    *
+    * That task is being forced to execute on the `io` scheduler,
+    * including the `map` transformation that follows after
+    * `executeOn`. But what if we want to jump with the execution
+    * run-loop on another scheduler for the following transformations?
+    *
+    * Then we can do:
+    * {{{
+    *   import monix.execution.Scheduler.global
+    *
+    *   source.asyncBoundary(global).map(_ + 2)
+    * }}}
+    *
+    * In this sample, whatever gets evaluated by the `source` will
+    * happen on the `io` scheduler, however the `asyncBoundary` call
+    * will make all subsequent operations to happen on the specified
+    * `global` scheduler.
+    *
+    * @param s is the scheduler triggering the asynchronous boundary
+    */
+  def asyncBoundary(s: Scheduler): Task[A] =
+    self.flatMap(r => Task.forkedUnit.executeOn(s).map(_ => r))
 
   /** Returns a failed projection of this task.
     *
@@ -269,18 +342,45 @@ sealed abstract class Task[+A] extends Serializable { self =>
       case Now(_) => raiseError(new NoSuchElementException("failed"))
     }
 
-  /** Returns a new Task that applies the mapping function to
-    * the element emitted by the source.
+  /** Returns a new task that upon evaluation will execute the given
+    * function for the generated element, transforming the source into
+    * a `Task[Unit]`.
+    *
+    * Similar in spirit with normal [[foreach]], but lazy, as
+    * obviously nothing gets executed at this point.
+    */
+  def foreachL(f: A => Unit): Task[Unit] =
+    self.map { a => f(a); () }
+
+  /** Triggers the evaluation of the source, executing the given
+    * function for the generated element.
+    *
+    * The application of this function has strict behavior, as the
+    * task is immediately executed.
+    */
+  def foreach(f: A => Unit)(implicit s: Scheduler): CancelableFuture[Unit] =
+    foreachL(f).runAsync(s)
+
+  /** Returns a new Task that applies the mapping function to the
+    * element emitted by the source.
     */
   def map[B](f: A => B): Task[B] =
     flatMap(a => try now(f(a)) catch { case NonFatal(ex) => raiseError(ex) })
 
-  /** Returns a new `Task` in which `f` is scheduled to be run on completion.
-    * This would typically be used to release any resources acquired by this
-    * `Task`.
+  /** Returns a new `Task` in which `f` is scheduled to be run on
+    * completion.  This would typically be used to release any
+    * resources acquired by this `Task`.
     *
-    * The returned `Task` completes when both the source and the
-    * task returned by `f` complete.
+    * The returned `Task` completes when both the source and the task
+    * returned by `f` complete.
+    *
+    * NOTE: The given function is only called when the task is
+    * complete.  However the function does not get called if the task
+    * gets canceled.  Cancellation is a process that's concurrent with
+    * the execution of a task and hence needs special handling.
+    *
+    * See [[doOnCancel]] for specifying a callback to call on
+    * canceling a task.
     */
   def doOnFinish(f: Option[Throwable] => Task[Unit]): Task[A] =
     materializeAttempt.flatMap {
@@ -289,6 +389,19 @@ sealed abstract class Task[+A] extends Serializable { self =>
       case Error(ex) =>
         f(Some(ex)).flatMap(_ => raiseError(ex))
     }
+
+  /** Returns a new `Task` that will mirror the source, but that will
+    * execute the given `callback` if the task gets canceled before
+    * completion.
+    *
+    * This only works for premature cancellation. See [[doOnFinish]]
+    * for triggering callbacks when the source finishes.
+    *
+    * @param callback is the callback to execute if the task gets
+    *        canceled prematurely
+    */
+  def doOnCancel(callback: Task[Unit]): Task[A] =
+    TaskDoOnCancel(self, callback)
 
   /** Creates a new [[Task]] that will expose any triggered error from
     * the source.
@@ -303,20 +416,25 @@ sealed abstract class Task[+A] extends Serializable { self =>
     self match {
       case Delay(coeval) =>
         Suspend(() => Delay(coeval.materializeAttempt))
+
       case Suspend(thunk) =>
         Suspend(() => try {
           thunk().materializeAttempt
         } catch { case NonFatal(ex) =>
           now(Error(ex))
         })
+
       case ref: MemoizeSuspend[_] =>
         val task = ref.asInstanceOf[MemoizeSuspend[A]]
-        Async[Attempt[A]] { (s, conn, cb) =>
-          Task.unsafeStartAsync[A](task, s, conn, new Callback[A] {
+        Async[Attempt[A]] { (ctx, cb) =>
+          import ctx.{scheduler => s}
+          // Light asynchronous boundary
+          Task.unsafeStartTrampolined[A](task, ctx, new Callback[A] {
             def onSuccess(value: A): Unit = cb.asyncOnSuccess(Now(value))(s)
             def onError(ex: Throwable): Unit = cb.asyncOnSuccess(Error(ex))(s)
           })
         }
+
       case BindSuspend(thunk, g) =>
         BindSuspend[Attempt[Any], Attempt[A]](
           () => Suspend(() =>
@@ -335,20 +453,25 @@ sealed abstract class Task[+A] extends Serializable { self =>
             case Error(ex) =>
               now(Error(ex))
           })
+
       case Async(onFinish) =>
-        Async((s, conn, cb) =>
-          s.executeTrampolined(() => onFinish(s, conn, new Callback[A] {
+        Async { (context, cb) =>
+          import context.{scheduler => s}
+          s.executeTrampolined(() => onFinish(context, new Callback[A] {
             def onSuccess(value: A): Unit = cb.asyncOnSuccess(Now(value))(s)
             def onError(ex: Throwable): Unit = cb.asyncOnSuccess(Error(ex))(s)
-          })))
+          }))
+        }
 
       case BindAsync(onFinish, g) =>
         BindAsync[Attempt[Any], Attempt[A]](
-          (s, conn, cb) =>
-            s.executeTrampolined(() => onFinish(s, conn, new Callback[Any] {
+          (context, cb) => {
+            import context.{scheduler => s}
+            s.executeTrampolined(() => onFinish(context, new Callback[Any] {
               def onSuccess(value: Any): Unit = cb.asyncOnSuccess(Now(value))(s)
               def onError(ex: Throwable): Unit = cb.asyncOnSuccess(Error(ex))(s)
-            })),
+            }))
+          },
           result => result match {
             case Now(any) =>
               try {
@@ -457,35 +580,7 @@ sealed abstract class Task[+A] extends Serializable { self =>
     * Reactive Streams specification.
     */
   def toReactivePublisher[B >: A](implicit s: Scheduler): org.reactivestreams.Publisher[B] =
-    new org.reactivestreams.Publisher[B] {
-      def subscribe(out: Subscriber[_ >: B]): Unit = {
-        out.onSubscribe(new Subscription {
-          private[this] var isActive = true
-          private[this] val conn = StackedCancelable()
-
-          def request(n: Long): Unit = {
-            require(n > 0, "n must be strictly positive, according to " +
-              "the Reactive Streams contract, rule 3.9")
-
-            if (isActive) Task.unsafeStartAsync[A](self, s, conn, Callback.safe(
-              new Callback[A] {
-                def onError(ex: Throwable): Unit =
-                  out.onError(ex)
-
-                def onSuccess(value: A): Unit = {
-                  out.onNext(value)
-                  out.onComplete()
-                }
-              }))
-          }
-
-          def cancel(): Unit = {
-            isActive = false
-            conn.cancel()
-          }
-        })
-      }
-    }
+    TaskToReactivePublisher[B](self)(s)
 
   /** Returns a Task that mirrors the source Task but that triggers a
     * `TimeoutException` in case the given duration passes without the
@@ -573,10 +668,6 @@ object Task extends TaskInstances {
   /** Alias for [[coeval]]. */
   def delay[A](a: => A): Task[A] = eval(a)
 
-  /** Alias for [[coeval]]. Deprecated. */
-  @deprecated("Renamed, please use Task.eval", since="2.0-RC12")
-  def evalAlways[A](a: => A): Task[A] = eval(a)
-
   /** A [[Task]] instance that upon evaluation will never complete. */
   def never[A]: Task[A] = neverRef
 
@@ -584,11 +675,25 @@ object Task extends TaskInstances {
   def fromTry[A](a: Try[A]): Task[A] =
     Delay(Coeval.fromTry(a))
 
+  /** Keeps calling `f` until it returns a `Right` result.
+    *
+    * Based on Phil Freeman's
+    * [[http://functorial.com/stack-safety-for-free/index.pdf Stack Safety for Free]].
+    */
+  def tailRecM[A,B](a: A)(f: A => Task[Either[A,B]]): Task[B] =
+    Task.defer(f(a)).flatMap {
+      case Left(continueA) => tailRecM(continueA)(f)
+      case Right(b) => Task.now(b)
+    }
+
   private[this] final val neverRef: Async[Nothing] =
-    Async((_,_,_) => ())
+    Async((_,_) => ())
 
   /** A `Task[Unit]` provided for convenience. */
   final val unit: Task[Unit] = Delay(Coeval.unit)
+
+  /** Reusable task instance used in `Task#asyncBoundary` */
+  private final val forkedUnit = Task.fork(Task.unit)
 
   /** Transforms a [[Coeval]] into a [[Task]]. */
   def coeval[A](a: Coeval[A]): Task[A] = Delay(a)
@@ -602,9 +707,10 @@ object Task extends TaskInstances {
     * @param fa is the task that will get executed asynchronously
     */
   def fork[A](fa: Task[A]): Task[A] =
-    Async { (s, conn, cb) =>
+    Async { (context, cb) =>
       // Asynchronous boundary
-      Task.startTrampolineAsync(s, conn, fa, Callback.async(cb)(s), Nil)
+      implicit val s = context.scheduler
+      Task.unsafeStartAsync(fa, context, Callback.async(cb))
     }
 
   /** Mirrors the given source `Task`, but upon execution ensure
@@ -620,9 +726,10 @@ object Task extends TaskInstances {
     * @param scheduler is the scheduler to use for execution
     */
   def fork[A](fa: Task[A], scheduler: Scheduler): Task[A] =
-    Async { (_, conn, cb) =>
+    Async { (context, cb) =>
       // Asynchronous boundary
-      Task.startTrampolineAsync(scheduler, conn, fa, Callback.async(cb)(scheduler), Nil)
+      val newContext = context.copy(scheduler = scheduler)
+      Task.unsafeStartAsync(fa, newContext, Callback.async(cb)(scheduler))
     }
 
   /** Create a `Task` from an asynchronous computation.
@@ -640,65 +747,60 @@ object Task extends TaskInstances {
     *
     * Contract:
     *
-    *  1. execution of the `register` callback is async,
-    *     forking a (logical) thread
-    *  2. execution of the `onSuccess` and `onError` callbacks,
-    *     is async, forking another (logical) thread
+    *  - execution of the `register` callback is asynchronous,
+    *    always forking a (logical) thread
+    *  - execution of the `onSuccess` and `onError` callbacks, is also
+    *    async, however they are executed on the current thread /
+    *    call-stack if the scheduler is enhanced for execution of
+    *    [[monix.execution.schedulers.TrampolinedRunnable trampolined runnables]]
     *
-    * Point number 2 happens because [[create]] is supposed to be safe
-    * or otherwise, depending on the executed logic, one can end up with
-    * a stack overflow exception. So this contract happens in order to
-    * guarantee safety. In order to bypass rule number 2, one can use
-    * [[unsafeCreate]], but that's for people knowing what they are doing.
+    * This asynchrony is needed because [[create]] is supposed to be
+    * safe or otherwise, depending on the executed logic, one can end
+    * up with a stack overflow exception. So this contract happens in
+    * order to guarantee safety. In order to bypass this, one can use
+    * [[unsafeCreate]], but that's more difficult and meant for people
+    * knowing what they are doing.
     *
     * @param register is a function that will be called when this `Task`
     *        is executed, receiving a callback as a parameter, a
     *        callback that the user is supposed to call in order to
     *        signal the desired outcome of this `Task`.
     */
-  def create[A](register: (Scheduler, Callback[A]) => Cancelable): Task[A] = {
-    // Wraps a callback into an implementation that pops the stack
-    // before calling onSuccess/onError
-    final class CreateCallback(conn: StackedCancelable, cb: Callback[A])
-      (implicit s: Scheduler)
-      extends Callback[A] {
-
-      def onSuccess(value: A): Unit = {
-        conn.pop()
-        cb.asyncOnSuccess(value)
-      }
-
-      def onError(ex: Throwable): Unit = {
-        conn.pop()
-        cb.asyncOnError(ex)
-      }
-    }
-
-    Async { (scheduler, conn, cb) =>
-      val c = SingleAssignmentCancelable()
-      conn push c
-
-      // Forcing asynchronous boundary, otherwise
-      // stack-overflows can happen
-      scheduler.executeAsync(() =>
-        try {
-          c := register(scheduler, new CreateCallback(conn, cb)(scheduler))
-        }
-        catch {
-          case NonFatal(ex) =>
-            // We cannot stream the error, because the callback might have
-            // been called already and we'd be violating its contract,
-            // hence the only thing possible is to log the error.
-            scheduler.reportFailure(ex)
-        })
-    }
-  }
+  def create[A](register: (Scheduler, Callback[A]) => Cancelable): Task[A] =
+    TaskCreate(register)
 
   /** Constructs a lazy [[Task]] instance whose result
     * will be computed asynchronously.
     *
-    * Unsafe to use directly, only use if you know what you're doing.
-    * For building `Task` instances safely see [[create]].
+    * **WARNING:** Unsafe to use directly, only use if you know
+    * what you're doing. For building `Task` instances safely
+    * see [[create Task.create]].
+    *
+    * Rules of usage:
+    *
+    *  - the received `StackedCancelable` can be used to store
+    *    cancelable references that will be executed upon cancel;
+    *    every `push` must happen at the beginning, before any
+    *    execution happens and `pop` must happen afterwards
+    *    when the processing is finished, before signaling the
+    *    result
+    *  - the received `FrameRef` indicates the current frame
+    *    index and must be reset on real asynchronous boundaries
+    *    (which avoids doing extra async boundaries in batched
+    *    execution mode)
+    *  - before execution, an asynchronous boundary is recommended,
+    *    to avoid stack overflow errors, but can happen using the
+    *    scheduler's facilities for trampolined execution
+    *  - on signaling the result (`onSuccess`, `onError`),
+    *    another async boundary is necessary, but can also
+    *    happen with the scheduler's facilities for trampolined
+    *    execution (e.g. `asyncOnSuccess` and `asyncOnError`)
+    *
+    * **WARNING:** note that not only is this builder unsafe, but also
+    * unstable, as the [[OnFinish]] callback type is exposing volatile
+    * internal implementation details. This builder is meant to create
+    * optimized asynchronous tasks, but for normal usage prefer
+    * [[Task.create]].
     */
   def unsafeCreate[A](onFinish: OnFinish[A]): Task[A] =
     Async(onFinish)
@@ -708,35 +810,8 @@ object Task extends TaskInstances {
     * NOTE: if you want to defer the creation of the future, use
     * in combination with [[defer]].
     */
-  def fromFuture[A](f: Future[A]): Task[A] = {
-    if (f.isCompleted) {
-      // An already computed result is synchronous
-      fromTry(f.value.get)
-    }
-    else f match {
-      // Do we have a CancelableFuture?
-      case c: Cancelable =>
-        // Cancelable future, needs canceling
-        Async { (s, conn, cb) =>
-          // Already completed future?
-          if (f.isCompleted) cb.asyncApply(f.value.get)(s) else {
-            conn.push(c)
-            f.onComplete { result =>
-              conn.pop()
-              cb(result)
-            }(s)
-          }
-        }
-      case _ =>
-        // Simple future, convert directly
-        Async { (s, conn, cb) =>
-          if (f.isCompleted)
-            cb.asyncApply(f.value.get)(s)
-          else
-            f.onComplete(cb)(s)
-        }
-    }
-  }
+  def fromFuture[A](f: Future[A]): Task[A] =
+    TaskFromFuture(f)
 
   /** Creates a `Task` that upon execution will execute both given tasks
     * (possibly in parallel in case the tasks are asynchronous) and will
@@ -746,98 +821,13 @@ object Task extends TaskInstances {
     * If the first task that completes
     */
   def chooseFirstOf[A,B](fa: Task[A], fb: Task[B]): Task[Either[(A, CancelableFuture[B]), (CancelableFuture[A], B)]] =
-    Async { (scheduler, conn, cb) =>
-      implicit val s = scheduler
-      val pa = Promise[A]()
-      val pb = Promise[B]()
-
-      val isActive = Atomic(true)
-      val connA = StackedCancelable()
-      val connB = StackedCancelable()
-      conn push CompositeCancelable(connA, connB)
-
-      // First task: A
-      Task.unsafeStartAsync(fa, scheduler, connA, new Callback[A] {
-        def onSuccess(valueA: A): Unit =
-          if (isActive.getAndSet(false)) {
-            val futureB = CancelableFuture(pb.future, connB)
-            conn.pop()
-            cb.asyncOnSuccess(Left((valueA, futureB)))
-          } else {
-            pa.success(valueA)
-          }
-
-        def onError(ex: Throwable): Unit =
-          if (isActive.getAndSet(false)) {
-            conn.pop()
-            connB.cancel()
-            cb.asyncOnError(ex)
-          } else {
-            pa.failure(ex)
-          }
-      })
-
-      // Second task: B
-      Task.unsafeStartAsync(fb, scheduler, connB, new Callback[B] {
-        def onSuccess(valueB: B): Unit =
-          if (isActive.getAndSet(false)) {
-            val futureA = CancelableFuture(pa.future, connA)
-            conn.pop()
-            cb.asyncOnSuccess(Right((futureA, valueB)))
-          } else {
-            pb.success(valueB)
-          }
-
-        def onError(ex: Throwable): Unit =
-          if (isActive.getAndSet(false)) {
-            conn.pop()
-            connA.cancel()
-            cb.asyncOnError(ex)
-          } else {
-            pb.failure(ex)
-          }
-      })
-    }
-
+    TaskChooseFirstOf(fa, fb)
 
   /** Creates a `Task` that upon execution will return the result of the
     * first completed task in the given list and then cancel the rest.
     */
   def chooseFirstOfList[A](tasks: TraversableOnce[Task[A]]): Task[A] =
-    Async { (scheduler, conn, callback) =>
-      implicit val s = scheduler
-      val isActive = Atomic.withPadding(true, PaddingStrategy.LeftRight128)
-      val composite = CompositeCancelable()
-      conn.push(composite)
-
-      val cursor = tasks.toIterator
-
-      while (isActive.get && cursor.hasNext) {
-        val task = cursor.next()
-        val taskCancelable = StackedCancelable()
-        composite += taskCancelable
-
-        Task.unsafeStartAsync(task, scheduler, taskCancelable, new Callback[A] {
-          def onSuccess(value: A): Unit =
-            if (isActive.getAndSet(false)) {
-              composite -= taskCancelable
-              composite.cancel()
-              conn.popAndCollapse(taskCancelable)
-              callback.asyncOnSuccess(value)
-            }
-
-          def onError(ex: Throwable): Unit =
-            if (isActive.getAndSet(false)) {
-              composite -= taskCancelable
-              composite.cancel()
-              conn.popAndCollapse(taskCancelable)
-              callback.asyncOnError(ex)
-            } else {
-              scheduler.reportFailure(ex)
-            }
-        })
-      }
-    }
+    TaskChooseFirstOfList(tasks)
 
   /** Given a `TraversableOnce` of tasks, transforms it to a task signaling
     * the collection, executing the tasks one by one and gathering their
@@ -884,132 +874,26 @@ object Task extends TaskInstances {
     * for the more efficient alternative.
     */
   def gather[A, M[X] <: TraversableOnce[X]](in: M[Task[A]])
-    (implicit cbf: CanBuildFrom[M[Task[A]], A, M[A]]): Task[M[A]] = {
-
-    val sortKey = new Ordering[(A,Int)] {
-      def compare(x: (A, Int), y: (A, Int)): Int =
-        if (x._2 < y._2) -1 else if (x._2 > y._2) 1 else 0
-    }
-
-    val tasks = in.toIterable
-      .zipWithIndex.map { case (t,i) => t.map(a => (a,i)) }
-
-    for (result <- gatherUnordered(tasks)) yield {
-      val array = result.toArray
-      // In place, because we're creating enough junk already
-      Sorting.quickSort(array)(sortKey)
-      val builder = cbf(in)
-      var idx = 0
-      while (idx < array.length) { builder += array(idx)._1; idx += 1 }
-      builder.result()
-    }
-  }
+    (implicit cbf: CanBuildFrom[M[Task[A]], A, M[A]]): Task[M[A]] =
+    TaskGather(in)(cbf)
 
   /** Nondeterministically gather results from the given collection of tasks,
     * without keeping the original ordering of results.
     *
+    * If the tasks in the list are set to execute asynchronously, forking
+    * logical threads, then the tasks will execute in parallel.
+    *
     * This function is similar to [[gather]], but neither the effects nor the
-    * results will be ordered. Useful when you don't need ordering because it
-    * can be more efficient than `gather`.
+    * results will be ordered. Useful when you don't need ordering because:
+    *
+    *  - it has non-blocking behavior (but not wait-free)
+    *  - it can be more efficient (compared with [[gather]]), but not
+    *    necessarily (if you care about performance, then test)
+    *
+    * @param in is a list of tasks to execute
     */
-  def gatherUnordered[A, M[X] <: TraversableOnce[X]](in: M[Task[A]])
-    (implicit cbf: CanBuildFrom[M[Task[A]], A, M[A]]): Task[M[A]] = {
-
-    // We are using OOP for initializing this `OnFinish` callback because we
-    // need something to synchronize on and because it's better for making the
-    // state explicit (e.g. the builder, remaining, isActive vars)
-    Async { (scheduler, conn, finalCallback) =>
-      // We need a monitor to synchronize on, per evaluation!
-      val lock = new AnyRef
-      // Forces a fork on another (logical) thread!
-      scheduler.executeAsync(() => lock.synchronized {
-        // Aggregates all results into a buffer.
-        // MUST BE synchronized by `lock`!
-        var builder = cbf(in)
-
-        // Keeps track of tasks remaining to be completed.
-        // Is initialized by 1 because of the logic - tasks can run synchronously,
-        // and we decrement this value whenever one finishes, so we must prevent
-        // zero values before the loop is done.
-        // MUST BE synchronized by `lock`!
-        var remaining = 1
-
-        // If this variable is false, then a task ended in error.
-        // MUST BE synchronized by `lock`!
-        var isActive = true
-
-        // MUST BE synchronized by `lock`!
-        // MUST NOT BE called if isActive == false!
-        @inline def maybeSignalFinal(conn: StackedCancelable, finalCallback: Callback[M[A]])
-          (implicit s: Scheduler): Unit = {
-
-          remaining -= 1
-          if (remaining == 0) {
-            isActive = false
-            conn.pop()
-            val result = builder.result()
-            builder = null // GC relief
-            finalCallback.asyncOnSuccess(result)
-          }
-        }
-
-        implicit val s = scheduler
-        // Represents the collection of cancelables for all started tasks
-        val composite = CompositeCancelable()
-        conn.push(composite)
-
-        // Collecting all cancelables in a buffer, because adding
-        // cancelables one by one in our `CompositeCancelable` is
-        // expensive, so we do it at the end
-        val allCancelables = ListBuffer.empty[StackedCancelable]
-        val cursor = in.toIterator
-
-        // The `isActive` check short-circuits the process in case
-        // we have a synchronous task that just completed in error
-        while (cursor.hasNext && isActive) {
-          remaining += 1
-          val task = cursor.next()
-          val stacked = StackedCancelable()
-          allCancelables += stacked
-
-          // Light asynchronous boundary; with most scheduler implementations
-          // it will not fork a new (logical) thread!
-          scheduler.executeTrampolined(() =>
-            Task.unsafeStartNow(task, scheduler, stacked,
-              new Callback[A] {
-                def onSuccess(value: A): Unit =
-                  lock.synchronized {
-                    if (isActive) {
-                      builder += value
-                      maybeSignalFinal(conn, finalCallback)
-                    }
-                  }
-
-                def onError(ex: Throwable): Unit =
-                  lock.synchronized {
-                    if (isActive) {
-                      isActive = false
-                      // This should cancel our CompositeCancelable
-                      conn.pop().cancel()
-                      finalCallback.asyncOnError(ex)
-                      builder = null // GC relief
-                    } else {
-                      scheduler.reportFailure(ex)
-                    }
-                  }
-              }))
-        }
-
-        // All tasks could have executed synchronously, so we might be
-        // finished already. If so, then trigger the final callback.
-        maybeSignalFinal(conn, finalCallback)
-
-        // Note that if an error happened, this should cancel all
-        // other active tasks.
-        composite ++= allCancelables
-      })
-    }
-  }
+  def gatherUnordered[A](in: TraversableOnce[Task[A]]): Task[List[A]] =
+    TaskGatherUnordered(in)
 
   /** Apply a mapping functions to the results of two tasks, nondeterministically
     * ordering their effects.
@@ -1020,101 +904,8 @@ object Task extends TaskInstances {
     * at the same time and in a multi-threading environment they'll execute
     * in parallel and have their results synchronized.
     */
-  def mapBoth[A1,A2,R](fa1: Task[A1], fa2: Task[A2])(f: (A1,A2) => R): Task[R] = {
-    /* For signaling the values after the successful completion of both tasks. */
-    def sendSignal(conn: StackedCancelable, cb: Callback[R], a1: A1, a2: A2)
-      (implicit s: Scheduler): Unit = {
-
-      var streamErrors = true
-      try {
-        val r = f(a1,a2)
-        streamErrors = false
-        conn.pop()
-        cb.asyncOnSuccess(r)
-      } catch {
-        case NonFatal(ex) if streamErrors =>
-          // Both tasks completed by this point, so we don't need
-          // to worry about the `state` being a `Stop`
-          conn.pop()
-          cb.asyncOnError(ex)
-      }
-    }
-
-    /* For signaling an error. */
-    @tailrec def sendError(conn: StackedCancelable, state: AtomicAny[AnyRef], cb: Callback[R], ex: Throwable)
-      (implicit s: Scheduler): Unit = {
-
-      // Guarding the contract of the callback, as we cannot send an error
-      // if an error has already happened because of the other task
-      state.get match {
-        case Stop =>
-          // We've got nowhere to send the error, so report it
-          s.reportFailure(ex)
-        case other =>
-          if (!state.compareAndSet(other, Stop))
-            sendError(conn, state, cb, ex)(s) // retry
-          else {
-            conn.pop().cancel()
-            cb.asyncOnError(ex)(s)
-          }
-      }
-    }
-
-    // The resulting task will be executed asynchronously
-    Async { (scheduler, conn, cb) =>
-      // Initial asynchronous boundary
-      scheduler.executeAsync { () =>
-        // for synchronizing the results
-        val state = Atomic(null : AnyRef)
-        val task1 = StackedCancelable()
-        val task2 = StackedCancelable()
-        conn push CompositeCancelable(task1, task2)
-
-        // Light asynchronous boundary; with most scheduler implementations
-        // it will not fork a new (logical) thread!
-        scheduler.executeTrampolined(() =>
-          Task.unsafeStartNow(fa1, scheduler, task1, new Callback[A1] {
-            @tailrec def onSuccess(a1: A1): Unit =
-              state.get match {
-                case null => // null means this is the first task to complete
-                  if (!state.compareAndSet(null, Left(a1))) onSuccess(a1)
-                case ref @ Right(a2) => // the other task completed, so we can send
-                  sendSignal(conn, cb, a1, a2.asInstanceOf[A2])(scheduler)
-                case Stop => // the other task triggered an error
-                  () // do nothing
-                case s @ Left(_) =>
-                  // This task has triggered multiple onSuccess calls
-                  // violating the protocol. Should never happen.
-                  onError(new IllegalStateException(s.toString))
-              }
-
-            def onError(ex: Throwable): Unit =
-              sendError(conn, state, cb, ex)(scheduler)
-          }))
-
-        // Light asynchronous boundary
-        scheduler.executeTrampolined(() =>
-          Task.unsafeStartNow(fa2, scheduler, task2, new Callback[A2] {
-            @tailrec def onSuccess(a2: A2): Unit =
-              state.get match {
-                case null => // null means this is the first task to complete
-                  if (!state.compareAndSet(null, Right(a2))) onSuccess(a2)
-                case ref @ Left(a1) => // the other task completed, so we can send
-                  sendSignal(conn, cb, a1.asInstanceOf[A1], a2)(scheduler)
-                case Stop => // the other task triggered an error
-                  () // do nothing
-                case s @ Right(_) =>
-                  // This task has triggered multiple onSuccess calls
-                  // violating the protocol. Should never happen.
-                  onError(new IllegalStateException(s.toString))
-              }
-
-            def onError(ex: Throwable): Unit =
-              sendError(conn, state, cb, ex)(scheduler)
-          }))
-      }
-    }
-  }
+  def mapBoth[A1,A2,R](fa1: Task[A1], fa2: Task[A2])(f: (A1,A2) => R): Task[R] =
+    TaskMapBoth(fa1, fa2)(f)
 
   /** Gathers the results from a sequence of tasks into a single list.
     * The effects are not ordered, but the results are.
@@ -1179,28 +970,117 @@ object Task extends TaskInstances {
     zipMap2(fa12345, fa6) { case ((a1,a2,a3,a4,a5), a6) => f(a1,a2,a3,a4,a5,a6) }
   }
 
-  @deprecated("Renamed to Task.zipMap2", since="2.0-RC12")
-  def zipWith2[A1,A2,R](fa1: Task[A1], fa2: Task[A2])(f: (A1,A2) => R): Task[R] =
-    zipMap2(fa1, fa2)(f)
+  /** A frame index is a number representing the current run-loop
+    * cycle. It gets used for automatically forcing asynchronous
+    * boundaries, according to the
+    * [[monix.execution.schedulers.ExecutionModel ExecutionModel]]
+    * injected by the
+    * [[monix.execution.Scheduler Scheduler]].
+    */
+  type FrameIndex = Int
 
-  @deprecated("Renamed to Task.zipMap3", since="2.0-RC12")
-  def zipWith3[A1,A2,A3,R](fa1: Task[A1], fa2: Task[A2], fa3: Task[A3])(f: (A1,A2,A3) => R): Task[R] =
-    zipMap3(fa1, fa2, fa3)(f)
+  /** Type alias representing callbacks for
+    * [[unsafeCreate asynchronous]] tasks.
+    */
+  type OnFinish[+A] = (Context, Callback[A]) => Unit
 
-  @deprecated("Renamed to Task.zipMap4", since="2.0-RC12")
-  def zipWith4[A1,A2,A3,A4,R](fa1: Task[A1], fa2: Task[A2], fa3: Task[A3], fa4: Task[A4])(f: (A1,A2,A3,A4) => R): Task[R] =
-    zipMap4(fa1, fa2, fa3, fa4)(f)
+  /** Set of options for customizing the task's behavior.
+    *
+    * @param autoCancelableRunLoops should be set to `true` in
+    *        case you want `flatMap` driven loops to be
+    *        auto-cancelable. Defaults to `false`.
+    */
+  final case class Options(
+    autoCancelableRunLoops: Boolean) {
 
-  @deprecated("Renamed to Task.zipMap5", since="2.0-RC12")
-  def zipWith5[A1,A2,A3,A4,A5,R](fa1: Task[A1], fa2: Task[A2], fa3: Task[A3], fa4: Task[A4], fa5: Task[A5])(f: (A1,A2,A3,A4,A5) => R): Task[R] =
-    zipMap5(fa1, fa2, fa3, fa4, fa5)(f)
+    /** Creates a new set of options from the source, but with
+      * the [[autoCancelableRunLoops]] value set to `true`.
+      */
+    def enableAutoCancelableRunLoops: Options =
+      copy(autoCancelableRunLoops = true)
 
-  @deprecated("Renamed to Task.zipMap6", since="2.0-RC12")
-  def zipWith6[A1,A2,A3,A4,A5,A6,R](fa1: Task[A1], fa2: Task[A2], fa3: Task[A3], fa4: Task[A4], fa5: Task[A5], fa6: Task[A6])(f: (A1,A2,A3,A4,A5,A6) => R): Task[R] =
-    zipMap6(fa1, fa2, fa3, fa4, fa5, fa6)(f)
+    /** Creates a new set of options from the source, but with
+      * the [[autoCancelableRunLoops]] value set to `false`.
+      */
+    def disableAutoCancelableRunLoops: Options =
+      copy(autoCancelableRunLoops = false)
+  }
 
-  /** Type alias representing callbacks for [[create]] tasks. */
-  type OnFinish[+A] = (Scheduler, StackedCancelable, Callback[A]) => Unit
+  /** Default [[Options]] to use for [[Task]] evaluation,
+    * thus:
+    *
+    *  - `autoCancelableRunLoops` is `false` by default
+    *
+    * On top of the JVM the default can be overridden by
+    * setting the following system properties:
+    *
+    *  - `monix.environment.autoCancelableRunLoops`
+    *    (`true`, `yes` or `1` for enabling)
+    *
+    * @see [[Task.Options]]
+    */
+  val defaultOptions: Options = {
+    if (Platform.isJS)
+      Options(autoCancelableRunLoops = false)
+    else
+      Options(
+        autoCancelableRunLoops =
+          Option(System.getProperty("monix.environment.autoCancelableRunLoops", ""))
+            .map(_.toLowerCase)
+            .exists(v => v == "yes" || v == "true" || v == "1")
+      )
+  }
+
+  /** The `Context` under which [[Task]] is supposed to
+    * be executed.
+    *
+    * @param scheduler is the [[monix.execution.Scheduler Scheduler]]
+    *        in charge of evaluation on `runAsync`.
+    *
+    * @param connection is the
+    *        [[monix.execution.cancelables.StackedCancelable StackedCancelable]]
+    *        that handles the cancellation on `runAsync`
+    *
+    * @param frameRef is a thread-local counter that keeps track of the current
+    *        frame index of the run-loop. The run-loop is supposed to
+    *        force an asynchronous boundary upon reaching a certain
+    *        threshold, when the task is evaluated with
+    *        [[monix.execution.schedulers.ExecutionModel.BatchedExecution]].
+    *        And this `frameIndexRef` should be reset whenever a real
+    *        asynchronous boundary happens.
+    *
+    * @param options is a set of options for customizing the task's behavior
+    *        upon evaluation.
+    */
+  final case class Context(
+    scheduler: Scheduler,
+    connection: StackedCancelable,
+    frameRef: ThreadLocal[FrameIndex],
+    options: Options) {
+
+    /** Helper that returns the
+      * [[monix.execution.schedulers.ExecutionModel ExecutionModel]]
+      * specified by the [[scheduler]].
+      */
+    @inline def executionModel: ExecutionModel =
+      scheduler.executionModel
+
+    /** Helper that returns `true` if the current `Task` run-loop
+      * should be canceled or `false` otherwise.
+      */
+    @inline def shouldCancel: Boolean =
+      options.autoCancelableRunLoops &&
+      connection.isCanceled
+  }
+
+  // We always start from 1
+  private final val frameStart: FrameIndex = 1
+
+  /** Creates a `ThreadLocal[FrameIndex]` reference to use as
+    * the default. The starting frame index should always be `1`.
+    */
+  private[eval] def startFrameRef(): ThreadLocal[FrameIndex] =
+    ThreadLocal(frameStart)
 
   private case class Delay[A](coeval: Coeval[A]) extends Task[A] {
     override def runAsync(cb: Callback[A])(implicit s: Scheduler): Cancelable = {
@@ -1289,48 +1169,49 @@ object Task extends TaskInstances {
       thunk = null
     }
 
-    @tailrec def execute(active: StackedCancelable, cb: Callback[A], binds: List[Bind], nextFrame: Int)
-      (implicit s: Scheduler): Boolean = {
-
+    @tailrec def execute(context: Context, cb: Callback[A], binds: List[Bind], nextFrame: FrameIndex): Boolean = {
+      implicit val s = context.scheduler
       state.get match {
         case null =>
           val p = Promise[A]()
 
-          if (!state.compareAndSet(null, (p, active)))
-            execute(active, cb, binds, nextFrame)(s) // retry
+          if (!state.compareAndSet(null, (p, context.connection)))
+            execute(context, cb, binds, nextFrame) // retry
           else {
             val underlying = try thunk() catch { case NonFatal(ex) => raiseError(ex) }
+
             val callback = new Callback[A] {
               def onError(ex: Throwable): Unit = {
                 memoizeValue(Failure(ex))
                 if (binds.isEmpty) cb.asyncOnError(ex) else
                   // Resuming trampoline with the rest of the binds
-                  Task.startTrampolineAsync(s, active, raiseError(ex), cb, binds)
+                  Task.startTrampolineAsync(raiseError(ex), context, cb, binds)
               }
 
               def onSuccess(value: A): Unit = {
                 memoizeValue(Success(value))
                 if (binds.isEmpty) cb.asyncOnSuccess(value) else
                   // Resuming trampoline with the rest of the binds
-                  Task.startTrampolineAsync(s, active, now(value), cb, binds)
+                  Task.startTrampolineAsync(now(value), context, cb, binds)
               }
             }
 
             // Asynchronous boundary to prevent stack-overflows!
-            s.executeTrampolined(() =>
-              runLoop(s, s.executionModel, active, underlying,
+            s.executeTrampolined { () =>
+              runLoop(underlying, context, s.executionModel,
                 callback.asInstanceOf[Callback[Any]], Nil,
-                nextFrame))
+                nextFrame)
+            }
 
             true
           }
 
         case (p: Promise[_], mainCancelable: StackedCancelable) =>
           // execution is pending completion
-          active push mainCancelable
+          context.connection push mainCancelable
           p.asInstanceOf[Promise[A]].future.onComplete { r =>
-            active.pop()
-            Task.startTrampolineRunLoop(s, active, fromTry(r), cb, binds)
+            context.connection.pop()
+            Task.internalRestartTrampolineLoop(fromTry(r), context, cb, binds)
           }
           true
 
@@ -1354,10 +1235,23 @@ object Task extends TaskInstances {
     * what you're doing. Prefer [[Task.runAsync(cb* Task.runAsync]]
     * and `Task.fork`.
     */
-  def unsafeStartAsync[A](source: Task[A], scheduler: Scheduler, conn: StackedCancelable, cb: Callback[A]): Unit = {
-    // Task is already known to execute asynchronously
-    startTrampolineAsync(scheduler, conn, source, cb, Nil)
-  }
+  def unsafeStartAsync[A](source: Task[A], context: Context, cb: Callback[A]): Unit =
+    startTrampolineAsync(source, context, cb, Nil)
+
+  /** Unsafe utility - starts the execution of a Task with a guaranteed
+    * [[monix.execution.schedulers.TrampolinedRunnable trampolined asynchronous boundary]],
+    * by providing the needed [[monix.execution.Scheduler Scheduler]],
+    * [[monix.execution.cancelables.StackedCancelable StackedCancelable]]
+    * and [[Callback]].
+    *
+    * DO NOT use directly, as it is UNSAFE to use, unless you know
+    * what you're doing. Prefer [[Task.runAsync(cb* Task.runAsync]]
+    * and `Task.fork`.
+    */
+  def unsafeStartTrampolined[A](source: Task[A], context: Context, cb: Callback[A]): Unit =
+    context.scheduler.executeTrampolined { () =>
+      internalRestartTrampolineLoop(source, context, cb, Nil)
+    }
 
   /** Unsafe utility - starts the execution of a Task, by providing
     * the needed [[monix.execution.Scheduler Scheduler]],
@@ -1367,199 +1261,225 @@ object Task extends TaskInstances {
     * DO NOT use directly, as it is UNSAFE to use, unless you know
     * what you're doing. Prefer [[Task.runAsync(cb* Task.runAsync]].
     */
-  def unsafeStartNow[A](source: Task[A], scheduler: Scheduler, conn: StackedCancelable, cb: Callback[A]): Unit =
-    startTrampolineRunLoop(scheduler, conn, source, cb, Nil)
-
-  /** Internal utility, returns true if the current state
-    * is known to be asynchronous.
-    */
-  private def isNextAsync[A](source: Task[A]): Boolean =
-    source match {
-      case Async(_) | BindAsync(_,_) => true
-      case _ => false
-    }
+  def unsafeStartNow[A](source: Task[A], context: Context, cb: Callback[A]): Unit =
+    internalRestartTrampolineLoop(source, context, cb, Nil)
 
   /** Internal utility, for forcing an asynchronous boundary in the
     * trampoline loop.
     */
   @inline private def startTrampolineAsync[A](
-    scheduler: Scheduler,
-    conn: StackedCancelable,
     source: Task[A],
+    context: Context,
     cb: Callback[A],
     binds: List[Bind]): Unit = {
 
-    if (!conn.isCanceled)
-      scheduler.executeAsync(() =>
-        startTrampolineRunLoop(scheduler, conn, source, cb, binds))
+    if (!context.shouldCancel)
+      context.scheduler.executeAsyncBatch { () =>
+        // Resetting the frameRef, as a real asynchronous boundary happened
+        context.frameRef.reset()
+        internalRestartTrampolineLoop(source, context, cb, binds)
+      }
   }
 
   /** Internal utility - the actual trampoline run-loop implementation. */
-  @tailrec def runLoop(
-    scheduler: Scheduler,
-    em: ExecutionModel,
-    conn: StackedCancelable,
+  @tailrec private def runLoop(
     source: Current,
+    context: Context,
+    em: ExecutionModel,
     cb: Callback[Any],
     binds: List[Bind],
-    frameIndex: Int): Unit = {
+    frameIndex: FrameIndex): Unit = {
 
     @inline def executeOnFinish(
-      scheduler: Scheduler,
-      conn: StackedCancelable,
+      context: Context,
+      em: ExecutionModel,
       cb: Callback[Any],
       fs: List[Bind],
-      onFinish: OnFinish[Any]): Unit = {
+      onFinish: OnFinish[Any],
+      nextFrame: FrameIndex): Unit = {
 
-      if (!conn.isCanceled)
-        onFinish(scheduler, conn, new Callback[Any] {
+      // We are going to resume the frame index from where we were left,
+      // but only if no real asynchronous execution happened. So in order
+      // to detect asynchronous execution, we are reading a thread-local
+      // variable that's going to be reset in case of an thread jump.
+      // Obviously this doesn't work for Javascript, but that's OK, as
+      // it only means that Javascript can experience more async
+      // boundaries and everything is fine for as long as the implementation
+      // of `Async` tasks are triggering a `frameRef.reset`.
+      context.frameRef.set(nextFrame)
+
+      if (!context.shouldCancel)
+        onFinish(context, new Callback[Any] {
           def onSuccess(value: Any): Unit =
-            startTrampolineRunLoop(scheduler, conn, now(value), cb, fs)
+            internalRestartTrampolineLoop(now(value), context, cb, fs)
           def onError(ex: Throwable): Unit =
             cb.onError(ex)
         })
     }
 
-    if (frameIndex == 0 && !Task.isNextAsync(source)) {
+    if (frameIndex == 0) {
       // Asynchronous boundary is forced because of the Scheduler's ExecutionModel
-      startTrampolineAsync(scheduler, conn, source, cb, binds)
+      startTrampolineAsync(source, context, cb, binds)
     }
     else source match {
       case Delay(coeval) =>
-        binds match {
-          case Nil =>
-            cb(coeval)
-          case f :: rest =>
-            coeval.runAttempt match {
-              case Now(a) =>
-                val fa = try f(a) catch { case NonFatal(ex) => raiseError(ex) }
-                runLoop(scheduler, em, conn, fa, cb, rest, em.nextFrameIndex(frameIndex))
-              case Error(ex) =>
-                cb.onError(ex)
-            }
+        val result = coeval.runAttempt
+        if (result.isFailure || binds.isEmpty) {
+          // We are done and can signal the result!
+          context.frameRef.set(em.nextFrameIndex(frameIndex))
+          cb(result)
+        } else {
+          val f = binds.head
+          val fa = try f(result.get) catch { case NonFatal(ex) => raiseError(ex) }
+          // Next iteration please
+          runLoop(fa, context, em, cb, binds.tail, em.nextFrameIndex(frameIndex))
         }
 
       case Suspend(thunk) =>
         val fa = try thunk() catch { case NonFatal(ex) => raiseError(ex) }
-        runLoop(scheduler, em, conn, fa, cb, binds, em.nextFrameIndex(frameIndex))
+        // Next iteration please
+        runLoop(fa, context, em, cb, binds, em.nextFrameIndex(frameIndex))
 
       case ref: MemoizeSuspend[_] =>
         val nextFrame = em.nextFrameIndex(frameIndex)
         ref.value match {
           case Some(materialized) =>
-            runLoop(scheduler, em, conn, coeval(materialized), cb, binds, nextFrame)
+            runLoop(coeval(materialized), context, em, cb, binds, nextFrame)
           case None =>
-            val success = source.asInstanceOf[MemoizeSuspend[Any]].execute(
-              conn, cb, binds, nextFrame)(scheduler)
+            val success = source.asInstanceOf[MemoizeSuspend[Any]]
+              .execute(context, cb, binds, nextFrame)
             if (!success) // retry?
-              runLoop(scheduler, em, conn, source, cb, binds, nextFrame)
+              runLoop(source, context, em, cb, binds, nextFrame)
         }
 
       case BindSuspend(thunk, f) =>
         val fa = try thunk() catch { case NonFatal(ex) => raiseError(ex) }
-        runLoop(scheduler, em, conn, fa, cb, f.asInstanceOf[Bind] :: binds,
+        runLoop(fa, context, em, cb, f.asInstanceOf[Bind] :: binds,
           em.nextFrameIndex(frameIndex))
 
       case BindAsync(onFinish, f) =>
-        executeOnFinish(scheduler, conn, cb, f.asInstanceOf[Bind] :: binds, onFinish)
+        executeOnFinish(context, em, cb, f.asInstanceOf[Bind] :: binds, onFinish,
+          em.nextFrameIndex(frameIndex))
 
       case Async(onFinish) =>
-        executeOnFinish(scheduler, conn, cb, binds, onFinish)
+        executeOnFinish(context, em, cb, binds, onFinish,
+          em.nextFrameIndex(frameIndex))
     }
   }
 
   /** Internal utility, starts or resumes evaluation of
     * the run-loop from where it left off.
+    *
+    * The `frameIndex=1` default value ensures that the
+    * first cycle of the trampoline gets executed regardless of
+    * the `ExecutionModel`.
     */
-  private def startTrampolineRunLoop[A](
-    scheduler: Scheduler,
-    conn: StackedCancelable,
+  private def internalRestartTrampolineLoop[A](
     source: Task[A],
+    context: Context,
     cb: Callback[A],
     binds: List[Bind]): Unit = {
 
-    runLoop(scheduler, scheduler.executionModel,
-      conn, source, cb.asInstanceOf[Callback[Any]], binds,
-      // value ensures that first cycle is not async
-      frameIndex = 1)
+    runLoop(
+      source,
+      context,
+      context.executionModel,
+      cb.asInstanceOf[Callback[Any]],
+      binds,
+      context.frameRef.get())
   }
 
   /** A run-loop that attempts to complete a
     * [[monix.execution.CancelableFuture CancelableFuture]] synchronously ,
-    * falling back to [[startTrampolineRunLoop]] and actual asynchronous execution
+    * falling back to [[internalRestartTrampolineLoop]] and actual asynchronous execution
     * in case of an asynchronous boundary.
     */
-  private def startTrampolineForFuture[A](
-    scheduler: Scheduler,
+  private[monix] def startTrampolineForFuture[A](
     source: Task[A],
+    context: Context,
     binds: List[Bind]): CancelableFuture[A] = {
 
-    def goAsync(scheduler: Scheduler, source: Current, binds: List[Bind], isNextAsync: Boolean): CancelableFuture[Any] = {
+    def goAsync(source: Current, context: Context, binds: List[Bind],
+      nextFrame: FrameIndex, forceAsync: Boolean): CancelableFuture[Any] = {
+
       val p = Promise[Any]()
       val cb: Callback[Any] = new Callback[Any] {
         def onSuccess(value: Any): Unit = p.trySuccess(value)
         def onError(ex: Throwable): Unit = p.tryFailure(ex)
       }
 
-      val conn = StackedCancelable()
-      if (!isNextAsync)
-        startTrampolineAsync(scheduler, conn, source, cb, binds)
-      else
-        startTrampolineRunLoop(scheduler, conn, source, cb, binds)
+      if (forceAsync)
+        startTrampolineAsync(source, context, cb, binds)
+      else {
+        // See the description in runLoop()
+        context.frameRef.set(nextFrame)
+        internalRestartTrampolineLoop(source, context, cb, binds)
+      }
 
-      CancelableFuture(p.future, conn)
+      CancelableFuture(p.future, context.connection)
     }
 
     @tailrec def loop(
-      scheduler: Scheduler,
-      em: ExecutionModel,
       source: Current,
+      context: Context,
+      em: ExecutionModel,
       binds: List[Bind],
       frameIndex: Int): CancelableFuture[Any] = {
 
-      if (frameIndex == 0 && !Task.isNextAsync(source)) {
+      if (frameIndex == 0) {
         // Asynchronous boundary is forced
-        goAsync(scheduler, source, binds, isNextAsync = false)
+        goAsync(source, context, binds,
+          em.nextFrameIndex(frameIndex),
+          forceAsync = true)
       }
       else source match {
         case Delay(coeval) =>
           coeval.runAttempt match {
             case Error(ex) =>
+              context.frameRef.set(em.nextFrameIndex(frameIndex))
               CancelableFuture.failed(ex)
+
             case Now(a) =>
               binds match {
                 case Nil =>
+                  context.frameRef.set(em.nextFrameIndex(frameIndex))
                   CancelableFuture.successful(a)
                 case f :: rest =>
                   val fa = try f(a) catch { case NonFatal(ex) => raiseError(ex) }
-                  loop(scheduler, em, fa, rest, em.nextFrameIndex(frameIndex))
+                  loop(fa, context, em, rest, em.nextFrameIndex(frameIndex))
               }
           }
 
         case Suspend(thunk) =>
           val fa = try thunk() catch { case NonFatal(ex) => raiseError(ex) }
-          loop(scheduler, em, fa, binds, em.nextFrameIndex(frameIndex))
+          loop(fa, context, em, binds,
+            em.nextFrameIndex(frameIndex))
 
         case BindSuspend(thunk, f) =>
           val fa = try thunk() catch { case NonFatal(ex) => raiseError(ex) }
-          loop(scheduler, em, fa, f.asInstanceOf[Bind] :: binds,
+          loop(fa, context, em, f.asInstanceOf[Bind] :: binds,
             em.nextFrameIndex(frameIndex))
 
         case ref: MemoizeSuspend[_] =>
           val task = ref.asInstanceOf[MemoizeSuspend[A]]
           task.value match {
             case Some(materialized) =>
-              loop(scheduler, em, coeval(materialized), binds, em.nextFrameIndex(frameIndex))
+              loop(coeval(materialized), context, em, binds,
+                em.nextFrameIndex(frameIndex))
             case None =>
-              goAsync(scheduler, source, binds, isNextAsync = true)
+              goAsync(source, context, binds,
+                em.nextFrameIndex(frameIndex),
+                forceAsync = false)
           }
 
         case async =>
-          goAsync(scheduler, async, binds, isNextAsync = true)
+          goAsync(async, context, binds,
+            em.nextFrameIndex(frameIndex),
+            forceAsync = false)
       }
     }
 
-    loop(scheduler, scheduler.executionModel, source, binds, frameIndex = 1)
+    loop(source, context, context.executionModel, binds, frameIndex = context.frameRef.get())
       .asInstanceOf[CancelableFuture[A]]
   }
 
@@ -1585,10 +1505,10 @@ private[eval] trait TaskInstances {
   /** Groups the implementation for the type-classes defined in [[monix.types]]. */
   class TypeClassInstances
     extends DeferrableClass[Task]
-    with MemoizableClass[Task]
-    with RecoverableClass[Task,Throwable]
-    with CoflatMapClass[Task]
-    with MonadRecClass[Task] {
+      with MemoizableClass[Task]
+      with RecoverableClass[Task,Throwable]
+      with CoflatMapClass[Task]
+      with MonadRecClass[Task] {
 
     override def pure[A](a: A): Task[A] = Task.now(a)
     override def defer[A](fa: => Task[A]): Task[A] = Task.defer(fa)

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskChooseFirstOf.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskChooseFirstOf.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval.internal
+
+import monix.eval.{Callback, Task}
+import monix.execution.CancelableFuture
+import monix.execution.atomic.Atomic
+import monix.execution.cancelables._
+import scala.concurrent.Promise
+
+private[monix] object TaskChooseFirstOf {
+  /**
+    * Implementation for `Task.chooseFirstOf`.
+    */
+  def apply[A,B](fa: Task[A], fb: Task[B]): Task[Either[(A, CancelableFuture[B]), (CancelableFuture[A], B)]] =
+    Task.unsafeCreate { (context, cb) =>
+      implicit val s = context.scheduler
+      val conn = context.connection
+
+      val pa = Promise[A]()
+      val pb = Promise[B]()
+
+      val isActive = Atomic(true)
+      val connA = StackedCancelable()
+      val connB = StackedCancelable()
+      conn push CompositeCancelable(connA, connB)
+
+      val contextA = context.copy(connection = connA)
+      val contextB = context.copy(connection = connB)
+
+      // First task: A
+      Task.unsafeStartAsync(fa, contextA, new Callback[A] {
+        def onSuccess(valueA: A): Unit =
+          if (isActive.getAndSet(false)) {
+            val futureB = CancelableFuture(pb.future, connB)
+            conn.pop()
+            cb.asyncOnSuccess(Left((valueA, futureB)))
+          } else {
+            pa.success(valueA)
+          }
+
+        def onError(ex: Throwable): Unit =
+          if (isActive.getAndSet(false)) {
+            conn.pop()
+            connB.cancel()
+            cb.asyncOnError(ex)
+          } else {
+            pa.failure(ex)
+          }
+      })
+
+      // Second task: B
+      Task.unsafeStartAsync(fb, contextB, new Callback[B] {
+        def onSuccess(valueB: B): Unit =
+          if (isActive.getAndSet(false)) {
+            val futureA = CancelableFuture(pa.future, connA)
+            conn.pop()
+            cb.asyncOnSuccess(Right((futureA, valueB)))
+          } else {
+            pb.success(valueB)
+          }
+
+        def onError(ex: Throwable): Unit =
+          if (isActive.getAndSet(false)) {
+            conn.pop()
+            connA.cancel()
+            cb.asyncOnError(ex)
+          } else {
+            pb.failure(ex)
+          }
+      })
+    }
+}

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskChooseFirstOfList.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskChooseFirstOfList.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval.internal
+
+import monix.eval.{Callback, Task}
+import monix.execution.atomic.{Atomic, PaddingStrategy}
+import monix.execution.cancelables.{CompositeCancelable, StackedCancelable}
+
+private[monix] object TaskChooseFirstOfList {
+  /**
+    * Implementation for `Task.chooseFirstOfList`
+    */
+  def apply[A](tasks: TraversableOnce[Task[A]]): Task[A] =
+    Task.unsafeCreate { (context, callback) =>
+      implicit val s = context.scheduler
+      val conn = context.connection
+
+      val isActive = Atomic.withPadding(true, PaddingStrategy.LeftRight128)
+      val composite = CompositeCancelable()
+      conn.push(composite)
+
+      val cursor = tasks.toIterator
+
+      while (isActive.get && cursor.hasNext) {
+        val task = cursor.next()
+        val taskCancelable = StackedCancelable()
+        val taskContext = context.copy(connection = taskCancelable)
+        composite += taskCancelable
+
+        Task.unsafeStartAsync(task, taskContext, new Callback[A] {
+          def onSuccess(value: A): Unit =
+            if (isActive.getAndSet(false)) {
+              composite -= taskCancelable
+              composite.cancel()
+              conn.popAndCollapse(taskCancelable)
+              callback.asyncOnSuccess(value)
+            }
+
+          def onError(ex: Throwable): Unit =
+            if (isActive.getAndSet(false)) {
+              composite -= taskCancelable
+              composite.cancel()
+              conn.popAndCollapse(taskCancelable)
+              callback.asyncOnError(ex)
+            } else {
+              s.reportFailure(ex)
+            }
+        })
+      }
+    }
+}

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskCreate.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskCreate.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval.internal
+
+import monix.eval.{Callback, Task}
+import monix.execution.cancelables.{SingleAssignmentCancelable, StackedCancelable}
+import monix.execution.{Cancelable, Scheduler}
+import scala.util.control.NonFatal
+
+private[monix] object TaskCreate {
+  /**
+    * Implementation for `Task.create`
+    */
+  def apply[A](register: (Scheduler, Callback[A]) => Cancelable): Task[A] = {
+    // Wraps a callback into an implementation that pops the stack
+    // before calling onSuccess/onError
+    final class CreateCallback(conn: StackedCancelable, cb: Callback[A])
+      (implicit s: Scheduler)
+      extends Callback[A] {
+
+      def onSuccess(value: A): Unit = {
+        conn.pop()
+        cb.asyncOnSuccess(value)
+      }
+
+      def onError(ex: Throwable): Unit = {
+        conn.pop()
+        cb.asyncOnError(ex)
+      }
+    }
+
+    Task.unsafeCreate { (context, cb) =>
+      val s = context.scheduler
+      val conn = context.connection
+      val c = SingleAssignmentCancelable()
+      conn push c
+
+      // Forcing a real asynchronous boundary,
+      // otherwise stack-overflows can happen
+      s.executeAsyncBatch(() =>
+        try {
+          context.frameRef.reset()
+          c := register(s, new CreateCallback(conn, cb)(s))
+        }
+        catch {
+          case NonFatal(ex) =>
+            // We cannot stream the error, because the callback might have
+            // been called already and we'd be violating its contract,
+            // hence the only thing possible is to log the error.
+            s.reportFailure(ex)
+        })
+    }
+  }
+}

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDelayExecution.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDelayExecution.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval.internal
+
+import monix.eval.{Callback, Task}
+import monix.execution.cancelables.SingleAssignmentCancelable
+import scala.concurrent.duration.FiniteDuration
+
+private[monix] object TaskDelayExecution {
+  /**
+    * Implementation for `Task.delayExecution`
+    */
+  def apply[A](self: Task[A], timespan: FiniteDuration): Task[A] =
+    Task.unsafeCreate { (context, cb) =>
+      implicit val s = context.scheduler
+      val conn = context.connection
+      val c = SingleAssignmentCancelable()
+      conn push c
+
+      c := s.scheduleOnce(timespan.length, timespan.unit, new Runnable {
+        def run(): Unit = {
+          conn.pop()
+          // We had an async boundary, as we must reset the frame
+          context.frameRef.reset()
+          Task.unsafeStartNow(self, context, Callback.async(cb))
+        }
+      })
+    }
+}

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDelayResult.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDelayResult.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval.internal
+
+import monix.eval.{Callback, Task}
+import monix.execution.cancelables.SingleAssignmentCancelable
+import scala.concurrent.duration.FiniteDuration
+
+private[monix] object TaskDelayResult {
+  /**
+    * Implementation for `Task.delayResult`
+    */
+  def apply[A](self: Task[A], timespan: FiniteDuration): Task[A] =
+    Task.unsafeCreate { (context, cb) =>
+      implicit val s = context.scheduler
+      val conn = context.connection
+
+      Task.unsafeStartAsync(self, context,
+        new Callback[A] {
+          def onSuccess(value: A): Unit = {
+            val task = SingleAssignmentCancelable()
+            conn push task
+
+            // Delaying result
+            task := s.scheduleOnce(timespan.length, timespan.unit,
+              new Runnable {
+                def run(): Unit = {
+                  conn.pop()
+                  context.frameRef.reset()
+                  cb.asyncOnSuccess(value)
+                }
+              })
+          }
+
+          def onError(ex: Throwable): Unit =
+            cb.asyncOnError(ex)
+        })
+    }
+}

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDelayResultBySelector.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDelayResultBySelector.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval.internal
+
+import monix.eval.{Callback, Task}
+import scala.util.control.NonFatal
+
+private[monix] object TaskDelayResultBySelector {
+  /**
+    * Implementation for `Task.delayResultBySelector`
+    */
+  def apply[A,B](self: Task[A], selector: A => Task[B]): Task[A] =
+    Task.unsafeCreate { (context, cb) =>
+      implicit val s = context.scheduler
+
+      Task.unsafeStartAsync(self, context,
+        new Callback[A] {
+          def onSuccess(value: A): Unit = {
+            var streamErrors = true
+            try {
+              val trigger = selector(value)
+              streamErrors = false
+
+              // Delaying result
+              Task.unsafeStartAsync(trigger, context,
+                new Callback[B] {
+                  def onSuccess(b: B): Unit = cb.asyncOnSuccess(value)
+                  def onError(ex: Throwable): Unit = cb.asyncOnError(ex)
+                })
+            } catch {
+              case NonFatal(ex) if streamErrors =>
+                cb.asyncOnError(ex)
+            }
+          }
+
+          def onError(ex: Throwable): Unit =
+            cb.asyncOnError(ex)
+        })
+    }
+}

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDoOnCancel.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDoOnCancel.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval.internal
+
+import monix.eval.{Callback, Task}
+import monix.execution.Cancelable
+
+private[monix] object TaskDoOnCancel {
+  /**
+    * Implementation for `Task.doOnCancel`
+    */
+  def apply[A](self: Task[A], callback: Task[Unit]): Task[A] =
+    Task.unsafeCreate { (context, onFinish) =>
+      implicit val s = context.scheduler
+      val c = Cancelable(() => callback.runAsync(Callback.empty))
+      val conn = context.connection
+      conn.push(c)
+
+      // Light asynchronous boundary
+      Task.unsafeStartTrampolined(self, context, new Callback[A] {
+        def onSuccess(value: A): Unit = {
+          conn.pop()
+          onFinish.asyncOnSuccess(value)
+        }
+
+        def onError(ex: Throwable): Unit = {
+          conn.pop()
+          onFinish.asyncOnError(ex)
+        }
+      })
+    }
+}

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskExecuteWithModel.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskExecuteWithModel.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval.internal
+
+import monix.eval.{Callback, Task}
+import monix.execution.schedulers.ExecutionModel
+import scala.util.control.NonFatal
+
+private[monix] object TaskExecuteWithModel {
+  /**
+    * Implementation for `Task.executeWithModel`
+    */
+  def apply[A](self: Task[A], em: ExecutionModel): Task[A] =
+    Task.unsafeCreate { (context, cb) =>
+      var streamErrors = true
+      try {
+        implicit val s2 = context.scheduler.withExecutionModel(em)
+        val context2 = context.copy(scheduler = s2)
+        streamErrors = false
+        Task.unsafeStartTrampolined[A](self, context2, Callback.async(cb))
+      } catch {
+        case NonFatal(ex) =>
+          if (streamErrors) cb.onError(ex)
+          else context.scheduler.reportFailure(ex)
+      }
+    }
+}

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskExecuteWithOptions.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskExecuteWithOptions.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval.internal
+
+import monix.eval.Task.Options
+import monix.eval.{Callback, Task}
+import scala.util.control.NonFatal
+
+private[monix] object TaskExecuteWithOptions {
+  /**
+    * Implementation for `Task.executeWithOptions`
+    */
+  def apply[A](self: Task[A], f: Options => Options): Task[A] =
+    Task.unsafeCreate { (context, cb) =>
+      implicit val s = context.scheduler
+      var streamErrors = true
+      try {
+        val context2 = context.copy(options = f(context.options))
+        streamErrors = false
+        Task.unsafeStartTrampolined[A](self, context2, Callback.async(cb))
+      } catch {
+        case NonFatal(ex) =>
+          if (streamErrors) cb.asyncOnError(ex)
+          else context.scheduler.reportFailure(ex)
+      }
+    }
+}

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskFromFuture.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskFromFuture.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval.internal
+
+import monix.eval.Task
+import monix.execution.Cancelable
+import scala.concurrent.Future
+
+private[monix] object TaskFromFuture {
+  /**
+    * Implementation for `Task.fromFuture`
+    */
+  def apply[A](f: Future[A]): Task[A] = {
+    if (f.isCompleted) {
+      // An already computed result is synchronous
+      Task.fromTry(f.value.get)
+    }
+    else f match {
+      // Do we have a CancelableFuture?
+      case c: Cancelable =>
+        // Cancelable future, needs canceling
+        Task.unsafeCreate { (context, cb) =>
+          implicit val s = context.scheduler
+          // Already completed future?
+          if (f.isCompleted) cb.asyncApply(f.value.get) else {
+            val conn = context.connection
+            conn.push(c)
+            f.onComplete { result =>
+              // Async boundary should trigger frame reset
+              context.frameRef.reset()
+              conn.pop()
+              cb(result)
+            }
+          }
+        }
+      case _ =>
+        // Simple future, convert directly
+        Task.unsafeCreate { (context, cb) =>
+          implicit val s = context.scheduler
+          if (f.isCompleted)
+            cb.asyncApply(f.value.get)
+          else
+            f.onComplete { result =>
+              // Async boundary should trigger frame reset
+              context.frameRef.reset()
+              cb(result)
+            }
+        }
+    }
+  }
+}

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskGather.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskGather.scala
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval.internal
+
+import monix.eval.{Callback, Task}
+import monix.execution.Scheduler
+import monix.execution.cancelables.{CompositeCancelable, StackedCancelable}
+import scala.collection.generic.CanBuildFrom
+import scala.collection.mutable.ListBuffer
+import scala.util.control.NonFatal
+
+private[monix] object TaskGather {
+  /**
+    * Implementation for `Task.gather`
+    */
+  def apply[A, M[X] <: TraversableOnce[X]](in: M[Task[A]])
+    (implicit cbf: CanBuildFrom[M[Task[A]], A, M[A]]): Task[M[A]] = {
+
+    Task.unsafeCreate { (context, finalCallback) =>
+      // We need a monitor to synchronize on, per evaluation!
+      val lock = new AnyRef
+      val mainConn = context.connection
+
+      var tasks: Array[Task[A]] = null
+      var results: Array[AnyRef] = null
+      var tasksCount = 0
+      var completed = 0
+
+      // If this variable is false, then a task ended in error.
+      // MUST BE synchronized by `lock`!
+      var isActive = true
+
+      // MUST BE synchronized by `lock`!
+      // MUST NOT BE called if isActive == false!
+      @inline def maybeSignalFinal(mainConn: StackedCancelable, finalCallback: Callback[M[A]])
+        (implicit s: Scheduler): Unit = {
+
+        completed += 1
+        if (completed >= tasksCount) {
+          isActive = false
+          mainConn.pop()
+
+          val builder = cbf(in)
+          var idx = 0
+          while (idx < results.length) {
+            builder += results(idx).asInstanceOf[A]
+            idx += 1
+          }
+
+          tasks = null // GC relief
+          results = null // GC relief
+          finalCallback.asyncOnSuccess(builder.result())
+        }
+      }
+
+      // MUST BE synchronized by `lock`!
+      @inline def reportError(mainConn: StackedCancelable, ex: Throwable)
+        (implicit s: Scheduler): Unit = {
+
+        if (isActive) {
+          isActive = false
+          // This should cancel our CompositeCancelable
+          mainConn.pop().cancel()
+          tasks = null // GC relief
+          results = null // GC relief
+          finalCallback.asyncOnError(ex)
+        } else {
+          s.reportFailure(ex)
+        }
+      }
+
+      // Light asynchronous boundary
+      context.scheduler.executeTrampolined(() => lock.synchronized {
+        try {
+          implicit val s = context.scheduler
+          tasks = in.toArray
+          tasksCount = tasks.length
+
+          if (tasksCount == 0) {
+            // With no tasks available, we need to return an empty sequence
+            finalCallback.asyncOnSuccess(cbf(in).result())
+          }
+          else if (tasksCount == 1) {
+            // If it's a single task, then execute it directly
+            val source = tasks(0).map(r => (cbf(in) += r).result())
+            Task.unsafeStartNow(source, context, finalCallback)
+          }
+          else if (tasksCount == 2) {
+            // Optimizing for 2 tasks by calling `mapBoth`
+            val source = Task.mapBoth(tasks(0), tasks(1)) { (a1,a2) =>
+              val b = cbf(in)
+              b += a1 += a2
+              b.result()
+            }
+
+            Task.unsafeStartNow(source, context, finalCallback)
+          }
+          else {
+            results = new Array[AnyRef](tasksCount)
+
+            // Collecting all cancelables in a buffer, because adding
+            // cancelables one by one in our `CompositeCancelable` is
+            // expensive, so we do it at the end
+            val allCancelables = ListBuffer.empty[StackedCancelable]
+
+            // We need a composite because we are potentially starting tasks
+            // in paralel and thus we need to cancel everything
+            val composite = CompositeCancelable()
+            mainConn.push(composite)
+
+            var idx = 0
+            while (idx < tasksCount && isActive) {
+              val currentTask = idx
+              val stacked = StackedCancelable()
+              val childContext = context.copy(connection = stacked)
+              allCancelables += stacked
+
+              // Light asynchronous boundary
+              Task.unsafeStartTrampolined(tasks(idx), childContext,
+                new Callback[A] {
+                  def onSuccess(value: A): Unit =
+                    lock.synchronized {
+                      if (isActive) {
+                        results(currentTask) = value.asInstanceOf[AnyRef]
+                        maybeSignalFinal(mainConn, finalCallback)
+                      }
+                    }
+
+                  def onError(ex: Throwable): Unit =
+                    lock.synchronized(reportError(mainConn, ex))
+                })
+
+              idx += 1
+            }
+
+            // Note that if an error happened, this should cancel all
+            // active tasks.
+            composite ++= allCancelables
+          }
+        }
+        catch {
+          case NonFatal(ex) =>
+            // We are still under the lock.synchronize block
+            // so this call is safe
+            reportError(context.connection, ex)(context.scheduler)
+        }
+      })
+    }
+  }
+}

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskGatherUnordered.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskGatherUnordered.scala
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval.internal
+
+import monix.eval.{Callback, Task}
+import monix.execution.Scheduler
+import monix.execution.atomic.{Atomic, AtomicAny}
+import monix.execution.atomic.PaddingStrategy.LeftRight128
+import monix.execution.cancelables.{CompositeCancelable, StackedCancelable}
+import scala.annotation.tailrec
+import scala.collection.mutable.ListBuffer
+import scala.util.control.NonFatal
+
+private[monix] object TaskGatherUnordered {
+  /**
+    * Implementation for `Task.gatherUnordered`
+    */
+  def apply[A](in: TraversableOnce[Task[A]]): Task[List[A]] = {
+    Task.unsafeCreate { (context, finalCallback) =>
+      // Forced asynchronous boundary
+      context.scheduler.executeTrampolined { () =>
+        @inline def maybeSignalFinal(
+          ref: AtomicAny[State[A]],
+          currentState: State[A],
+          mainConn: StackedCancelable,
+          finalCallback: Callback[List[A]])
+          (implicit s: Scheduler): Unit = {
+
+          currentState match {
+            case State.Active(list, 0) =>
+              ref.lazySet(State.Complete)
+              mainConn.pop()
+              finalCallback.asyncOnSuccess(list)
+            case _ =>
+              () // invalid state
+          }
+        }
+
+        @inline def reportError(
+          stateRef: AtomicAny[State[A]],
+          mainConn: StackedCancelable,
+          ex: Throwable)(implicit s: Scheduler): Unit = {
+
+          val currentState = stateRef.getAndSet(State.Complete)
+          if (currentState != State.Complete) {
+            mainConn.pop().cancel()
+            finalCallback.asyncOnError(ex)
+          } else {
+            s.reportFailure(ex)
+          }
+        }
+
+        @tailrec def activate(stateRef: AtomicAny[State[A]], count: Int,
+          conn: StackedCancelable,
+          finalCallback: Callback[List[A]])
+          (implicit s: Scheduler): Unit = {
+
+          stateRef.get match {
+            case current @ State.Initializing(_,_) =>
+              val update = current.activate(count)
+              if (!stateRef.compareAndSet(current, update))
+                activate(stateRef, count, conn, finalCallback)(s)
+              else
+                maybeSignalFinal(stateRef, update, conn, finalCallback)(s)
+
+            case _ =>
+              () // do nothing
+          }
+        }
+
+        // Shared state for synchronization
+        val stateRef = Atomic.withPadding(State.empty[A], LeftRight128)
+
+        try {
+          implicit val s = context.scheduler
+          // Represents the collection of cancelables for all started tasks
+          val composite = CompositeCancelable()
+          val mainConn = context.connection
+          mainConn.push(composite)
+
+          // Collecting all cancelables in a buffer, because adding
+          // cancelables one by one in our `CompositeCancelable` is
+          // expensive, so we do it at the end
+          val allCancelables = ListBuffer.empty[StackedCancelable]
+          val batchSize = s.executionModel.recommendedBatchSize
+          val cursor = in.toIterator
+
+          var continue = true
+          var count = 0
+
+          // The `isActive` check short-circuits the process in case
+          // we have a synchronous task that just completed in error
+          while (cursor.hasNext && continue) {
+            val task = cursor.next()
+            count += 1
+            continue = count % batchSize != 0 || stateRef.get.isActive
+
+            val stacked = StackedCancelable()
+            val childCtx = context.copy(connection = stacked)
+            allCancelables += stacked
+
+            // Light asynchronous boundary
+            Task.unsafeStartTrampolined(task, childCtx,
+              new Callback[A] {
+                @tailrec
+                def onSuccess(value: A): Unit = {
+                  val current = stateRef.get
+                  if (current.isActive) {
+                    val update = current.enqueue(value)
+                    if (!stateRef.compareAndSet(current, update))
+                      onSuccess(value) // retry
+                    else
+                      maybeSignalFinal(stateRef, update, context.connection, finalCallback)
+                  }
+                }
+
+                def onError(ex: Throwable): Unit =
+                  reportError(stateRef, mainConn, ex)
+              })
+          }
+
+          // Note that if an error happened, this should cancel all
+          // other active tasks.
+          composite ++= allCancelables
+          // We are done triggering tasks, now we can allow the final
+          // callback to be triggered
+          activate(stateRef, count, mainConn, finalCallback)(s)
+        }
+        catch {
+          case NonFatal(ex) =>
+            reportError(stateRef, context.connection, ex)(context.scheduler)
+        }
+      }
+    }
+  }
+
+  private sealed abstract class State[+A] {
+    def isActive: Boolean
+    def enqueue[B >: A](value: B): State[B]
+  }
+
+  private object State {
+    def empty[A]: State[A] =
+      Initializing(List.empty, 0)
+
+    case object Complete extends State[Nothing] {
+      def isActive = false
+
+      override def enqueue[B >: Nothing](value: B): State[B] =
+        this
+    }
+
+    final case class Initializing[+A](list: List[A], remaining: Int)
+      extends State[A] {
+
+      def isActive = true
+      def enqueue[B >: A](value: B): Initializing[B] =
+        Initializing(value :: list, remaining - 1)
+
+      def activate(totalCount: Int): Active[A] =
+        Active(list, remaining + totalCount)
+    }
+
+    final case class Active[+A](list: List[A], remaining: Int)
+      extends State[A] {
+
+      def isActive = true
+      def enqueue[B >: A](value: B): Active[B] =
+        Active(value :: list, remaining - 1)
+    }
+  }
+}

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskMapBoth.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskMapBoth.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval.internal
+
+import monix.eval.{Callback, Task}
+import monix.execution.Ack.Stop
+import monix.execution.Scheduler
+import monix.execution.atomic.PaddingStrategy.LeftRight128
+import monix.execution.atomic.{Atomic, AtomicAny}
+import monix.execution.cancelables.{CompositeCancelable, StackedCancelable}
+
+import scala.annotation.tailrec
+import scala.util.control.NonFatal
+
+private[monix] object TaskMapBoth {
+  /**
+    * Implementation for `Task.mapBoth`.
+    */
+  def apply[A1,A2,R](fa1: Task[A1], fa2: Task[A2])(f: (A1,A2) => R): Task[R] = {
+    /* For signaling the values after the successful completion of both tasks. */
+    def sendSignal(mainConn: StackedCancelable, cb: Callback[R], a1: A1, a2: A2)
+      (implicit s: Scheduler): Unit = {
+
+      var streamErrors = true
+      try {
+        val r = f(a1, a2)
+        streamErrors = false
+        mainConn.pop()
+        cb.asyncOnSuccess(r)
+      } catch {
+        case NonFatal(ex) if streamErrors =>
+          // Both tasks completed by this point, so we don't need
+          // to worry about the `state` being a `Stop`
+          mainConn.pop()
+          cb.asyncOnError(ex)
+      }
+    }
+
+    /* For signaling an error. */
+    @tailrec def sendError(mainConn: StackedCancelable, state: AtomicAny[AnyRef], cb: Callback[R], ex: Throwable)
+      (implicit s: Scheduler): Unit = {
+
+      // Guarding the contract of the callback, as we cannot send an error
+      // if an error has already happened because of the other task
+      state.get match {
+        case Stop =>
+          // We've got nowhere to send the error, so report it
+          s.reportFailure(ex)
+        case other =>
+          if (!state.compareAndSet(other, Stop))
+            sendError(mainConn, state, cb, ex)(s) // retry
+          else {
+            mainConn.pop().cancel()
+            cb.asyncOnError(ex)(s)
+          }
+      }
+    }
+
+    // The resulting task will be executed asynchronously
+    Task.unsafeCreate { (context, cb) =>
+      // Initial asynchronous boundary
+      context.scheduler.executeTrampolined { () =>
+        implicit val s = context.scheduler
+        val mainConn = context.connection
+        // for synchronizing the results
+        val state = Atomic.withPadding(null: AnyRef, LeftRight128)
+        val task1 = StackedCancelable()
+        val context1 = context.copy(connection = task1)
+        val task2 = StackedCancelable()
+        val context2 = context.copy(connection = task2)
+        mainConn push CompositeCancelable(task1, task2)
+
+        // Light asynchronous boundary; with most scheduler implementations
+        // it will not fork a new (logical) thread!
+        Task.unsafeStartTrampolined(fa1, context1, new Callback[A1] {
+          @tailrec def onSuccess(a1: A1): Unit =
+            state.get match {
+              case null => // null means this is the first task to complete
+                if (!state.compareAndSet(null, Left(a1))) onSuccess(a1)
+              case ref@Right(a2) => // the other task completed, so we can send
+                sendSignal(mainConn, cb, a1, a2.asInstanceOf[A2])(s)
+              case Stop => // the other task triggered an error
+                () // do nothing
+              case s@Left(_) =>
+                // This task has triggered multiple onSuccess calls
+                // violating the protocol. Should never happen.
+                onError(new IllegalStateException(s.toString))
+            }
+
+          def onError(ex: Throwable): Unit =
+            sendError(mainConn, state, cb, ex)(s)
+        })
+
+        // Light asynchronous boundary
+        Task.unsafeStartTrampolined(fa2, context2, new Callback[A2] {
+          @tailrec def onSuccess(a2: A2): Unit =
+            state.get match {
+              case null => // null means this is the first task to complete
+                if (!state.compareAndSet(null, Right(a2))) onSuccess(a2)
+              case ref@Left(a1) => // the other task completed, so we can send
+                sendSignal(mainConn, cb, a1.asInstanceOf[A1], a2)(s)
+              case Stop => // the other task triggered an error
+                () // do nothing
+              case s@Right(_) =>
+                // This task has triggered multiple onSuccess calls
+                // violating the protocol. Should never happen.
+                onError(new IllegalStateException(s.toString))
+            }
+
+          def onError(ex: Throwable): Unit =
+            sendError(mainConn, state, cb, ex)(s)
+        })
+      }
+    }
+  }
+}

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskToReactivePublisher.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskToReactivePublisher.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval.internal
+
+import monix.eval.{Callback, Task}
+import monix.execution.Scheduler
+import monix.execution.cancelables.StackedCancelable
+import monix.execution.rstreams.Subscription
+import org.reactivestreams.Subscriber
+
+private[monix] object TaskToReactivePublisher {
+  /**
+    * Implementation for `Task.toReactivePublisher`
+    */
+  def apply[A](self: Task[A])(implicit s: Scheduler): org.reactivestreams.Publisher[A] =
+    new org.reactivestreams.Publisher[A] {
+      def subscribe(out: Subscriber[_ >: A]): Unit = {
+        out.onSubscribe(new Subscription {
+          private[this] var isActive = true
+          private[this] val conn = StackedCancelable()
+          private[this] val context =
+            Task.Context(s, conn, Task.startFrameRef(), Task.defaultOptions)
+
+          def request(n: Long): Unit = {
+            require(n > 0, "n must be strictly positive, according to " +
+              "the Reactive Streams contract, rule 3.9")
+
+            if (isActive) {
+              Task.unsafeStartAsync[A](self, context,
+                Callback.safe(new Callback[A] {
+                  def onError(ex: Throwable): Unit =
+                    out.onError(ex)
+
+                  def onSuccess(value: A): Unit = {
+                    out.onNext(value)
+                    out.onComplete()
+                  }
+                }))
+            }
+          }
+
+          def cancel(): Unit = {
+            isActive = false
+            conn.cancel()
+          }
+        })
+      }
+    }
+}

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalEvalAlwaysSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalEvalAlwaysSuite.scala
@@ -141,7 +141,7 @@ object CoevalEvalAlwaysSuite extends BaseTestSuite {
       t1.runAttempt
       t2.runAttempt
 
-      t1 =!= t1
+      t1 !== t1
     }
   }
 }

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskApplySuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskApplySuite.scala
@@ -92,8 +92,9 @@ object TaskApplySuite extends BaseTestSuite {
       // Running once to trigger effects
       t1.runAsync(s)
       t2.runAsync(s)
+      s.tick()
 
-      t1 =!= t1
+      t1 !== t2
     }
   }
 

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskChooseFirstOfSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskChooseFirstOfSuite.scala
@@ -19,7 +19,6 @@ package monix.eval
 
 import monix.execution.CancelableFuture
 import monix.execution.internal.Platform
-
 import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskCoevalDoOnFinishSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskCoevalDoOnFinishSuite.scala
@@ -20,7 +20,7 @@ package monix.eval
 import scala.concurrent.Promise
 import scala.util.{Failure, Success}
 
-object DoOnFinishSuite extends BaseTestSuite {
+object TaskCoevalDoOnFinishSuite extends BaseTestSuite {
   test("Task.doOnFinish should work for successful values") { implicit s =>
     val p = Promise[Option[Throwable]]()
 

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskCoevalForeachSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskCoevalForeachSuite.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval
+
+import minitest.TestSuite
+import monix.execution.schedulers.TestScheduler
+
+object TaskCoevalForeachSuite extends TestSuite[TestScheduler] {
+  def setup(): TestScheduler = TestScheduler()
+  def tearDown(env: TestScheduler): Unit = {
+    assert(env.state.tasks.isEmpty,
+      "should not have tasks left to execute")
+  }
+
+  test("Task.foreachL") { implicit s =>
+    var effect = 0
+    val task = Task(1).foreachL(x => effect += x)
+
+    assertEquals(effect, 0)
+    task.runAsync; s.tick()
+    assertEquals(effect, 1)
+    task.runAsync; s.tick()
+    assertEquals(effect, 2)
+  }
+
+  test("Task.foreach") { implicit s =>
+    var effect = 0
+    val task = Task(1)
+
+    assertEquals(effect, 0)
+    task.foreach(x => effect += x); s.tick()
+    assertEquals(effect, 1)
+    task.foreach(x => effect += x); s.tick()
+    assertEquals(effect, 2)
+  }
+
+
+  test("Coeval.foreachL") { _ =>
+    var effect = 0
+    val coeval = Coeval(1).foreachL(x => effect += x)
+
+    assertEquals(effect, 0)
+    coeval.value
+    assertEquals(effect, 1)
+    coeval.value
+    assertEquals(effect, 2)
+  }
+
+  test("Coeval.foreach") { _ =>
+    var effect = 0
+    val coeval = Coeval(1)
+
+    assertEquals(effect, 0)
+    coeval.foreach(x => effect += x)
+    assertEquals(effect, 1)
+    coeval.foreach(x => effect += x)
+    assertEquals(effect, 2)
+  }
+}

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskCreateSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskCreateSuite.scala
@@ -21,8 +21,7 @@ import monix.execution.Cancelable
 import monix.execution.atomic.Atomic
 import monix.execution.cancelables.{CompositeCancelable, MultiAssignmentCancelable}
 import monix.execution.internal.Platform
-
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
 object TaskCreateSuite extends BaseTestSuite {
   test("Task.create should be stack safe, take 1") { implicit s =>
@@ -118,5 +117,24 @@ object TaskCreateSuite extends BaseTestSuite {
     val f = t.runAsync
     s.tick()
     assertEquals(f.value, Some(Failure(dummy)))
+  }
+
+  test("Task.create should not execute immediately when executed as future") { implicit s =>
+    val t = Task.create[Int] { (_,cb) => cb.onSuccess(100); Cancelable.empty }
+    val result = t.runAsync
+
+    assertEquals(result.value, None)
+    s.tick()
+    assertEquals(result.value, Some(Success(100)))
+  }
+
+  test("Task.create should not execute immediately when executed with callback") { implicit s =>
+    var result = Option.empty[Try[Int]]
+    val t = Task.create[Int] { (_,cb) => cb.onSuccess(100); Cancelable.empty }
+    t.runAsync { r: Try[Int] => result = Some(r) }
+
+    assertEquals(result, None)
+    s.tick()
+    assertEquals(result, Some(Success(100)))
   }
 }

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskDoOnCancelSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskDoOnCancelSuite.scala
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval
+
+import concurrent.duration._
+import scala.util.{Failure, Success}
+
+object TaskDoOnCancelSuite extends BaseTestSuite {
+  test("Task.doOnCancel should normally mirror the source") { implicit s =>
+    var effect1 = 0
+    var effect2 = 0
+    var effect3 = 0
+
+    val f = Task.eval(1)
+      .delayExecution(1.second)
+      .doOnCancel(Task.eval { effect1 += 1 })
+      .delayExecution(1.second)
+      .doOnCancel(Task.eval { effect2 += 1 })
+      .delayExecution(1.second)
+      .doOnCancel(Task.eval { effect3 += 1 })
+      .runAsync
+
+    s.tick(3.seconds)
+    assertEquals(f.value, Some(Success(1)))
+    assertEquals(effect1, 0)
+    assertEquals(effect2, 0)
+    assertEquals(effect3, 0)
+  }
+
+  test("Task.doOnCancel should mirror failed sources") { implicit s =>
+    var effect = 0
+    val dummy = new RuntimeException("dummy")
+    val f = Task.fork(Task.raiseError(dummy))
+      .doOnCancel(Task.eval { effect += 1 })
+      .runAsync
+
+    s.tick()
+    assertEquals(f.value, Some(Failure(dummy)))
+    assertEquals(effect, 0)
+  }
+
+  test("Task.doOnCancel should cancel delayResult #1") { implicit s =>
+    var effect1 = 0
+    var effect2 = 0
+    var effect3 = 0
+
+    val f = Task.eval(1)
+      .delayResult(1.second)
+      .doOnCancel(Task.eval { effect1 += 1 })
+      .delayResult(1.second)
+      .doOnCancel(Task.eval { effect2 += 1 })
+      .delayResult(1.second)
+      .doOnCancel(Task.eval { effect3 += 1 })
+      .runAsync
+
+    s.tick(2.seconds)
+    assertEquals(f.value, None)
+    f.cancel()
+
+    s.tick()
+    assertEquals(effect1, 0)
+    assertEquals(effect2, 0)
+    assertEquals(effect3, 1)
+
+    assert(s.state.tasks.isEmpty, "s.state.tasks.isEmpty")
+  }
+
+  test("Task.doOnCancel should cancel delayResult #2") { implicit s =>
+    var effect1 = 0
+    var effect2 = 0
+    var effect3 = 0
+
+    val f = Task.eval(1)
+      .delayResult(1.second)
+      .doOnCancel(Task.eval { effect1 += 1 })
+      .delayResult(1.second)
+      .doOnCancel(Task.eval { effect2 += 1 })
+      .delayResult(1.second)
+      .doOnCancel(Task.eval { effect3 += 1 })
+      .runAsync
+
+    s.tick(1.seconds)
+    assertEquals(f.value, None)
+    f.cancel()
+
+    s.tick()
+    assertEquals(effect1, 0)
+    assertEquals(effect2, 1)
+    assertEquals(effect3, 1)
+
+    assert(s.state.tasks.isEmpty, "s.state.tasks.isEmpty")
+  }
+
+  test("Task.doOnCancel should cancel delayResult #3") { implicit s =>
+    var effect1 = 0
+    var effect2 = 0
+    var effect3 = 0
+
+    val f = Task.eval(1)
+      .delayResult(1.second)
+      .doOnCancel(Task.eval { effect1 += 1 })
+      .delayResult(1.second)
+      .doOnCancel(Task.eval { effect2 += 1 })
+      .delayResult(1.second)
+      .doOnCancel(Task.eval { effect3 += 1 })
+      .runAsync
+
+    s.tick()
+    assertEquals(f.value, None)
+    f.cancel()
+
+    s.tick()
+    assertEquals(effect1, 1)
+    assertEquals(effect2, 1)
+    assertEquals(effect3, 1)
+
+    assert(s.state.tasks.isEmpty, "s.state.tasks.isEmpty")
+  }
+
+  test("Task.doOnCancel should cancel delayExecution #1") { implicit s =>
+    var effect1 = 0
+    var effect2 = 0
+    var effect3 = 0
+
+    val f = Task.eval(1)
+      .doOnCancel(Task.eval { effect1 += 1 })
+      .delayExecution(1.second)
+      .doOnCancel(Task.eval { effect2 += 1 })
+      .delayExecution(1.second)
+      .doOnCancel(Task.eval { effect3 += 1 })
+      .delayExecution(1.second)
+      .runAsync
+
+    s.tick(1.second)
+    assertEquals(f.value, None)
+    f.cancel()
+
+    s.tick()
+    assertEquals(effect1, 0)
+    assertEquals(effect2, 0)
+    assertEquals(effect3, 1)
+
+    assert(s.state.tasks.isEmpty, "s.state.tasks.isEmpty")
+  }
+
+  test("Task.doOnCancel should cancel delayExecution #2") { implicit s =>
+    var effect1 = 0
+    var effect2 = 0
+    var effect3 = 0
+
+    val f = Task.eval(1)
+      .doOnCancel(Task.eval { effect1 += 1 })
+      .delayExecution(1.second)
+      .doOnCancel(Task.eval { effect2 += 1 })
+      .delayExecution(1.second)
+      .doOnCancel(Task.eval { effect3 += 1 })
+      .delayExecution(1.second)
+      .runAsync
+
+    s.tick(2.second)
+    assertEquals(f.value, None)
+    f.cancel()
+
+    s.tick()
+    assertEquals(effect1, 0)
+    assertEquals(effect2, 1)
+    assertEquals(effect3, 1)
+
+    assert(s.state.tasks.isEmpty, "s.state.tasks.isEmpty")
+  }
+}

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskErrorSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskErrorSuite.scala
@@ -19,6 +19,7 @@ package monix.eval
 
 import monix.eval.Coeval.{Error, Now}
 import monix.execution.internal.Platform
+
 import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
@@ -173,7 +174,7 @@ object TaskErrorSuite extends BaseTestSuite {
   }
 
   test("Task#onErrorHandle should mirror source on success") { implicit s =>
-    val task = Task(1).onErrorHandle { case ex: Throwable => 99 }
+    val task = Task(1).onErrorHandle { ex: Throwable => 99 }
     val f = task.runAsync
     s.tick()
     assertEquals(f.value, Some(Success(1)))
@@ -195,7 +196,7 @@ object TaskErrorSuite extends BaseTestSuite {
     val ex2 = DummyException("two")
 
     val task = Task[Int](if (1 == 1) throw ex1 else 1)
-      .onErrorHandle { case ex => throw ex2 }
+      .onErrorHandle { ex => throw ex2 }
 
     val f = task.runAsync; s.tick()
     assertEquals(f.value, Some(Failure(ex2)))
@@ -225,12 +226,12 @@ object TaskErrorSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Failure(err)))
   }
 
-  test("Task.onErrorFallbackTo should be cancelable") { implicit s =>
+  test("Task.onErrorFallbackTo should be cancelable if the ExecutionModel allows it") { implicit s =>
     def recursive(): Task[Int] = {
       Task[Int](throw DummyException("dummy")).onErrorFallbackTo(Task.defer(recursive()))
     }
 
-    val task = recursive()
+    val task = recursive().executeWithOptions(_.enableAutoCancelableRunLoops)
     val f = task.runAsync
     assertEquals(f.value, None)
 
@@ -268,11 +269,11 @@ object TaskErrorSuite extends BaseTestSuite {
     assertEquals(tries, 11)
   }
 
-  test("Task.onErrorRestart should not be cancelable") { implicit s =>
+  test("Task.onErrorRestart should be cancelable if ExecutionModel permits") { implicit s =>
     val task = Task[Int](throw DummyException("dummy"))
       .onErrorRestart(s.executionModel.recommendedBatchSize*2)
 
-    val f = task.runAsync
+    val f = task.executeWithOptions(_.enableAutoCancelableRunLoops).runAsync
     assertEquals(f.value, None)
 
     // cancelling after scheduled for execution, but before execution
@@ -311,14 +312,13 @@ object TaskErrorSuite extends BaseTestSuite {
     assertEquals(tries, 11)
   }
 
-  test("Task.onErrorRestartIf should be cancelable") { implicit s =>
+  test("Task.onErrorRestartIf should be cancelable if ExecutionModel permits") { implicit s =>
     val task = Task[Int](throw DummyException("dummy")).onErrorRestartIf(ex => true)
-    val f = task.runAsync
+    val f = task.executeWithOptions(_.enableAutoCancelableRunLoops).runAsync
     assertEquals(f.value, None)
 
     // cancelling after scheduled for execution, but before execution
     f.cancel(); s.tick()
-
     assertEquals(f.value, None)
   }
 

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskEvalAlwaysSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskEvalAlwaysSuite.scala
@@ -73,7 +73,7 @@ object TaskEvalAlwaysSuite extends BaseTestSuite {
       t2.runAsync(s)
       s.tick()
 
-      t1 =!= t2
+      t1 !== t2
     }
   }
 

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskForkSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskForkSuite.scala
@@ -19,84 +19,42 @@ package monix.eval
 
 import monix.execution.Cancelable
 import monix.execution.internal.Platform
-
+import monix.execution.schedulers.ExecutionModel.AlwaysAsyncExecution
+import monix.execution.schedulers.TestScheduler
 import scala.util.Success
 
 object TaskForkSuite extends BaseTestSuite {
-  test("Task.now.fork should execute async") { implicit s =>
-    val t = Task.fork(Task.now(10))
+  test("Task.now.executeWithFork should execute async") { implicit s =>
+    val t = Task.now(10).executeWithFork
     val f = t.runAsync
+
     assertEquals(f.value, None)
     s.tick()
     assertEquals(f.value, Some(Success(10)))
   }
 
-  test("Task.evalOnce.fork should execute async") { implicit s =>
-    val t = Task.fork(Task.evalOnce(10))
+  test("Task.now.executeOn should execute async") { implicit s =>
+    val s2 = TestScheduler()
+    val t = Task.now(10).executeOn(s2)
     val f = t.runAsync
+
     assertEquals(f.value, None)
     s.tick()
+    assertEquals(f.value, None)
+    s2.tick()
     assertEquals(f.value, Some(Success(10)))
   }
 
-  test("Task.eval.fork should execute async") { implicit s =>
-    val t = Task.fork(Task.eval(10))
-    val f = t.runAsync
-    assertEquals(f.value, None)
-    s.tick()
-    assertEquals(f.value, Some(Success(10)))
-  }
-
-  test("Task.defer.fork should execute async") { implicit s =>
-    val t = Task.fork(Task.defer(Task.now(10)))
-    val f = t.runAsync
-    assertEquals(f.value, None)
-    s.tick()
-    assertEquals(f.value, Some(Success(10)))
-  }
-
-  test("Task.async.fork should execute async") { implicit s =>
-    val source = Task.unsafeCreate[Int]((s, conn, cb) => cb.onSuccess(10))
-    val t = Task.fork(source)
-    val f = t.runAsync
-    assertEquals(f.value, None)
-    s.tick()
-    assertEquals(f.value, Some(Success(10)))
-  }
-
-  test("Task.async.defer.fork should execute async") { implicit s =>
-    val source = Task.unsafeCreate[Int]((s, conn, cb) => cb.onSuccess(10))
-    val t = Task.fork(Task.defer(source))
-    val f = t.runAsync
-    assertEquals(f.value, None)
-    s.tick()
-    assertEquals(f.value, Some(Success(10)))
-  }
-
-  test("Task.async.flatMap.fork should execute async") { implicit s =>
-    val source = Task.unsafeCreate[Int]((s, conn, cb) => cb.onSuccess(10)).flatMap(Task.now)
-    val t = Task.fork(source)
-    val f = t.runAsync
-    assertEquals(f.value, None)
-    s.tick()
-    assertEquals(f.value, Some(Success(10)))
-  }
-
-  test("Task.async.memoize.fork should execute async") { implicit s =>
-    val source = Task.unsafeCreate[Int]((s, conn, cb) => cb.onSuccess(10))
-    val t = Task.fork(source.memoize)
-    val f = t.runAsync
-    assertEquals(f.value, None)
-    s.tick()
-    assertEquals(f.value, Some(Success(10)))
-  }
-
-  test("Task.create.fork should execute async") { implicit s =>
+  test("Task.create.executeOn should execute async") { implicit s =>
+    val s2 = TestScheduler()
     val source = Task.create[Int] { (s, cb) => cb.onSuccess(10); Cancelable.empty }
-    val t = Task.fork(source)
+    val t = source.executeOn(s2)
     val f = t.runAsync
+
     assertEquals(f.value, None)
     s.tick()
+    assertEquals(f.value, None)
+    s2.tick()
     assertEquals(f.value, Some(Success(10)))
   }
 
@@ -130,5 +88,56 @@ object TaskForkSuite extends BaseTestSuite {
     val result = loop(count).runAsync
     s.tick()
     assertEquals(result.value, Some(Success(0)))
+  }
+
+  test("Task.executeWithModel should work") { implicit s =>
+    val task = Task.now(1).executeWithModel(AlwaysAsyncExecution)
+    val f = task.runAsync
+
+    assertEquals(f.value, None)
+    s.tick()
+    assertEquals(f.value, Some(Success(1)))
+  }
+
+  test("Task.asyncBoundary should work") { implicit s =>
+    val io = TestScheduler()
+    var effect = 0
+    val f = Task.fork(Task.eval { effect += 1; effect }, io)
+      .asyncBoundary
+      .map(_ + 1)
+      .runAsync
+
+    assertEquals(effect, 0)
+    s.tick()
+    assertEquals(effect, 0)
+
+    io.tick()
+    assertEquals(effect, 1)
+    assertEquals(f.value, None)
+
+    s.tick()
+    assertEquals(f.value, Some(Success(2)))
+  }
+
+  test("Task.asyncBoundary(other) should work") { implicit s1 =>
+    val io = TestScheduler()
+    val s2 = TestScheduler()
+
+    var effect = 0
+    val f = Task.fork(Task.eval { effect += 1; effect }, io)
+      .asyncBoundary(s2)
+      .map(_ + 1)
+      .runAsync
+
+    assertEquals(effect, 0)
+    s1.tick()
+    assertEquals(effect, 0)
+
+    io.tick()
+    assertEquals(effect, 1)
+    assertEquals(f.value, None)
+
+    s2.tick()
+    assertEquals(f.value, Some(Success(2)))
   }
 }

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskGatherSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskGatherSuite.scala
@@ -18,12 +18,11 @@
 package monix.eval
 
 import monix.execution.internal.Platform
-
-import concurrent.duration._
+import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
 object TaskGatherSuite extends BaseTestSuite {
-  test("Task.gather should execute in parallel") { implicit s =>
+  test("Task.gather should execute in parallel for async tasks") { implicit s =>
     val seq = Seq(Task(1).delayExecution(2.seconds), Task(2).delayExecution(1.second), Task(3).delayExecution(3.seconds))
     val f = Task.gather(seq).runAsync
 

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskGatherUnorderedSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskGatherUnorderedSuite.scala
@@ -18,7 +18,6 @@
 package monix.eval
 
 import monix.execution.internal.Platform
-
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
@@ -33,7 +32,7 @@ object TaskGatherUnorderedSuite extends BaseTestSuite {
     s.tick(2.seconds)
     assertEquals(f.value, None)
     s.tick(1.second)
-    assertEquals(f.value, Some(Success(List(2, 1, 3))))
+    assertEquals(f.value, Some(Success(List(3, 1, 2))))
   }
 
   test("Task.gatherUnordered should onError if one of the tasks terminates in error") { implicit s =>

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskMapBothSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskMapBothSuite.scala
@@ -17,9 +17,18 @@
 
 package monix.eval
 
-import scala.util.Success
+import scala.util.{Failure, Success}
 
 object TaskMapBothSuite extends BaseTestSuite {
+  test("if both tasks are synchronous, then mapBoth is also synchronous") { implicit s =>
+    val ta = Task.eval(1)
+    val tb = Task.eval(2)
+
+    val r = Task.mapBoth(ta,tb)(_ + _)
+    val f = r.runAsync
+    assertEquals(f.value, Some(Success(3)))
+  }
+
   test("sum two async tasks") { implicit s =>
     val ta = Task(1)
     val tb = Task(2)
@@ -73,6 +82,25 @@ object TaskMapBothSuite extends BaseTestSuite {
     check1 { (numbers: List[Int]) =>
       val sum = numbers.foldLeft(Task(0))((acc,t) => Task.mapBoth(acc, Task(t))(_+_))
       sum === Task(numbers.sum)
+    }
+  }
+
+  test("both task can fail with error") { implicit s =>
+    val err1 = new RuntimeException("Error 1")
+    val t1 = Task.fork(Task.defer(Task.raiseError[Int](err1)))
+    val err2 = new RuntimeException("Error 2")
+    val t2 = Task.fork(Task.defer(Task.raiseError[Int](err2)))
+
+    val fb = Task.mapBoth(t1, t2)(_ + _).runAsync
+    s.tick()
+
+    fb.value match {
+      case Some(Failure(`err1`)) =>
+        assertEquals(s.state.lastReportedError, err2)
+      case Some(Failure(`err2`)) =>
+        assertEquals(s.state.lastReportedError, err1)
+      case other =>
+        fail(s"fb.value is $other")
     }
   }
 }


### PR DESCRIPTION
Issues included:

- #239: `Task.flatMap` loops should not be auto-cancelable by default
- #226: Add Task.Options with an `autoCancelableRunLoops property`
- #227: Add executeWithFork, executeWithModel and asyncBoundary operators on Task
- #232: Task should use TrampolinedRunnables everywhere it can
- #236: Task and Coeval need `foreach` and `foreachL`
- #238: Add `Coeval.Attempt.get`
