### PR TITLE
Added wander/wanderUnordered to Task.

### DIFF
--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -896,7 +896,7 @@ object Task extends TaskInstances {
    */
   def wander[A, B, M[X] <: TraversableOnce[X]](in: M[A])(f: A => Task[B])
     (implicit cbf: CanBuildFrom[M[A], B, M[B]]): Task[M[B]] = {
-    TaskGather(in.toArray.map(f), () => cbf(in))
+    TaskGather(in.map(f).toArray, () => cbf(in))
   }
 
   /** Nondeterministically gather results from the given collection of tasks,

--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -875,7 +875,29 @@ object Task extends TaskInstances {
     */
   def gather[A, M[X] <: TraversableOnce[X]](in: M[Task[A]])
     (implicit cbf: CanBuildFrom[M[Task[A]], A, M[A]]): Task[M[A]] =
-    TaskGather(in)(cbf)
+    TaskGather(in.toArray, () => cbf(in))
+
+   /** Given a `TraversableOnce[A]` and a function `A => Task[B]`,
+   * nondeterministically apply the function to each element of the collection
+   * and return a task that will signal a collection of the results once all
+   * tasks are finished.
+   *
+   * This function is the nondeterministic analogue of `traverse` and should
+   * behave identically to `traverse` so long as there is no interaction between
+   * the effects being gathered. However, unlike `traverse`, which decides on
+   * a total order of effects, the effects in a `wander` are unordered with
+   * respect to each other.
+   *
+   * Although the effects are unordered, we ensure the order of results
+   * matches the order of the input sequence. Also see [[wanderUnordered]]
+   * for the more efficient alternative.
+   *
+   * It's a generalized version of [[gather]].
+   */
+  def wander[A, B, M[X] <: TraversableOnce[X]](in: M[A])(f: A => Task[B])
+    (implicit cbf: CanBuildFrom[M[A], B, M[B]]): Task[M[B]] = {
+    TaskGather(in.toArray.map(f), () => cbf(in))
+  }
 
   /** Nondeterministically gather results from the given collection of tasks,
     * without keeping the original ordering of results.
@@ -894,6 +916,30 @@ object Task extends TaskInstances {
     */
   def gatherUnordered[A](in: TraversableOnce[Task[A]]): Task[List[A]] =
     TaskGatherUnordered(in)
+
+  /** Given a `TraversableOnce[A]` and a function `A => Task[B]`,
+    * nondeterministically apply the function to each element of the collection
+    * without keeping the original ordering of the results.
+    *
+    * This function is similar to [[wander]], but neither the effects nor the
+    * results will be ordered. Useful when you don't need ordering because:
+    *
+    *  - it has non-blocking behavior (but not wait-free)
+    *  - it can be more efficient (compared with [[wander]]), but not
+    *    necessarily (if you care about performance, then test)
+    *
+    * It's a generalized version of [[gatherUnordered]].
+    */
+  def wanderUnordered[A, B, M[X] <: TraversableOnce[X]](in: M[A])(f: A => Task[B])
+    (implicit cbf: CanBuildFrom[M[A], B, M[B]]): Task[M[B]] = {
+    val tasks = in.toIterable.map(f)
+
+    for (result <- gatherUnordered(tasks)) yield {
+      val builder = cbf(in)
+      for (b <- result) builder += b
+      builder.result()
+    }
+  }
 
   /** Apply a mapping functions to the results of two tasks, nondeterministically
     * ordering their effects.

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskGather.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskGather.scala
@@ -28,7 +28,7 @@ private[monix] object TaskGather {
   /**
     * Implementation for `Task.gather`
     */
-  def apply[A, M[X] <: TraversableOnce[X]](in: Array[Task[A]], bldrBldr: () => mutable.Builder[A, M[A]]): Task[M[A]] = {
+  def apply[A, M[X] <: TraversableOnce[X]](in: TraversableOnce[Task[A]], bldrBldr: () => mutable.Builder[A, M[A]]): Task[M[A]] = {
 
     Task.unsafeCreate { (context, finalCallback) =>
       // We need a monitor to synchronize on, per evaluation!
@@ -87,7 +87,7 @@ private[monix] object TaskGather {
       context.scheduler.executeTrampolined(() => lock.synchronized {
         try {
           implicit val s = context.scheduler
-          tasks = in
+          tasks = in.toArray
           tasksCount = tasks.length
 
           if (tasksCount == 0) {

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskWanderSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskWanderSuite.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval
+
+import monix.execution.internal.Platform
+import concurrent.duration._
+
+import scala.util.{Failure, Success}
+
+object TaskWanderSuite extends BaseTestSuite {
+  test("Task.wander should execute in parallel for async tasks") { implicit s =>
+    val seq = Seq((1, 2), (2, 1), (3, 3))
+    val f = Task.wander(seq) {
+      case (i, d) =>
+        Task(i + 1).delayExecution(d.seconds)
+    }.runAsync
+
+    s.tick()
+    assertEquals(f.value, None)
+    s.tick(2.seconds)
+    assertEquals(f.value, None)
+    s.tick(1.second)
+    assertEquals(f.value, Some(Success(Seq(2, 3, 4))))
+  }
+
+  test("Task.wander should onError if one of the tasks terminates in error") { implicit s =>
+    val ex = DummyException("dummy")
+    val seq = Seq((1, 3), (-1, 1), (3, 2), (3, 1))
+    val f = Task.wander(seq) {
+      case (i, d) =>
+        Task(if (i < 0) throw ex else i + 1)
+          .delayExecution(d.seconds)
+    }.runAsync
+
+    s.tick()
+    assertEquals(f.value, None)
+    s.tick(2.seconds)
+    assertEquals(f.value, Some(Failure(ex)))
+  }
+
+  test("Task.wander should be canceled") { implicit s =>
+    val seq = Seq((1, 2), (2, 1), (3, 3))
+    val f = Task.wander(seq) {
+      case (i, d) => Task(i + 1).delayExecution(d.seconds)
+    }.runAsync
+
+    s.tick()
+    assertEquals(f.value, None)
+    s.tick(2.seconds)
+    assertEquals(f.value, None)
+
+    f.cancel()
+    s.tick(1.second)
+    assertEquals(f.value, None)
+  }
+
+  test("Task.wander should be stack safe for synchronous tasks") { implicit s =>
+    val count = if (Platform.isJVM) 100000 else 5000
+    val seq = for (i <- 0 until count) yield 1
+    val composite = Task.wander(seq)(Task.now).map(_.sum)
+    val result = composite.runAsync
+    s.tick()
+    assertEquals(result.value, Some(Success(count)))
+  }
+
+  test("Task.wander runAsync multiple times") { implicit s =>
+    var effect = 0
+
+    val task1 = Task { effect += 1; 3 }.memoize
+
+    val task2 = Task.wander(Seq(0,0,0)) { _ =>
+      task1 map { x => effect += 1; x + 1 }
+    }
+
+    val result1 = task2.runAsync; s.tick()
+    assertEquals(result1.value, Some(Success(List(4,4,4))))
+    assertEquals(effect, 1 + 3)
+
+    val result2 = task2.runAsync; s.tick()
+    assertEquals(result2.value, Some(Success(List(4,4,4))))
+    assertEquals(effect, 1 + 3 + 3)
+  }
+}

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskWanderSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskWanderSuite.scala
@@ -95,4 +95,14 @@ object TaskWanderSuite extends BaseTestSuite {
     assertEquals(result2.value, Some(Success(List(4,4,4))))
     assertEquals(effect, 1 + 3 + 3)
   }
+
+  test("Task.wander should wrap exceptions in the function") { implicit s =>
+    val ex = DummyException("dummy")
+    val task1 = Task.wander(Seq(0)) { _ =>
+      throw ex
+    }
+
+    val result1 = task1.runAsync; s.tick()
+    assertEquals(result1.value, Some(Failure(ex)))
+  }
 }

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskWanderUnorderedSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskWanderUnorderedSuite.scala
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval
+
+import monix.execution.internal.Platform
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+object TaskWanderUnorderedSuite extends BaseTestSuite {
+  test("Task.wanderUnordered should execute in parallel") { implicit s =>
+    val seq = Seq((1, 2), (2, 1), (3, 3))
+    val f = Task.wanderUnordered(seq) {
+      case (i, d) =>
+        Task(i + 1).delayExecution(d.seconds)
+    }.runAsync
+
+    s.tick()
+    assertEquals(f.value, None)
+    s.tick(2.seconds)
+    assertEquals(f.value, None)
+    s.tick(1.second)
+    assertEquals(f.value, Some(Success(Seq(4, 2, 3))))
+  }
+
+  test("Task.wanderUnordered should onError if one of the tasks terminates in error") { implicit s =>
+    val ex = DummyException("dummy")
+    val seq = Seq((1, 3), (-1, 1), (3, 2), (3, 1))
+    val f = Task.wanderUnordered(seq) {
+      case (i, d) =>
+        Task(if (i < 0) throw ex else i + 1)
+          .delayExecution(d.seconds)
+    }.runAsync
+
+    s.tick()
+    assertEquals(f.value, None)
+    s.tick(2.seconds)
+    assertEquals(f.value, Some(Failure(ex)))
+  }
+
+  test("Task.wanderUnordered should be canceled") { implicit s =>
+    val seq = Seq((1, 2), (2, 1), (3, 3))
+    val f = Task.wanderUnordered(seq) {
+      case (i, d) => Task(i + 1).delayExecution(d.seconds)
+    }.runAsync
+
+    s.tick()
+    assertEquals(f.value, None)
+    s.tick(2.seconds)
+    assertEquals(f.value, None)
+
+    f.cancel()
+    s.tick(1.second)
+    assertEquals(f.value, None)
+  }
+
+  test("Task.wanderUnordered should run over an iterator") { implicit s =>
+    val count = 10
+    val seq = 0 until count
+    val sum = Task.wanderUnordered(seq.iterator)(x => Task.eval(x + 1)).map(_.sum)
+
+    val result = sum.runAsync; s.tick()
+    assertEquals(result.value.get, Success((count + 1) * count / 2))
+  }
+
+  test("Task.wanderUnordered should be stack-safe on handling many tasks") { implicit s =>
+    val count = 10000
+    val seq = for (i <- 0 until count) yield i
+    val sum = Task.wanderUnordered(seq)(x => Task.eval(x)).map(_.sum)
+
+    val result = sum.runAsync; s.tick()
+    assertEquals(result.value.get, Success(count * (count - 1) / 2))
+  }
+
+  test("Task.wanderUnordered should be stack safe on success") { implicit s =>
+    def fold[A](ta: Task[ListBuffer[A]], next: A): Task[ListBuffer[A]] =
+      ta flatMap { acc =>
+        Task.wanderUnordered(Seq(acc, next)) { v =>
+          Task.eval(v)
+        }
+      } map {
+        case a :: b :: Nil =>
+          val (accR, valueR) = if (a.isInstanceOf[ListBuffer[_]]) (a, b) else (b, a)
+          val acc = accR.asInstanceOf[ListBuffer[A]]
+          val value = valueR.asInstanceOf[A]
+          acc += value
+        case _ =>
+          throw new RuntimeException("Oops!")
+      }
+
+    def wanderSpecial[A](in: Seq[A]): Task[List[A]] = {
+      val init = Task.eval(ListBuffer.empty[A])
+      val r = in.foldLeft(init)(fold)
+      r.map(_.result())
+    }
+
+    val count = if (Platform.isJVM) 100000 else 10000
+    val tasks = 0 until count
+    var result = Option.empty[Try[Int]]
+
+    wanderSpecial(tasks).map(_.sum).runAsync(
+      new Callback[Int] {
+        def onSuccess(value: Int): Unit =
+          result = Some(Success(value))
+
+        def onError(ex: Throwable): Unit =
+          result = Some(Failure(ex))
+      })
+
+    s.tick()
+    assertEquals(result, Some(Success(count * (count - 1) / 2)))
+  }
+
+  test("Task.wanderUnordered should log errors if multiple errors happen") { implicit s =>
+    val ex = DummyException("dummy1")
+    var errorsThrow = 0
+    val gather = Task.wanderUnordered(Seq(0, 0)) { _ =>
+      Task.fork(Task.raiseError[Int](ex))
+        .doOnFinish { x => if (x.isDefined) errorsThrow += 1; Task.unit }
+    }
+    val result = gather.runAsync
+    s.tick()
+
+    assertEquals(result.value, Some(Failure(ex)))
+    assertEquals(s.state.lastReportedError, ex)
+    assertEquals(errorsThrow, 2)
+  }
+
+  test("Task.wanderUnordered runAsync multiple times") { implicit s =>
+    var effect = 0
+    val task1 = Task {
+      effect += 1; 3
+    }.memoize
+    val task2 = task1 map { x => effect += 1; x + 1 }
+
+    val task3 = Task.wanderUnordered(List(0, 0, 0)) { _ =>
+      task2
+    }
+
+    val result1 = task3.runAsync; s.tick()
+    assertEquals(result1.value, Some(Success(List(4, 4, 4))))
+    assertEquals(effect, 1 + 3)
+
+    val result2 = task3.runAsync; s.tick()
+    assertEquals(result2.value, Some(Success(List(4, 4, 4))))
+    assertEquals(effect, 1 + 3 + 3)
+  }
+}

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskWanderUnorderedSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskWanderUnorderedSuite.scala
@@ -160,4 +160,15 @@ object TaskWanderUnorderedSuite extends BaseTestSuite {
     assertEquals(result2.value, Some(Success(List(4, 4, 4))))
     assertEquals(effect, 1 + 3 + 3)
   }
+
+  test("Task.wanderUnordered should wrap exceptions in the function") { implicit s =>
+    val ex = DummyException("dummy")
+    val task1 = Task.wanderUnordered(Seq(0)) { _ =>
+      throw ex
+    }
+
+    val result1 = task1.runAsync; s.tick()
+    assertEquals(result1.value, Some(Failure(ex)))
+  }
+
 }


### PR DESCRIPTION
This should satisfy Issue #249.

I ended up modifying the backing implementation of `TaskGather` to requiring multiple CanBuildFroms for gatherUnordered.

I added a first pass at the Scaladoc, based heavily on the Scaladoc for gather(unordered).

Let me know if there's any questions/comments/concerns.

-Matt