### PR TITLE
MVar, a non-blocking Task-based implementation

### DIFF
--- a/monix-eval/shared/src/main/scala/monix/eval/MVar.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/MVar.scala
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval
+
+import monix.execution.atomic.PaddingStrategy
+import monix.execution.misc.AsyncVar
+
+/** A mutable location, that is either empty or contains
+  * a value of type `A`.
+  *
+  * It has 2 fundamental atomic operations:
+  *
+  *  - [[put]] which fills the var if empty, or blocks
+  *    (asynchronously) until the var is empty again
+  *  - [[take]] which empties the var if full, returning the contained
+  *    value, or blocks (asynchronously) otherwise until there is
+  *    a value to pull
+  *
+  * The `MVar` is appropriate for building synchronization
+  * primitives and performing simple inter-thread communications.
+  * If it helps, it's similar with a `BlockingQueue(capacity = 1)`,
+  * except that it doesn't block any threads, all waiting being
+  * done asynchronously by means of [[Task]].
+  *
+  * Given its asynchronous, non-blocking nature, it can be used on
+  * top of Javascript as well.
+  *
+  * Inspired by `Control.Concurrent.MVar` from Haskell and
+  * by `scalaz.concurrent.MVar`.
+  */
+abstract class MVar[A] {
+  /** Fills the `MVar` if it is empty, or blocks (asynchronously)
+    * if the `MVar` is full, until the given value is next in
+    * line to be consumed on [[take]].
+    *
+    * This operation is atomic.
+    **
+    * @return a task that on evaluation will complete when the
+    *         `put` operation succeeds in filling the `MVar`,
+    *         with the given value being next in line to
+    *         be consumed
+    */
+  def put(a: A): Task[Unit]
+
+  /** Empties the `MVar` if full, returning the contained value,
+    * or blocks (asynchronously) until a value is available.
+    *
+    * This operation is atomic.
+    *
+    * @return a task that on evaluation will be completed after
+    *         a value was retrieved
+    */
+  def take: Task[A]
+
+  /** Tries reading the current value, or blocks (asynchronously)
+    * until there is a value available, at which point the operation
+    * resorts to a [[take]] followed by a [[put]].
+    *
+    * This `read` operation is equivalent to:
+    * {{{
+    *   for (a <- v.read; _ <- v.put(a)) yield a
+    * }}}
+    *
+    * This operation is not atomic. Being equivalent with a `take`
+    * followed by a `put`, in order to ensure that no race conditions
+    * happen, additional synchronization is necessary.
+    * See [[TaskSemaphore]] for a possible solution.
+    *
+    * @return a task that on evaluation will be completed after
+    *         a value has been read
+    */
+  def read: Task[A]
+}
+
+object MVar {
+  /** Builds an [[MVar]] instance with an `initial` value. */
+  def apply[A](initial: A): MVar[A] =
+    new AsyncMVarImpl[A](AsyncVar(initial))
+
+  /** Returns an empty [[MVar]] instance. */
+  def empty[A]: MVar[A] =
+    new AsyncMVarImpl[A](AsyncVar.empty)
+
+  /** Builds an [[MVar]] instance with an `initial`  value and a given
+    * [[PaddingStrategy]] (for avoiding the false sharing problem).
+    */
+  def withPadding[A](initial: A, ps: PaddingStrategy): MVar[A] =
+    new AsyncMVarImpl[A](AsyncVar.withPadding(initial, ps))
+
+  /** Builds an empty [[MVar]] instance with a given [[PaddingStrategy]]
+    * (for avoiding the false sharing problem).
+    */
+  def withPadding[A](ps: PaddingStrategy): MVar[A] =
+    new AsyncMVarImpl[A](AsyncVar.withPadding(ps))
+
+  /** [[MVar]] implementation based on
+    * [[monix.execution.misc.AsyncVar]]
+    */
+  private final class AsyncMVarImpl[A](av: AsyncVar[A]) extends MVar[A] {
+    def put(a: A): Task[Unit] =
+      Task.unsafeCreate { (context, callback) =>
+        // Execution could be synchronous
+        if (av.unsafePut(a, callback))
+          callback.onSuccess(())
+      }
+
+    def take: Task[A] =
+      Task.unsafeCreate { (context, callback) =>
+        // Execution could be synchronous (e.g. result is null or not)
+        av.unsafeTake(callback) match {
+          case null => () // do nothing
+          case a => callback.onSuccess(a)
+        }
+      }
+
+    def read: Task[A] =
+      Task.unsafeCreate { (context, callback) =>
+        // Execution could be synchronous (e.g. result is null or not)
+        av.unsafeRead(callback) match {
+          case null => () // do nothing
+          case a => callback.onSuccess(a)
+        }
+      }
+  }
+}

--- a/monix-eval/shared/src/test/scala/monix/eval/MVarSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/MVarSuite.scala
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval
+
+import monix.execution.atomic.PaddingStrategy.LeftRight128
+import scala.util.Success
+
+object MVarSuite extends BaseTestSuite {
+  test("empty; put; take; put; take") { implicit s =>
+    val av = MVar.empty[Int]
+
+    val task = for {
+      _ <- av.put(10)
+      r1 <- av.take
+      _ <- av.put(20)
+      r2 <- av.take
+    } yield List(r1,r2)
+
+    assertEquals(task.runSyncMaybe, Right(List(10,20)))
+  }
+
+  test("empty; take; put; take; put") { implicit s =>
+    val av = MVar.empty[Int]
+
+    val task = for {
+      r1 <- Task.mapBoth(av.take, av.put(10))((r,u) => r)
+      r2 <- Task.mapBoth(av.take, av.put(20))((r,u) => r)
+    } yield List(r1,r2)
+
+    assertEquals(task.runSyncMaybe, Right(List(10,20)))
+  }
+
+  test("empty; put; put; put; take; take; take") { implicit s =>
+    val av = MVar.empty[Int]
+
+    val take3 = Task.zip3(av.take, av.take, av.take)
+    val put3 = Task.zip3(av.put(10), av.put(20), av.put(30))
+
+    val task =
+      Task.mapBoth(put3,take3) { case (_, (r1,r2,r3)) => List(r1,r2,r3) }
+
+    val f = task.runAsync; s.tick()
+    assertEquals(f.value, Some(Success(List(10,20,30))))
+  }
+
+  test("empty; take; take; take; put; put; put") { implicit s =>
+    val av = MVar.empty[Int]
+
+    val take3 = Task.zip3(av.take, av.take, av.take)
+    val put3 = Task.zip3(av.put(10), av.put(20), av.put(30))
+
+    val task =
+      Task.mapBoth(take3, put3) { case ((r1,r2,r3), _) => List(r1,r2,r3) }
+
+    val f = task.runAsync; s.tick()
+    assertEquals(f.value, Some(Success(List(10,20,30))))
+  }
+
+  test("initial; take; put; take") { implicit s =>
+    val av = MVar(10)
+    val task = for {
+      r1 <- av.take
+      _ <- av.put(20)
+      r2 <- av.take
+    } yield List(r1,r2)
+
+    assertEquals(task.runSyncMaybe, Right(List(10,20)))
+  }
+
+  test("withPadding; put; take; put; take") { implicit s =>
+    val av = MVar.withPadding[Int](LeftRight128)
+    val task = for {
+      _ <- av.put(10)
+      r1 <- av.take
+      _ <- av.put(20)
+      r2 <- av.take
+    } yield List(r1,r2)
+
+    assertEquals(task.runSyncMaybe, Right(List(10,20)))
+  }
+
+  test("withPadding(initial); put; take; put; take") { implicit s =>
+    val av = MVar.withPadding[Int](10, LeftRight128)
+    val task = for {
+      r1 <- av.take
+      _ <- av.put(20)
+      r2 <- av.take
+    } yield List(r1,r2)
+
+    assertEquals(task.runSyncMaybe, Right(List(10,20)))
+  }
+
+  test("initial; read; take") { implicit s =>
+    val av = MVar(10)
+    val task = for {
+      read <- av.read
+      take <- av.take
+    } yield read + take
+
+    assertEquals(task.runSyncMaybe, Right(20))
+  }
+
+  test("empty; read; put") { implicit s =>
+    val av = MVar.empty[Int]
+    val task = Task.mapBoth(av.read, av.put(10))((r,_) => r)
+    assertEquals(task.runSyncMaybe, Right(10))
+  }
+
+  test("put(null) throws NullPointerException") { implicit s =>
+    val av = MVar.empty[String]
+    val task = av.put(null)
+
+    intercept[NullPointerException] {
+      task.runSyncMaybe
+    }
+  }
+}

--- a/monix-execution/shared/src/main/scala/monix/execution/Listener.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/Listener.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.execution
+
+import scala.concurrent.Promise
+
+/** A simple listener interface, to be used in observer pattern
+  * implementations or for specifying asynchronous callbacks.
+  *
+  * This interface does not provide any usage contract or
+  * assumptions on how the `onValue(a)` function gets called.
+  *
+  * It's a replacement for `Function1[A,Unit]` but it does
+  * not inherit from it, precisely because we want to attach
+  * `Listener` semantics to types that cannot be `Function1[A,Unit]`.
+  *
+  * In particular `monix.eval.Callback` is a supertype of
+  * `Listener`, even though `Callback` is a `Try[T] => Unit`.
+  */
+trait Listener[-A] extends Serializable {
+  def onValue(value: A): Unit
+}
+
+object Listener {
+  /** Builds a [[Listener]] from a `Function1`. */
+  def apply[A,U](f: A => U): Listener[A] =
+    new Listener[A] { def onValue(value: A) = f(value) }
+
+  /** Builds a [[Listener]] from a `Function0`. */
+  def unit(f: () => Unit): Listener[Unit] =
+    new Listener[Unit] { def onValue(value: Unit) = f() }
+
+  /** Converts a Scala `Promise` to a [[Listener]]. */
+  def fromPromise[A](p: Promise[A]): Listener[A] =
+    new Listener[A] { def onValue(value: A) = p.success(value) }
+}

--- a/monix-execution/shared/src/main/scala/monix/execution/misc/AsyncVar.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/misc/AsyncVar.scala
@@ -1,0 +1,330 @@
+/*
+ * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.execution.misc
+
+import monix.execution.Listener
+import monix.execution.atomic.PaddingStrategy.NoPadding
+import monix.execution.atomic.{AtomicAny, PaddingStrategy}
+
+import scala.annotation.tailrec
+import scala.collection.immutable.Queue
+import scala.concurrent.{Future, Promise}
+
+/** Asynchronous mutable location, that is either empty or contains
+  * a value of type `A`.
+  *
+  * It has 2 fundamental atomic operations:
+  *
+  *  - [[put]] which fills the var if empty, or blocks
+  *    (asynchronously) otherwise until the var is empty again
+  *
+  *  - [[take]] which empties the var if full, returning the contained
+  *    value, or blocks (asynchronously) otherwise until there is
+  *    a value to pull
+  *
+  * The `AsyncVar` is appropriate for building synchronization
+  * primitives and performing simple inter-thread communications.
+  * If it helps, it's similar with a `BlockingQueue(capacity = 1)`,
+  * except that it doesn't block any threads, all waiting being
+  * callback-based.
+  *
+  * Given its asynchronous, non-blocking nature, it can be used on
+  * top of Javascript as well.
+  *
+  * Inspired by `Control.Concurrent.MVar` from Haskell.
+  */
+final class AsyncVar[A] private (_ref: AtomicAny[AsyncVar.State[A]]) {
+  import AsyncVar._
+  private[this] val stateRef: AtomicAny[State[A]] = _ref
+
+  private def this(ps: PaddingStrategy) =
+    this(AtomicAny.withPadding(AsyncVar.State.empty[A], ps))
+  private def this(initial: A, ps: PaddingStrategy) =
+    this(AtomicAny.withPadding(AsyncVar.State(initial), ps))
+
+  /** Fills the `AsyncVar` if it is empty, or blocks (asynchronously)
+    * if the `AsyncVar` is full, until the given value is next in
+    * line to be consumed on [[take]].
+    *
+    * This operation is atomic.
+    *
+    * @see [[unsafePut]] for the raw, unsafe version that can work
+    *     with plain callbacks.
+    *
+    * @return a future that will complete when the `put` operation
+    *         succeeds in filling the `AsyncVar`, with the given
+    *         value being next in line to be consumed
+    */
+  def put(a: A): Future[Unit] = {
+    val p = Promise[Unit]()
+    if (unsafePut(a, Listener.fromPromise(p))) Future.successful(())
+    else p.future
+  }
+
+  /** Fills the `AsyncVar` if it is empty, or blocks (asynchronously)
+    * if the `AsyncVar` is full, until the given value is next in
+    * line to be consumed on [[take]] (or [[unsafeTake]]).
+    *
+    * This operation is atomic.
+    *
+    * @see [[put]] for the safe future-enabled version.
+    *
+    * @param a is the value to store
+    * @param await is a callback that, only in case of asynchronous blocking,
+    *        will get called when the blocking is over and the operation
+    *        succeeded
+    *
+    * @return `true` if the operation succeeded already, with no
+    *        blocking necessary, or `false` if the operation
+    *        is blocked because the var is already full
+    */
+  @tailrec def unsafePut(a: A, await: Listener[Unit]): Boolean = {
+    if (a == null) throw new NullPointerException("null not supported in AsyncVar/MVar")
+    val current: State[A] = stateRef.get
+
+    current match {
+      case _: Empty[_] =>
+        if (stateRef.compareAndSet(current, WaitForTake(a, Queue.empty))) true
+        else unsafePut(a, await) // retry
+
+      case WaitForTake(value, queue) =>
+        val update = WaitForTake(value, queue.enqueue(a -> await))
+        if (stateRef.compareAndSet(current, update)) false
+        else unsafePut(a, await) // retry
+
+      case current @ WaitForPut(first, queue) =>
+        if (stateRef.compareAndSet(current, current.dequeue)) { first.onValue(a); true }
+        else unsafePut(a, await) // retry
+    }
+  }
+
+  /** Empties the var if full, returning the contained value,
+    * or blocks (asynchronously) until a value is available.
+    *
+    * This operation is atomic.
+    *
+    * @see [[unsafeTake]] for the raw, unsafe version that can work
+    *     with plain callbacks.
+    */
+  def take: Future[A] = {
+    val p = Promise[A]()
+    unsafeTake(Listener.fromPromise(p)) match {
+      case null => p.future
+      case a => Future.successful(a)
+    }
+  }
+
+  /** Empties the var if full, returning the contained value,
+    * or blocks (asynchronously) until a value is available.
+    *
+    * This operation is atomic.
+    *
+    * @see [[take]] for the safe future-enabled version.
+    *
+    * @param await is a callback that, only in case of asynchronous blocking,
+    *        will get called sometime in the future with a value
+    *
+    * @return a value of type `A` if the operation succeeded already,
+    *         with no blocking necessary, or `null` if async blocking
+    *         is in progress (in which case the `await` callback
+    *         gets called with the result)
+    */
+  @tailrec def unsafeTake(await: Listener[A]): A = {
+    @inline def nil = null.asInstanceOf[A]
+
+    val current: State[A] = stateRef.get
+    current match {
+      case _: Empty[_] =>
+        if (stateRef.compareAndSet(current, WaitForPut(await, Queue.empty))) nil
+        else unsafeTake(await) // retry
+
+      case WaitForTake(value, queue) =>
+        if (queue.isEmpty) {
+          if (stateRef.compareAndSet(current, State.empty)) value
+          else unsafeTake(await)
+        }
+        else {
+          val ((ax, notify), xs) = queue.dequeue
+          if (stateRef.compareAndSet(current, WaitForTake(ax, xs))) {
+            notify.onValue(()) // notification
+            value
+          } else {
+            unsafeTake(await) // retry
+          }
+        }
+
+      case WaitForPut(first, queue) =>
+        if (stateRef.compareAndSet(current, WaitForPut(first, queue.enqueue(await)))) nil
+        else unsafeTake(await)
+    }
+  }
+
+  /** Tries reading the current value, or blocks (asynchronously)
+    * otherwise, until there is a value available, at which point
+    * the operation resorts to a `take` followed by a `put`.
+    *
+    * This `read` operation is equivalent to:
+    * {{{
+    *   for (a <- v.read; _ <- v.put(a)) yield a
+    * }}}
+    *
+    * This operation is not atomic. Being equivalent with a `take`
+    * followed by a `put`, in order to ensure that no race conditions
+    * happen, additional synchronization is necessary.
+    * See [[AsyncSemaphore]] for a possible solution.
+    *
+    * @see [[unsafeRead]] for the raw, unsafe version that can work
+    *     with plain callbacks.
+    *
+    * @return a future that might already be completed in case the
+    *         result is available immediately
+    */
+  def read: Future[A] = {
+    val p = Promise[A]()
+    unsafeRead(Listener.fromPromise(p)) match {
+      case null => p.future
+      case a => Future.successful(a)
+    }
+  }
+
+  /** Tries reading the current value, or blocks (asynchronously)
+    * otherwise, until there is a value available, at which point
+    * the operation resorts to a `take` followed by a `put`.
+    *
+    * This `read` operation is equivalent to:
+    * {{{
+    *   for (a <- v.read; _ <- v.put(a)) yield a
+    * }}}
+    *
+    * This operation is not atomic. Being equivalent with a `take`
+    * followed by a `put`, in order to ensure that no race conditions
+    * happen, additional synchronization is necessary.
+    * See [[AsyncSemaphore]] for a possible solution.
+    *
+    * @see [[read]] for the safe future-enabled version.
+    *
+    * @param await is a callback that, only in case of asynchronous blocking,
+    *        will get called sometime in the future with a value
+    *
+    * @return a value of type `A` if the operation succeeded already,
+    *         with no blocking necessary, or `null` if async blocking
+    *         is in progress (in which case the `await` callback
+    *         gets called with the result)
+    */
+  def unsafeRead(await: Listener[A]): A = {
+    // To be used with unsafePut
+    def awaitPut(a: A): Listener[Unit] = new Listener[Unit] {
+      def onValue(value: Unit): Unit =
+        await.onValue(a)
+    }
+    // To be used with unsafeTake
+    def awaitTake: Listener[A] = new Listener[A] {
+      def onValue(value: A): Unit = {
+        // Execution could be synchronous
+        if (unsafePut(value, awaitPut(value)))
+          await.onValue(value)
+      }
+    }
+
+    (stateRef.get : State[A]) match {
+      case WaitForTake(value, _) => value // Fast-path
+      case _ =>
+        // Doing the equivalent of:
+        // for (a <- take; _ <- put(a)) yield a
+        unsafeTake(awaitTake) match {
+          case null =>
+            // Async execution
+            null.asInstanceOf[A]
+          case value =>
+            if (unsafePut(value, awaitPut(value))) value
+            else null.asInstanceOf[A] // Async execution
+        }
+    }
+  }
+}
+
+object AsyncVar {
+  /** Builds an [[AsyncVar]] instance with an `initial` value. */
+  def apply[A](initial: A): AsyncVar[A] =
+    new AsyncVar[A](initial, NoPadding)
+
+  /** Returns an empty [[AsyncVar]] instance. */
+  def empty[A]: AsyncVar[A] =
+    new AsyncVar[A](NoPadding)
+
+  /** Builds an [[AsyncVar]] instance with an `initial`
+    * value and a given [[PaddingStrategy]] (for avoiding the
+    * false sharing problem).
+    */
+  def withPadding[A](initial: A, ps: PaddingStrategy): AsyncVar[A] =
+    new AsyncVar[A](initial, ps)
+
+  /** Builds an empty [[AsyncVar]] instance with a given
+    * [[PaddingStrategy]] (for avoiding the false sharing problem).
+    */
+  def withPadding[A](ps: PaddingStrategy): AsyncVar[A] =
+    new AsyncVar[A](ps)
+
+  /** ADT modelling the internal state of [[AsyncVar]]. */
+  private sealed trait State[A]
+
+  /** Private [[State]] builders.*/
+  private object State {
+    private[this] val ref = Empty()
+    def apply[A](a: A): State[A] = WaitForTake(a, Queue.empty)
+    /** `Empty` state, reusing the same instance. */
+    def empty[A]: State[A] = ref.asInstanceOf[State[A]]
+  }
+
+  /** `AsyncVar` state signaling an empty location.
+    *
+    * Evolves into [[WaitForPut]] or [[WaitForTake]],
+    * depending on which operation happens first.
+    */
+  private final case class Empty[A]() extends State[A]
+
+  /** `AsyncVar` state signaling it has `take` callbacks
+    * registered and we are waiting for one or multiple
+    * `put` operations.
+    *
+    * @param first is the first request waiting in line
+    * @param queue are the rest of the requests waiting in line,
+    *        if more than one `take` requests were registered
+    */
+  private final case class WaitForPut[A](first: Listener[A], queue: Queue[Listener[A]])
+    extends State[A] {
+
+    def dequeue: State[A] =
+      if (queue.isEmpty) State.empty[A] else {
+        val (x, xs) = queue.dequeue
+        WaitForPut(x, xs)
+      }
+  }
+
+  /** `AsyncVar` state signaling it has one or more values enqueued,
+    * to be signaled on the next `take`.
+    *
+    * @param value is the first value to signal
+    * @param queue are the rest of the `put` requests, along with the
+    *        callbacks that need to be called whenever the corresponding
+    *        value is first in line (i.e. when the corresponding `put`
+    *        is unblocked from the user's point of view)
+    */
+  private final case class WaitForTake[A](value: A, queue: Queue[(A, Listener[Unit])])
+    extends State[A]
+}

--- a/monix-execution/shared/src/test/scala/monix/execution/misc/AsyncVarSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/misc/AsyncVarSuite.scala
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.execution.misc
+
+import minitest.SimpleTestSuite
+import monix.execution.atomic.PaddingStrategy.LeftRight128
+import scala.util.Success
+
+object AsyncVarSuite extends SimpleTestSuite {
+  test("empty; put; take; put; take") {
+    val av = AsyncVar.empty[Int]
+
+    val r1 = av.put(10)
+    assertEquals(r1.value, Some(Success(())))
+    val r2 = av.take
+    assertEquals(r2.value, Some(Success(10)))
+
+    val r3 = av.put(20)
+    assertEquals(r3.value, Some(Success(())))
+    val r4 = av.take
+    assertEquals(r4.value, Some(Success(20)))
+  }
+
+  test("empty; take; put; take; put") {
+    val av = AsyncVar.empty[Int]
+
+    val take1 = av.take
+    assertEquals(take1.value, None)
+    val put1 = av.put(10)
+    assertEquals(put1.value, Some(Success(())))
+    assertEquals(take1.value, Some(Success(10)))
+
+    val take2 = av.take
+    assertEquals(take2.value, None)
+    val put2 = av.put(20)
+    assertEquals(put2.value, Some(Success(())))
+    assertEquals(take2.value, Some(Success(20)))
+  }
+
+  test("empty; put; put; put; take; take; take") {
+    val av = AsyncVar.empty[Int]
+
+    val put1 = av.put(10)
+    assertEquals(put1.value, Some(Success(())))
+    val put2 = av.put(20)
+    assertEquals(put2.value, None)
+    val put3 = av.put(30)
+    assertEquals(put3.value, None)
+
+    val take1 = av.take
+    assertEquals(take1.value, Some(Success(10)))
+    assertEquals(put2.value, Some(Success(())))
+    assertEquals(put3.value, None)
+
+    val take2 = av.take
+    assertEquals(take2.value, Some(Success(20)))
+    assertEquals(put3.value, Some(Success(())))
+
+    val take3 = av.take
+    assertEquals(take3.value, Some(Success(30)))
+  }
+
+  test("empty; take; take; take; put; put; put") {
+    val av = AsyncVar.empty[Int]
+
+    val take1 = av.take
+    assertEquals(take1.value, None)
+    val take2 = av.take
+    assertEquals(take2.value, None)
+    val take3 = av.take
+    assertEquals(take3.value, None)
+
+    val put1 = av.put(10)
+    assertEquals(put1.value, Some(Success(())))
+    assertEquals(take1.value, Some(Success(10)))
+
+    val put2 = av.put(20)
+    assertEquals(put2.value, Some(Success(())))
+    assertEquals(take2.value, Some(Success(20)))
+
+    val put3 = av.put(30)
+    assertEquals(put3.value, Some(Success(())))
+    assertEquals(take3.value, Some(Success(30)))
+  }
+
+  test("initial; take; take; put") {
+    val av = AsyncVar(10)
+
+    val take1 = av.take
+    assertEquals(take1.value, Some(Success(10)))
+    val take2 = av.take
+    assertEquals(take2.value, None)
+
+    val put1 = av.put(20)
+    assertEquals(put1.value, Some(Success(())))
+    assertEquals(take2.value, Some(Success(20)))
+  }
+
+  test("empty; read; put; take") {
+    val av = AsyncVar.empty[Int]
+
+    val read1 = av.read
+    assertEquals(read1.value, None)
+
+    val put1 = av.put(10)
+    assertEquals(put1.value, Some(Success(())))
+    assertEquals(read1.value, Some(Success(10)))
+
+    val take1 = av.take
+    assertEquals(take1.value, Some(Success(10)))
+  }
+
+  test("empty; put; read; take") {
+    val av = AsyncVar.empty[Int]
+
+    val put1 = av.put(10)
+    assertEquals(put1.value, Some(Success(())))
+
+    val read1 = av.read
+    assertEquals(read1.value, Some(Success(10)))
+
+    val take1 = av.take
+    assertEquals(take1.value, Some(Success(10)))
+  }
+
+  test("initial; read; take") {
+    val av = AsyncVar(10)
+
+    val read1 = av.read
+    assertEquals(read1.value, Some(Success(10)))
+
+    val take1 = av.take
+    assertEquals(take1.value, Some(Success(10)))
+  }
+
+  test("withPadding; put; take; put; take") {
+    val av = AsyncVar.withPadding[Int](LeftRight128)
+
+    val r1 = av.put(10)
+    assertEquals(r1.value, Some(Success(())))
+    val r2 = av.take
+    assertEquals(r2.value, Some(Success(10)))
+
+    val r3 = av.put(20)
+    assertEquals(r3.value, Some(Success(())))
+    val r4 = av.take
+    assertEquals(r4.value, Some(Success(20)))
+  }
+
+  test("withPadding(initial); put; take; put; take") {
+    val av = AsyncVar.withPadding[Int](10, LeftRight128)
+
+    val r2 = av.take
+    assertEquals(r2.value, Some(Success(10)))
+    val r3 = av.put(20)
+    assertEquals(r3.value, Some(Success(())))
+    val r4 = av.take
+    assertEquals(r4.value, Some(Success(20)))
+  }
+  
+  test("put(null) throws NullPointerException") {
+    val av = AsyncVar.empty[String]
+    intercept[NullPointerException] {
+      av.put(null)
+    }
+  }
+}


### PR DESCRIPTION
Inspired by `Control.Concurrent.MVar` from Haskell and by `scalaz.concurrent.MVar`.

An `MVar` is mutable location, that is either empty or contains a value of type `A` with these operations:

```scala
abstract class MVar[A] {
  def put(a: A): Task[Unit]
  def take: Task[A]
  def read: Task[A]
}
```

The `put` and `take` operations are atomic and their behavior is similar to usage of a `BlockingQueue(capacity = 1)`. Or in other words `take` blocks (asynchronously, with no threads getting abused) until there is a value available and `put` blocks (asynchronously) until the var is empty.

The `read` operation is provided for convenience and is equivalent with:
```scala
for (a <- v.take; _ <- v.put(a)) yield a
```
It's not atomic, so in case atomicity is needed, it can be combined with extra synchronization primitives, like `TaskSemaphore`.

Given its non-blocking nature, this implementation is cross-compiled and works on top of Javascript.

Work in progress: must add tests !!!