### PR TITLE
2.3 refactorings and deprecations

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,26 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: no
+    patch: no
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "header, diff"
+  behavior: default
+  require_changes: no

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,27 @@ dist: trusty
 
 matrix:
   include:
+    # Scala 2.10
     - jdk: oraclejdk8
       scala: 2.10.6
-      env: COMMAND=ci COVERAGE=
+      env: COMMAND=ci-jvm COVERAGE=
+    - jdk: oraclejdk8
+      scala: 2.10.6
+      env: COMMAND=ci-js COVERAGE=
+    # Scala 2.11
     - jdk: oraclejdk8
       scala: 2.11.11
-      env: COMMAND=ci COVERAGE=coverage
+      env: COMMAND=ci-jvm COVERAGE=coverage
+    - jdk: oraclejdk8
+      scala: 2.11.11
+      env: COMMAND=ci-js COVERAGE=
+    # Scala 2.12
     - jdk: oraclejdk8
       scala: 2.12.2
-      env: COMMAND=ci-all COVERAGE=
+      env: COMMAND=ci-jvm-all COVERAGE=
+    - jdk: oraclejdk8
+      scala: 2.12.2
+      env: COMMAND=ci-js COVERAGE=
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ matrix:
   include:
     - jdk: oraclejdk8
       scala: 2.10.6
-      env: COVERAGE=
+      env: COMMAND=ci COVERAGE=
     - jdk: oraclejdk8
       scala: 2.11.11
-      env: COVERAGE=coverage
+      env: COMMAND=ci COVERAGE=coverage
     - jdk: oraclejdk8
       scala: 2.12.2
-      env: COVERAGE=
+      env: COMMAND=ci-all COVERAGE=
 
 env:
   global:
@@ -24,7 +24,7 @@ install:
 
 script:
   - export SBT_PROFILE=$COVERAGE
-  - sbt -J-Xmx6144m ++$TRAVIS_SCALA_VERSION $COVERAGE ci
+  - sbt -J-Xmx6144m ++$TRAVIS_SCALA_VERSION $COVERAGE $COMMAND
 
 after_success:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
 
 script:
   - export SBT_PROFILE=$COVERAGE
-  - sbt -J-Xmx6144m ++$TRAVIS_SCALA_VERSION $COVERAGE $COMMAND
+  - travis_wait 20 sbt -J-Xmx6144m ++$TRAVIS_SCALA_VERSION $COVERAGE $COMMAND
 
 after_success:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
 
 script:
   - export SBT_PROFILE=$COVERAGE
-  - travis_wait 20 sbt -J-Xmx6144m ++$TRAVIS_SCALA_VERSION $COVERAGE $COMMAND
+  - travis_wait 30 sbt -J-Xmx6144m ++$TRAVIS_SCALA_VERSION $COVERAGE $COMMAND
 
 after_success:
   - |

--- a/build.sbt
+++ b/build.sbt
@@ -5,9 +5,9 @@ import com.typesafe.tools.mima.core._
 import scala.xml.Elem
 import scala.xml.transform.{RewriteRule, RuleTransformer}
 
-addCommandAlias("ci-all", ";clean ;test:compile ;coreJVM/test; coreJS/test ;mimaReportBinaryIssues ;unidoc")
-
-addCommandAlias("ci", ";clean ;test:compile ;coreJVM/test ;coreJS/test")
+addCommandAlias("ci-jvm-all", ";clean ;coreJVM/test:compile ;coreJVM/test ;mimaReportBinaryIssues ;unidoc")
+addCommandAlias("ci-jvm",     ";clean ;coreJVM/test:compile ;coreJVM/test")
+addCommandAlias("ci-js",      ";clean ;coreJS/test:compile  ;coreJS/test")
 
 val catsVersion = "0.9.0"
 val scalazVersion = "7.2.11"

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ import scala.xml.transform.{RewriteRule, RuleTransformer}
 
 addCommandAlias("ci-all", ";clean ;test:compile ;coreJVM/test; coreJS/test ;mimaReportBinaryIssues ;unidoc")
 
-addCommandAlias("ci", ";clean ;test:compile ;coreJVM/test; coreJS/test ;doc")
+addCommandAlias("ci", ";clean ;test:compile ;coreJVM/test ;coreJS/test")
 
 val catsVersion = "0.9.0"
 val scalazVersion = "7.2.11"

--- a/build.sbt
+++ b/build.sbt
@@ -130,11 +130,13 @@ lazy val sharedSettings = warnUnusedImport ++ Seq(
     "-sourcepath", file(".").getAbsolutePath.replaceAll("[.]$", "")
   ),
 
-  parallelExecution in Test := false,
-  parallelExecution in IntegrationTest := false,
-  testForkedParallel in Test := false,
-  testForkedParallel in IntegrationTest := false,
-  concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
+  // Not working !!!
+  //
+  // parallelExecution in Test := false,
+  // parallelExecution in IntegrationTest := false,
+  // testForkedParallel in Test := false,
+  // testForkedParallel in IntegrationTest := false,
+  // concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
 
   resolvers ++= Seq(
     "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases",
@@ -288,7 +290,7 @@ def profile: Project ⇒ Project = pr => cmdlineProfile match {
 lazy val monix = project.in(file("."))
   .enablePlugins(ScalaUnidocPlugin)
   .configure(profile)
-  .aggregate(coreJVM, coreJS, tckTests)
+  .aggregate(coreJVM, coreJS)
   .settings(sharedSettings)
   .settings(doNotPublishArtifact)
   .settings(unidocSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -5,9 +5,9 @@ import com.typesafe.tools.mima.core._
 import scala.xml.Elem
 import scala.xml.transform.{RewriteRule, RuleTransformer}
 
-addCommandAlias("ci-all", ";clean ;test:compile ;test ;mimaReportBinaryIssues ;unidoc")
+addCommandAlias("ci-all", ";clean ;test:compile ;coreJVM/test; coreJS/test ;mimaReportBinaryIssues ;unidoc")
 
-addCommandAlias("ci", ";clean ;test:compile ;test ;doc")
+addCommandAlias("ci", ";clean ;test:compile ;coreJVM/test; coreJS/test ;doc")
 
 val catsVersion = "0.9.0"
 val scalazVersion = "7.2.11"
@@ -130,13 +130,11 @@ lazy val sharedSettings = warnUnusedImport ++ Seq(
     "-sourcepath", file(".").getAbsolutePath.replaceAll("[.]$", "")
   ),
 
-  // Not working !!!
-  //
-  // parallelExecution in Test := false,
-  // parallelExecution in IntegrationTest := false,
-  // testForkedParallel in Test := false,
-  // testForkedParallel in IntegrationTest := false,
-  // concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
+  parallelExecution in Test := false,
+  parallelExecution in IntegrationTest := false,
+  testForkedParallel in Test := false,
+  testForkedParallel in IntegrationTest := false,
+  concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
 
   resolvers ++= Seq(
     "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases",

--- a/build.sbt
+++ b/build.sbt
@@ -6,9 +6,9 @@ import com.typesafe.tools.mima.core.ProblemFilters._
 import scala.xml.Elem
 import scala.xml.transform.{RewriteRule, RuleTransformer}
 
-addCommandAlias("ci-all", ";test:compile ;test ;mimaReportBinaryIssues ;unidoc")
+addCommandAlias("ci-all", ";clean ;test:compile ;test ;mimaReportBinaryIssues ;unidoc")
 
-addCommandAlias("ci", ";test:compile ;test ;doc")
+addCommandAlias("ci", ";clean ;test:compile ;test ;doc")
 
 val catsVersion = "0.9.0"
 val scalazVersion = "7.2.11"

--- a/build.sbt
+++ b/build.sbt
@@ -276,7 +276,7 @@ lazy val cmdlineProfile =
   sys.env.getOrElse("SBT_PROFILE", "")
 
 def mimaSettings(projectName: String) = Seq(
-  // mimaPreviousArtifacts := Set("io.monix" %% projectName % monixSeries)
+   // mimaPreviousArtifacts := Set("io.monix" %% projectName % monixSeries)
 )
 
 def profile: Project ⇒ Project = pr => cmdlineProfile match {
@@ -352,11 +352,8 @@ lazy val executionJS = project.in(file("monix-execution/js"))
 lazy val evalCommon =
   crossSettings ++ testSettings ++ Seq(
     name := "monix-eval",
-    // Filtering out private stuff for 2.2.x
-    mimaBinaryIssueFilters ++= Seq(
-      // Related to issue: https://github.com/monix/monix/issues/313
-      exclude[DirectMissingMethodProblem]("monix.eval.internal.TaskFromFuture.apply")
-    )
+    // Filtering out private stuff for 2.3.x
+    mimaBinaryIssueFilters ++= Seq.empty
   )
 
 lazy val evalJVM = project.in(file("monix-eval/jvm"))
@@ -377,21 +374,8 @@ lazy val evalJS = project.in(file("monix-eval/js"))
 lazy val reactiveCommon =
   crossSettings ++ testSettings ++ Seq(
     name := "monix-reactive",
-    // Filtering out private stuff for 2.2.x
-    mimaBinaryIssueFilters ++= Seq(
-      // Related to issue: https://github.com/monix/monix/issues/321
-      // All these types are private, so in fact we cannot break binary compatibility,
-      // unless accessed by reflection, for which Monix can't make a guarantee
-      exclude[MissingTypesProblem]("monix.reactive.internal.operators.ConcatMapObservable$FlatMapState$WaitComplete$"),
-      exclude[DirectMissingMethodProblem]("monix.reactive.internal.operators.ConcatMapObservable#FlatMapState#WaitComplete.apply"),
-      exclude[DirectMissingMethodProblem]("monix.reactive.internal.operators.ConcatMapObservable#FlatMapState#WaitComplete.copy"),
-      exclude[DirectMissingMethodProblem]("monix.reactive.internal.operators.ConcatMapObservable#FlatMapState#WaitComplete.this"),
-      exclude[MissingTypesProblem]("monix.reactive.internal.operators.MapTaskObservable$FlatMapState$WaitComplete$"),
-      exclude[DirectMissingMethodProblem]("monix.reactive.internal.operators.MapTaskObservable#FlatMapState#WaitComplete.apply"),
-      exclude[DirectMissingMethodProblem]("monix.reactive.internal.operators.MapTaskObservable#FlatMapState#WaitComplete.copy"),
-      exclude[DirectMissingMethodProblem]("monix.reactive.internal.operators.MapTaskObservable#FlatMapState#WaitComplete.this"),
-      exclude[MissingClassProblem]("monix.reactive.internal.operators.MapAsyncParallelObservable$MapAsyncParallelSubscriber")
-    )
+    // Filtering out private stuff for 2.3.x
+    mimaBinaryIssueFilters ++= Seq.empty
   )
 
 lazy val reactiveJVM = project.in(file("monix-reactive/jvm"))

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,5 @@
 import com.typesafe.sbt.pgp.PgpKeys
 import com.typesafe.tools.mima.core._
-import com.typesafe.tools.mima.core.ProblemFilters._
 
 // For getting Scoverage out of the generated POM
 import scala.xml.Elem

--- a/monix-cats/shared/src/test/scala/monix/cats/tests/BaseLawsSuite.scala
+++ b/monix-cats/shared/src/test/scala/monix/cats/tests/BaseLawsSuite.scala
@@ -167,7 +167,7 @@ trait BaseLawsSuiteInstances1 extends cats.instances.AllInstances with MonixToCa
       val eqA = implicitly[Eq[Try[A]]]
 
       def eqv(x: Coeval[A], y: Coeval[A]): Boolean =
-        eqA.eqv(x.runAttempt.asScala, y.runAttempt.asScala)
+        eqA.eqv(x.runTry, y.runTry)
     }
 
   implicit def equalityTask[A : Eq]: Eq[Task[A]] =

--- a/monix-eval/shared/src/main/scala/monix/eval/Coeval.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Coeval.scala
@@ -76,9 +76,8 @@ sealed abstract class Coeval[+A] extends (() => A) with Serializable { self =>
   def value: A = apply()
 
   /** Evaluates the underlying computation and returns the result or any
-    * triggered errors as a Scala [[scala.Either Either]], where
-    * `Right(_)` is for successful values and `Left(_)` is for thrown
-    * errors.
+    * triggered errors as a Scala `Either`, where `Right(_)` is for successful
+    * values and `Left(_)` is for thrown errors.
     */
   def run: Either[Throwable, A] =
     CoevalRunLoop.start(this) match {

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/Transformation.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/Transformation.scala
@@ -17,7 +17,14 @@
 
 package monix.eval.internal
 
-private[eval] abstract class Transformation[-A, +R] extends (A => R) { self =>
+/** A mapping function type that is also able to handle errors.
+  *
+  * Used in the `Task` and `Coeval` implementations to specify
+  * error handlers in their respective `FlatMap` internal states.
+  */
+private[eval] abstract class Transformation[-A, +R]
+  extends (A => R) { self =>
+
   final override def apply(a: A): R =
     success(a)
 
@@ -34,7 +41,8 @@ private[eval] abstract class Transformation[-A, +R] extends (A => R) { self =>
 }
 
 private[eval] object Transformation {
-  def fold[A, R](fa: A => R, fe: Throwable => R): Transformation[A, R] =
+  /** Builds a [[Transformation]] instance. */
+  def apply[A, R](fa: A => R, fe: Throwable => R): Transformation[A, R] =
     new Fold(fa, fe)
 
   private final class Fold[A, R](fa: A => R, fe: Throwable => R)

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalErrorSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalErrorSuite.scala
@@ -18,21 +18,19 @@
 package monix.eval
 
 import monix.execution.exceptions.DummyException
-
 import scala.concurrent.TimeoutException
 import scala.util.{Failure, Success}
 
 object CoevalErrorSuite extends BaseTestSuite {
-  test("Coeval.failed should expose error") { implicit s =>
+  test("Coeval.attempt should expose error") { implicit s =>
     val dummy = DummyException("ex")
-    val r = Coeval.raiseError[Int](dummy).failed.runTry
-    assertEquals(r, Success(dummy))
+    val r = Coeval.raiseError[Int](dummy).attempt.value
+    assertEquals(r, Left(dummy))
   }
 
-  test("Coeval.failed should end in error on success") { implicit s =>
-    intercept[NoSuchElementException] {
-      Coeval.now(10).failed.value
-    }
+  test("Coeval.attempt should expose successful value") { implicit s =>
+    val r = Coeval.now(10).attempt.value
+    assertEquals(r, Right(10))
   }
 
   test("Coeval.now.materialize") { implicit s =>
@@ -99,26 +97,15 @@ object CoevalErrorSuite extends BaseTestSuite {
     assertEquals(result, Failure(dummy))
   }
 
-  test("Coeval.now.dematerializeAttempt") { implicit s =>
-    val result = Coeval.now(10).materializeAttempt.dematerializeAttempt.runTry
-    assertEquals(result, Success(10))
-  }
-
-  test("Coeval.error.dematerializeAttempt") { implicit s =>
-    val dummy = DummyException("dummy")
-    val result = Coeval.raiseError[Int](dummy).materializeAttempt.dematerializeAttempt.runTry
-    assertEquals(result, Failure(dummy))
-  }
-
   test("Coeval#onErrorRecover should mirror source on success") { implicit s =>
-    val coeval = Coeval(1).onErrorRecover { case ex: Throwable => 99 }
+    val coeval = Coeval(1).onErrorRecover { case _: Throwable => 99 }
     assertEquals(coeval.runTry, Success(1))
   }
 
   test("Coeval#onErrorRecover should recover") { implicit s =>
     val ex = DummyException("dummy")
     val coeval = Coeval[Int](if (1 == 1) throw ex else 1).onErrorRecover {
-      case ex: DummyException => 99
+      case _: DummyException => 99
     }
 
     assertEquals(coeval.runTry, Success(99))
@@ -129,21 +116,20 @@ object CoevalErrorSuite extends BaseTestSuite {
     val ex2 = DummyException("two")
 
     val coeval = Coeval[Int](if (1 == 1) throw ex1 else 1)
-      .onErrorRecover { case ex => throw ex2 }
+      .onErrorRecover { case _ => throw ex2 }
 
     assertEquals(coeval.runTry, Failure(ex2))
   }
 
   test("Coeval#onErrorHandle should mirror source on success") { implicit s =>
-    val f = Coeval(1).onErrorHandle { case ex: Throwable => 99 }
+    val f = Coeval(1).onErrorHandle { _: Throwable => 99 }
     assertEquals(f.runTry, Success(1))
   }
 
   test("Coeval#onErrorHandle should recover") { implicit s =>
     val ex = DummyException("dummy")
-    val f = Coeval[Int](if (1 == 1) throw ex else 1).onErrorHandle {
-      case ex: DummyException => 99
-    }
+    val f = Coeval[Int](if (1 == 1) throw ex else 1)
+      .onErrorHandle { case _: DummyException => 99 }
 
     assertEquals(f.runTry, Success(99))
   }
@@ -152,7 +138,7 @@ object CoevalErrorSuite extends BaseTestSuite {
     val ex1 = DummyException("one")
     val ex2 = DummyException("two")
     val f = Coeval[Int](if (1 == 1) throw ex1 else 1)
-      .onErrorHandle { case ex => throw ex2 }
+      .onErrorHandle { _ => throw ex2 }
 
     assertEquals(f.runTry, Failure(ex2))
   }
@@ -202,7 +188,7 @@ object CoevalErrorSuite extends BaseTestSuite {
 
   test("Coeval.onErrorRestartIf should mirror the source onSuccess") { implicit s =>
     var tries = 0
-    val f = Coeval.eval { tries += 1; 1 }.onErrorRestartIf(ex => tries < 10)
+    val f = Coeval.eval { tries += 1; 1 }.onErrorRestartIf(_ => tries < 10)
     assertEquals(f.runTry, Success(1))
     assertEquals(tries, 1)
   }
@@ -211,7 +197,7 @@ object CoevalErrorSuite extends BaseTestSuite {
     val ex = DummyException("dummy")
     var tries = 0
     val f = Coeval.eval { tries += 1; if (tries < 5) throw ex else 1 }
-      .onErrorRestartIf(ex => tries <= 10)
+      .onErrorRestartIf(_ => tries <= 10)
 
     assertEquals(f.runTry, Success(1))
     assertEquals(tries, 5)
@@ -221,21 +207,21 @@ object CoevalErrorSuite extends BaseTestSuite {
     val ex = DummyException("dummy")
     var tries = 0
     val f = Coeval.eval { tries += 1; throw ex }
-      .onErrorRestartIf(ex => tries <= 10)
+      .onErrorRestartIf(_ => tries <= 10)
 
     assertEquals(f.runTry, Failure(ex))
     assertEquals(tries, 11)
   }
 
   test("Coeval#onErrorRecoverWith should mirror source on success") { implicit s =>
-    val f = Coeval(1).onErrorRecoverWith { case ex: Throwable => Coeval(99) }
+    val f = Coeval(1).onErrorRecoverWith { case _: Throwable => Coeval(99) }
     assertEquals(f.runTry, Success(1))
   }
 
   test("Coeval#onErrorRecoverWith should recover") { implicit s =>
     val ex = DummyException("dummy")
     val f = Coeval[Int](throw ex).onErrorRecoverWith {
-      case ex: DummyException => Coeval(99)
+      case _: DummyException => Coeval(99)
     }
 
     assertEquals(f.runTry, Success(99))
@@ -246,7 +232,7 @@ object CoevalErrorSuite extends BaseTestSuite {
     val ex2 = DummyException("two")
 
     val f = Coeval[Int](throw ex1)
-      .onErrorRecoverWith { case ex => throw ex2 }
+      .onErrorRecoverWith { case _ => throw ex2 }
 
     assertEquals(f.runTry, Failure(ex2))
   }

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalErrorSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalErrorSuite.scala
@@ -33,6 +33,18 @@ object CoevalErrorSuite extends BaseTestSuite {
     assertEquals(r, Right(10))
   }
 
+  test("Coeval.fail should expose error") { implicit s =>
+    val dummy = DummyException("dummy")
+    val r = Coeval.raiseError[Int](dummy).failed.value
+    assertEquals(r, dummy)
+  }
+
+  test("Coeval.fail should fail for successful values") { implicit s =>
+    intercept[NoSuchElementException] {
+      Coeval.now(10).failed.value
+    }
+  }
+
   test("Coeval.now.materialize") { implicit s =>
     assertEquals(Coeval.now(10).materialize.value, Success(10))
   }

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalEvalAlwaysSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalEvalAlwaysSuite.scala
@@ -17,9 +17,7 @@
 
 package monix.eval
 
-import monix.eval.Coeval.{Error, Now}
 import monix.execution.exceptions.DummyException
-
 import scala.util.{Failure, Success}
 
 object CoevalEvalAlwaysSuite extends BaseTestSuite {
@@ -63,7 +61,7 @@ object CoevalEvalAlwaysSuite extends BaseTestSuite {
 
   test("Coeval.eval.flatMap should be tail recursive") { implicit s =>
     def loop(n: Int, idx: Int): Coeval[Int] =
-      Coeval.eval(idx).flatMap { a =>
+      Coeval.eval(idx).flatMap { _ =>
         if (idx < n) loop(n, idx + 1).map(_ + 1) else
           Coeval.eval(idx)
       }
@@ -86,17 +84,17 @@ object CoevalEvalAlwaysSuite extends BaseTestSuite {
     assertEquals(effect, 1)
   }
 
-  test("Coeval.eval.materializeAttempt should work for success") { implicit s =>
-    val task = Coeval.eval(1).materializeAttempt
+  test("Coeval.eval.materialize should work for success") { implicit s =>
+    val task = Coeval.eval(1).materialize
     val f = task.runTry
-    assertEquals(f, Success(Now(1)))
+    assertEquals(f, Success(Success(1)))
   }
 
-  test("Coeval.eval.materializeAttempt should work for failure") { implicit s =>
+  test("Coeval.eval.materialize should work for failure") { implicit s =>
     val dummy = DummyException("dummy")
-    val task = Coeval.eval[Int](throw dummy).materializeAttempt
+    val task = Coeval.eval[Int](throw dummy).materialize
     val f = task.runTry
-    assertEquals(f, Success(Error(dummy)))
+    assertEquals(f, Success(Failure(dummy)))
   }
 
   test("Coeval.eval.task") { implicit s =>

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalEvalOnceSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalEvalOnceSuite.scala
@@ -17,9 +17,7 @@
 
 package monix.eval
 
-import monix.eval.Coeval.{Error, Now}
 import monix.execution.exceptions.DummyException
-
 import scala.util.{Failure, Success}
 
 object CoevalEvalOnceSuite extends BaseTestSuite {
@@ -63,7 +61,7 @@ object CoevalEvalOnceSuite extends BaseTestSuite {
 
   test("Coeval.evalOnce.flatMap should be tail recursive") { implicit s =>
     def loop(n: Int, idx: Int): Coeval[Int] =
-      Coeval.evalOnce(idx).flatMap { a =>
+      Coeval.evalOnce(idx).flatMap { _ =>
         if (idx < n) loop(n, idx + 1).map(_ + 1) else
           Coeval.evalOnce(idx)
       }
@@ -86,17 +84,17 @@ object CoevalEvalOnceSuite extends BaseTestSuite {
     assertEquals(effect, 1)
   }
 
-  test("Coeval.evalOnce.materializeAttempt should work for success") { implicit s =>
-    val task = Coeval.evalOnce(1).materializeAttempt
+  test("Coeval.evalOnce.materialize should work for success") { implicit s =>
+    val task = Coeval.evalOnce(1).materialize
     val f = task.runTry
-    assertEquals(f, Success(Now(1)))
+    assertEquals(f, Success(Success(1)))
   }
 
-  test("Coeval.evalOnce.materializeAttempt should work for failure") { implicit s =>
+  test("Coeval.evalOnce.materialize should work for failure") { implicit s =>
     val dummy = DummyException("dummy")
-    val task = Coeval.evalOnce[Int](throw dummy).materializeAttempt
+    val task = Coeval.evalOnce[Int](throw dummy).materialize
     val f = task.runTry
-    assertEquals(f, Success(Error(dummy)))
+    assertEquals(f, Success(Failure(dummy)))
   }
 
   test("Coeval.evalOnce.task") { implicit s =>

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalMiscSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalMiscSuite.scala
@@ -18,21 +18,18 @@
 package monix.eval
 
 import monix.execution.exceptions.DummyException
-
 import scala.util.{Failure, Random, Success}
 
 object CoevalMiscSuite extends BaseTestSuite {
-  test("Coeval.now.failed should end in error") { implicit s =>
-    val result = Coeval.now(1).failed.runTry
-    assert(result.isFailure &&
-      result.failed.get.isInstanceOf[NoSuchElementException],
-      "Should throw NoSuchElementException")
+  test("Coeval.now.attempt should succeed") { implicit s =>
+    val result = Coeval.now(1).attempt.value
+    assertEquals(result, Right(1))
   }
 
-  test("Coeval.raiseError.failed should expose error") { implicit s =>
+  test("Coeval.raiseError.attempt should expose error") { implicit s =>
     val ex = DummyException("dummy")
-    val result = Coeval.raiseError[Int](ex).failed.runTry
-    assertEquals(result, Success(ex))
+    val result = Coeval.raiseError[Int](ex).attempt.value
+    assertEquals(result, Left(ex))
   }
 
   test("Coeval.map protects against user code") { implicit s =>
@@ -41,14 +38,14 @@ object CoevalMiscSuite extends BaseTestSuite {
     assertEquals(result, Failure(ex))
   }
 
-  test("Coeval.now.dematerializeAttempt") { implicit s =>
-    val result = Coeval.now(1).materializeAttempt.dematerializeAttempt.runTry
+  test("Coeval.now.dematerialize") { implicit s =>
+    val result = Coeval.now(1).materialize.dematerialize.runTry
     assertEquals(result, Success(1))
   }
 
-  test("Coeval.raiseError.dematerializeAttempt") { implicit s =>
+  test("Coeval.raiseError.dematerialize") { implicit s =>
     val ex = DummyException("dummy")
-    val result = Coeval.raiseError[Int](ex).materializeAttempt.dematerializeAttempt.runTry
+    val result = Coeval.raiseError[Int](ex).materialize.dematerialize.runTry
     assertEquals(result, Failure(ex))
   }
 

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalMiscSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalMiscSuite.scala
@@ -32,6 +32,20 @@ object CoevalMiscSuite extends BaseTestSuite {
     assertEquals(result, Left(ex))
   }
 
+  test("Coeval.fail should expose error") { implicit s =>
+    val dummy = DummyException("dummy")
+    check1 { (fa: Coeval[Int]) =>
+      val r = fa.map(_ => throw dummy).failed.value
+      r == dummy
+    }
+  }
+
+  test("Coeval.fail should fail for successful values") { implicit s =>
+    intercept[NoSuchElementException] {
+      Coeval.eval(10).failed.value
+    }
+  }
+
   test("Coeval.map protects against user code") { implicit s =>
     val ex = DummyException("dummy")
     val result = Coeval.now(1).map(_ => throw ex).runTry

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalNowSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalNowSuite.scala
@@ -17,9 +17,7 @@
 
 package monix.eval
 
-import monix.eval.Coeval.{Error, Now}
 import monix.execution.exceptions.DummyException
-
 import scala.util.{Failure, Success}
 
 object CoevalNowSuite extends BaseTestSuite {
@@ -35,7 +33,7 @@ object CoevalNowSuite extends BaseTestSuite {
 
   test("Coeval.now.isSuccess") { implicit s =>
     assert(Coeval.Now(1).isSuccess, "isSuccess")
-    assert(!Coeval.Now(1).isFailure, "!isFailure")
+    assert(!Coeval.Now(1).isError, "!isFailure")
   }
 
   test("Coeval.error should work synchronously") { implicit s =>
@@ -86,7 +84,7 @@ object CoevalNowSuite extends BaseTestSuite {
 
   test("Coeval.now.flatMap should be tail recursive") { implicit s =>
     def loop(n: Int, idx: Int): Coeval[Int] =
-      Coeval.now(idx).flatMap { a =>
+      Coeval.now(idx).flatMap { _ =>
         if (idx < n) loop(n, idx + 1).map(_ + 1) else
           Coeval.now(idx)
       }
@@ -101,20 +99,10 @@ object CoevalNowSuite extends BaseTestSuite {
     assertEquals(task.value, Success(1))
   }
 
-  test("Coeval.now.materializeAttempt should work") { implicit s =>
-    val task = Coeval.now(1).materializeAttempt
-    assertEquals(task.value, Now(1))
-  }
 
   test("Coeval.error.materialize should work") { implicit s =>
     val dummy = DummyException("dummy")
     val task = Coeval.raiseError(dummy).materialize
     assertEquals(task.value, Failure(dummy))
-  }
-
-  test("Coeval.error.materializeAttempt should work") { implicit s =>
-    val dummy = DummyException("dummy")
-    val task = Coeval.raiseError(dummy).materializeAttempt
-    assertEquals(task.value, Error(dummy))
   }
 }

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskErrorSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskErrorSuite.scala
@@ -17,25 +17,22 @@
 
 package monix.eval
 
-import monix.eval.Coeval.{Error, Now}
 import monix.execution.exceptions.DummyException
 import monix.execution.internal.Platform
-
 import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
 object TaskErrorSuite extends BaseTestSuite {
-  test("Task.failed should expose error") { implicit s =>
+  test("Task.attempt should expose error") { implicit s =>
     val dummy = DummyException("ex")
-    val r = Task.raiseError[Int](dummy).failed.coeval.runTry
-    assertEquals(r, Success(Right(dummy)))
+    val r = Task.raiseError[Int](dummy).attempt.coeval.runTry
+    assertEquals(r, Success(Right(Left(dummy))))
   }
 
-  test("Task.failed should end in error on success") { implicit s =>
-    intercept[NoSuchElementException] {
-      Task.now(10).failed.coeval.value
-    }
+  test("Task.attempt should work for successful values") { implicit s =>
+    val r = Task.now(10).attempt.coeval.runTry
+    assertEquals(r, Success(Right(Right(10))))
   }
 
   test("Task.now.materialize") { implicit s =>
@@ -55,7 +52,7 @@ object TaskErrorSuite extends BaseTestSuite {
     def loop(n: Int): Task[Int] =
       if (n <= 0) Task.evalOnce(n)
       else Task.evalOnce(n).materialize.flatMap {
-        case Success(v) => loop(n-1)
+        case Success(_) => loop(n-1)
         case Failure(ex) => Task.raiseError(ex)
       }
 
@@ -134,19 +131,8 @@ object TaskErrorSuite extends BaseTestSuite {
     assertEquals(result, Some(Failure(dummy)))
   }
 
-  test("Task.now.dematerializeAttempt") { implicit s =>
-    val result = Task.now(10).materializeAttempt.dematerializeAttempt.runAsync.value
-    assertEquals(result, Some(Success(10)))
-  }
-
-  test("Task.error.dematerializeAttempt") { implicit s =>
-    val dummy = DummyException("dummy")
-    val result = Task.raiseError[Int](dummy).materializeAttempt.dematerializeAttempt.runAsync.value
-    assertEquals(result, Some(Failure(dummy)))
-  }
-
   test("Task#onErrorRecover should mirror source on success") { implicit s =>
-    val task = Task(1).onErrorRecover { case ex: Throwable => 99 }
+    val task = Task(1).onErrorRecover { case _: Throwable => 99 }
     val f = task.runAsync
     s.tick()
     assertEquals(f.value, Some(Success(1)))
@@ -155,7 +141,7 @@ object TaskErrorSuite extends BaseTestSuite {
   test("Task#onErrorRecover should recover") { implicit s =>
     val ex = DummyException("dummy")
     val task = Task[Int](if (1 == 1) throw ex else 1).onErrorRecover {
-      case ex: DummyException => 99
+      case _: DummyException => 99
     }
 
     val f = task.runAsync
@@ -168,14 +154,14 @@ object TaskErrorSuite extends BaseTestSuite {
     val ex2 = DummyException("two")
 
     val task = Task[Int](if (1 == 1) throw ex1 else 1)
-      .onErrorRecover { case ex => throw ex2 }
+      .onErrorRecover { case _ => throw ex2 }
 
     val f = task.runAsync; s.tick()
     assertEquals(f.value, Some(Failure(ex2)))
   }
 
   test("Task#onErrorHandle should mirror source on success") { implicit s =>
-    val task = Task(1).onErrorHandle { ex: Throwable => 99 }
+    val task = Task(1).onErrorHandle { _: Throwable => 99 }
     val f = task.runAsync
     s.tick()
     assertEquals(f.value, Some(Success(1)))
@@ -295,7 +281,7 @@ object TaskErrorSuite extends BaseTestSuite {
     val ex = DummyException("dummy")
     var tries = 0
     val task = Task.eval { tries += 1; if (tries < 5) throw ex else 1 }
-      .onErrorRestartIf(ex => tries <= 10)
+      .onErrorRestartIf(_ => tries <= 10)
 
     val f = task.runAsync
     assertEquals(f.value, Some(Success(1)))
@@ -306,7 +292,7 @@ object TaskErrorSuite extends BaseTestSuite {
     val ex = DummyException("dummy")
     var tries = 0
     val task = Task.eval { tries += 1; throw ex }
-      .onErrorRestartIf(ex => tries <= 10)
+      .onErrorRestartIf(_ => tries <= 10)
 
     val f = task.runAsync
     assertEquals(f.value, Some(Failure(ex)))
@@ -314,7 +300,7 @@ object TaskErrorSuite extends BaseTestSuite {
   }
 
   test("Task.onErrorRestartIf should be cancelable if ExecutionModel permits") { implicit s =>
-    val task = Task[Int](throw DummyException("dummy")).onErrorRestartIf(ex => true)
+    val task = Task[Int](throw DummyException("dummy")).onErrorRestartIf(_ => true)
     val f = task.executeWithOptions(_.enableAutoCancelableRunLoops).runAsync
     assertEquals(f.value, None)
 
@@ -324,7 +310,7 @@ object TaskErrorSuite extends BaseTestSuite {
   }
 
   test("Task#onErrorRecoverWith should mirror source on success") { implicit s =>
-    val task = Task(1).onErrorRecoverWith { case ex: Throwable => Task(99) }
+    val task = Task(1).onErrorRecoverWith { case _: Throwable => Task(99) }
     val f = task.runAsync
     s.tick()
     assertEquals(f.value, Some(Success(1)))
@@ -333,7 +319,7 @@ object TaskErrorSuite extends BaseTestSuite {
   test("Task#onErrorRecoverWith should recover") { implicit s =>
     val ex = DummyException("dummy")
     val task = Task[Int](throw ex).onErrorRecoverWith {
-      case ex: DummyException => Task(99)
+      case _: DummyException => Task(99)
     }
 
     val f = task.runAsync
@@ -346,7 +332,7 @@ object TaskErrorSuite extends BaseTestSuite {
     val ex2 = DummyException("two")
 
     val task = Task[Int](throw ex1)
-      .onErrorRecoverWith { case ex => throw ex2 }
+      .onErrorRecoverWith { case _ => throw ex2 }
 
     val f = task.runAsync; s.tick()
     assertEquals(f.value, Some(Failure(ex2)))
@@ -397,27 +383,27 @@ object TaskErrorSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(10)))
   }
 
-  test("Task.apply.materializeAttempt should work for success") { implicit s =>
-    val task = Task.apply(1).materializeAttempt
+  test("Task.apply.materialize should work for success") { implicit s =>
+    val task = Task.apply(1).materialize
     val f = task.runAsync
     s.tick()
-    assertEquals(f.value, Some(Success(Now(1))))
+    assertEquals(f.value, Some(Success(Success(1))))
   }
 
-  test("Task.apply.materializeAttempt should work for failure") { implicit s =>
+  test("Task.apply.materialize should work for failure") { implicit s =>
     val dummy = DummyException("dummy")
-    val task = Task.apply[Int] { throw dummy }.materializeAttempt
+    val task = Task.apply[Int] { throw dummy }.materialize
     val f = task.runAsync
     s.tick()
-    assertEquals(f.value, Some(Success(Error(dummy))))
+    assertEquals(f.value, Some(Success(Failure(dummy))))
   }
 
   test("Task.apply.materialize should be stack safe") { implicit s =>
     def loop(n: Int): Task[Int] =
       if (n <= 0) Task.apply(n)
       else Task.apply(n).materialize.flatMap {
-        case Success(v) => loop(n-1)
-        case Failure(ex) => Task.raiseError(ex)
+        case Success(_) => loop(n-1)
+        case Failure(e) => Task.raiseError(e)
       }
 
     val count = if (Platform.isJVM) 50000 else 5000
@@ -426,25 +412,25 @@ object TaskErrorSuite extends BaseTestSuite {
     assertEquals(result.value, Some(Success(0)))
   }
 
-  test("Task.eval.materializeAttempt should work for success") { implicit s =>
-    val task = Task.eval(1).materializeAttempt
+  test("Task.eval.materialize should work for success") { implicit s =>
+    val task = Task.eval(1).materialize
     val f = task.runAsync
-    assertEquals(f.value, Some(Success(Now(1))))
+    assertEquals(f.value, Some(Success(Success(1))))
   }
 
-  test("Task.eval.materializeAttempt should work for failure") { implicit s =>
+  test("Task.eval.materialize should work for failure") { implicit s =>
     val dummy = DummyException("dummy")
-    val task = Task.eval[Int](throw dummy).materializeAttempt
+    val task = Task.eval[Int](throw dummy).materialize
     val f = task.runAsync
-    assertEquals(f.value, Some(Success(Error(dummy))))
+    assertEquals(f.value, Some(Success(Failure(dummy))))
   }
 
   test("Task.eval.materialize should be stack safe") { implicit s =>
     def loop(n: Int): Task[Int] =
       if (n <= 0) Task.eval(n)
       else Task.eval(n).materialize.flatMap {
-        case Success(v) => loop(n-1)
-        case Failure(ex) => Task.raiseError(ex)
+        case Success(_) => loop(n-1)
+        case Failure(e) => Task.raiseError(e)
       }
 
     val count = if (Platform.isJVM) 50000 else 5000
@@ -452,24 +438,24 @@ object TaskErrorSuite extends BaseTestSuite {
     assertEquals(result.value, Some(Success(0)))
   }
 
-  test("Task.now.materializeAttempt should work") { implicit s =>
-    val task = Task.now(1).materializeAttempt
+  test("Task.now.materialize should work") { implicit s =>
+    val task = Task.now(1).materialize
     val f = task.runAsync
-    assertEquals(f.value, Some(Success(Now(1))))
+    assertEquals(f.value, Some(Success(Success(1))))
   }
 
-  test("Task.error.materializeAttempt should work") { implicit s =>
+  test("Task.error.materialize should work") { implicit s =>
     val dummy = DummyException("dummy")
-    val task = Task.raiseError(dummy).materializeAttempt
+    val task = Task.raiseError(dummy).materialize
     val f = task.runAsync
-    assertEquals(f.value, Some(Success(Error(dummy))))
+    assertEquals(f.value, Some(Success(Failure(dummy))))
   }
 
-  test("Task.materializeAttempt on failing flatMap") { implicit s =>
+  test("Task.materialize on failing flatMap") { implicit s =>
     val ex = DummyException("dummy")
-    val task = Task.now(1).flatMap { x => (throw ex) : Task[Int] }
-    val materialized = task.materializeAttempt.runAsync
-    assertEquals(materialized.value, Some(Success(Error(ex))))
+    val task = Task.now(1).flatMap { _ => (throw ex) : Task[Int] }
+    val materialized = task.materialize.runAsync
+    assertEquals(materialized.value, Some(Success(Failure(ex))))
   }
 
   test("Task.now.materialize should be stack safe") { implicit s =>
@@ -485,14 +471,9 @@ object TaskErrorSuite extends BaseTestSuite {
     assertEquals(result.value, Some(Success(0)))
   }
 
-  test("Task.now.dematerializeAttempt") { implicit s =>
-    val result = Task.now(1).materializeAttempt.dematerializeAttempt.runAsync
-    assertEquals(result.value, Some(Success(1)))
-  }
-
-  test("Task.raiseError.dematerializeAttempt") { implicit s =>
+  test("Task.raiseError.dematerialize") { implicit s =>
     val ex = DummyException("dummy")
-    val result = Task.raiseError[Int](ex).materializeAttempt.dematerializeAttempt.runAsync
+    val result = Task.raiseError[Int](ex).materialize.dematerialize.runAsync
     assertEquals(result.value, Some(Failure(ex)))
   }
 

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskErrorSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskErrorSuite.scala
@@ -25,7 +25,7 @@ import scala.util.{Failure, Success}
 
 object TaskErrorSuite extends BaseTestSuite {
   test("Task.attempt should expose error") { implicit s =>
-    val dummy = DummyException("ex")
+    val dummy = DummyException("dummy")
     val r = Task.raiseError[Int](dummy).attempt.coeval.runTry
     assertEquals(r, Success(Right(Left(dummy))))
   }
@@ -33,6 +33,18 @@ object TaskErrorSuite extends BaseTestSuite {
   test("Task.attempt should work for successful values") { implicit s =>
     val r = Task.now(10).attempt.coeval.runTry
     assertEquals(r, Success(Right(Right(10))))
+  }
+
+  test("Task.fail should expose error") { implicit s =>
+    val dummy = DummyException("dummy")
+    val r = Task.raiseError[Int](dummy).failed.coeval.value
+    assertEquals(r, Right(dummy))
+  }
+
+  test("Task.fail should fail for successful values") { implicit s =>
+    intercept[NoSuchElementException] {
+      Task.now(10).failed.coeval.value
+    }
   }
 
   test("Task.now.materialize") { implicit s =>

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskEvalOnceSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskEvalOnceSuite.scala
@@ -17,10 +17,7 @@
 
 package monix.eval
 
-
-import monix.eval.Coeval.{Error, Now}
 import monix.execution.exceptions.DummyException
-
 import scala.util.{Failure, Success}
 
 object TaskEvalOnceSuite extends BaseTestSuite {
@@ -64,7 +61,7 @@ object TaskEvalOnceSuite extends BaseTestSuite {
 
   test("Task.evalOnce.flatMap should be tail recursive") { implicit s =>
     def loop(n: Int, idx: Int): Task[Int] =
-      Task.evalOnce(idx).flatMap { a =>
+      Task.evalOnce(idx).flatMap { _ =>
         if (idx < n) loop(n, idx + 1).map(_ + 1) else
           Task.evalOnce(idx)
       }
@@ -95,16 +92,16 @@ object TaskEvalOnceSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Failure(dummy)))
   }
 
-  test("Task.evalOnce.materializeAttempt should work for success") { implicit s =>
-    val task = Task.evalOnce(1).materializeAttempt
+  test("Task.evalOnce.materialize should work for success") { implicit s =>
+    val task = Task.evalOnce(1).materialize
     val f = task.runAsync
-    assertEquals(f.value, Some(Success(Now(1))))
+    assertEquals(f.value, Some(Success(Success(1))))
   }
 
-  test("Task.evalOnce.materializeAttempt should work for failure") { implicit s =>
+  test("Task.evalOnce.materialize should work for failure") { implicit s =>
     val dummy = DummyException("dummy")
-    val task = Task.evalOnce[Int](throw dummy).materializeAttempt
+    val task = Task.evalOnce[Int](throw dummy).materialize
     val f = task.runAsync
-    assertEquals(f.value, Some(Success(Error(dummy))))
+    assertEquals(f.value, Some(Success(Failure(dummy))))
   }
 }

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskMiscSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskMiscSuite.scala
@@ -19,7 +19,6 @@ package monix.eval
 
 import monix.execution.exceptions.DummyException
 import org.reactivestreams.{Subscriber, Subscription}
-
 import scala.concurrent.Promise
 import scala.util.{Failure, Success}
 
@@ -33,6 +32,20 @@ object TaskMiscSuite extends BaseTestSuite {
     val ex = DummyException("dummy")
     val result = Task.raiseError[Int](ex).attempt.runAsync
     assertEquals(result.value, Some(Success(Left(ex))))
+  }
+
+  test("Task.fail should expose error") { implicit s =>
+    val dummy = DummyException("dummy")
+    check1 { (fa: Task[Int]) =>
+      val r = fa.map(_ => throw dummy).failed.coeval.value
+      r == Right(dummy)
+    }
+  }
+
+  test("Task.fail should fail for successful values") { implicit s =>
+    intercept[NoSuchElementException] {
+      Task.eval(10).failed.coeval.value
+    }
   }
 
   test("Task.map protects against user code") { implicit s =>

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskMiscSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskMiscSuite.scala
@@ -24,17 +24,15 @@ import scala.concurrent.Promise
 import scala.util.{Failure, Success}
 
 object TaskMiscSuite extends BaseTestSuite {
-  test("Task.failed should end in error") { implicit s =>
-    val result = Task.now(1).failed.runAsync
-    assert(result.value.isDefined && result.value.get.isFailure &&
-      result.value.get.failed.get.isInstanceOf[NoSuchElementException],
-      "Should throw NoSuchElementException")
+  test("Task.attempt should succeed") { implicit s =>
+    val result = Task.now(1).attempt.runAsync
+    assertEquals(result.value, Some(Success(Right(1))))
   }
 
-  test("Task.raiseError.failed should expose error") { implicit s =>
+  test("Task.raiseError.attempt should expose error") { implicit s =>
     val ex = DummyException("dummy")
-    val result = Task.raiseError[Int](ex).failed.runAsync
-    assertEquals(result.value, Some(Success(ex)))
+    val result = Task.raiseError[Int](ex).attempt.runAsync
+    assertEquals(result.value, Some(Success(Left(ex))))
   }
 
   test("Task.map protects against user code") { implicit s =>

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/AsyncSchedulerSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/AsyncSchedulerSuite.scala
@@ -108,7 +108,7 @@ object AsyncSchedulerSuite extends SimpleTestSuite {
       def run(): Unit = latch.countDown()
     })
 
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await")
   }
 
   test("execute local") {

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/AsyncSchedulerSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/AsyncSchedulerSuite.scala
@@ -108,7 +108,7 @@ object AsyncSchedulerSuite extends SimpleTestSuite {
       def run(): Unit = latch.countDown()
     })
 
-    assert(latch.await(2, TimeUnit.MINUTES), "latch.await")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await")
   }
 
   test("execute local") {

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/ExecutorSchedulerSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/ExecutorSchedulerSuite.scala
@@ -152,7 +152,7 @@ abstract class ExecutorSchedulerSuite extends TestSuite[SchedulerService] { self
           throw ex
       })
 
-      assert(latch.await(30, TimeUnit.SECONDS), "lastReportedFailureLatch.await")
+      assert(latch.await(5, TimeUnit.MINUTES), "lastReportedFailureLatch.await")
       self.synchronized(assertEquals(lastReportedFailure, ex))
     } finally {
       self.synchronized {
@@ -177,7 +177,7 @@ abstract class ExecutorSchedulerSuite extends TestSuite[SchedulerService] { self
           throw ex
       })
 
-      assert(latch.await(30, TimeUnit.SECONDS), "lastReportedFailureLatch.await")
+      assert(latch.await(5, TimeUnit.MINUTES), "lastReportedFailureLatch.await")
       self.synchronized(assertEquals(lastReportedFailure, ex))
     } finally {
       self.synchronized {
@@ -217,11 +217,11 @@ object ForkJoinSchedulerSuite extends ExecutorSchedulerSuite {
       scheduler.executeAsync { () =>
         blocking {
           latch.countDown()
-          finish.await(30, TimeUnit.SECONDS)
+          finish.await(5, TimeUnit.MINUTES)
         }
       }
 
-    assert(latch.await(30, TimeUnit.SECONDS), "latch.await")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await")
     finish.countDown()
   }
 }

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/ExecutorSchedulerSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/ExecutorSchedulerSuite.scala
@@ -152,7 +152,7 @@ abstract class ExecutorSchedulerSuite extends TestSuite[SchedulerService] { self
           throw ex
       })
 
-      assert(latch.await(5, TimeUnit.MINUTES), "lastReportedFailureLatch.await")
+      assert(latch.await(15, TimeUnit.MINUTES), "lastReportedFailureLatch.await")
       self.synchronized(assertEquals(lastReportedFailure, ex))
     } finally {
       self.synchronized {
@@ -177,7 +177,7 @@ abstract class ExecutorSchedulerSuite extends TestSuite[SchedulerService] { self
           throw ex
       })
 
-      assert(latch.await(5, TimeUnit.MINUTES), "lastReportedFailureLatch.await")
+      assert(latch.await(15, TimeUnit.MINUTES), "lastReportedFailureLatch.await")
       self.synchronized(assertEquals(lastReportedFailure, ex))
     } finally {
       self.synchronized {
@@ -217,11 +217,11 @@ object ForkJoinSchedulerSuite extends ExecutorSchedulerSuite {
       scheduler.executeAsync { () =>
         blocking {
           latch.countDown()
-          finish.await(5, TimeUnit.MINUTES)
+          finish.await(15, TimeUnit.MINUTES)
         }
       }
 
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await")
     finish.countDown()
   }
 }

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TestSchedulerCompanionSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TestSchedulerCompanionSuite.scala
@@ -33,7 +33,7 @@ object TestSchedulerCompanionSuite extends SimpleTestSuite {
       val r = new Runnable { def run() = latch.countDown() }
       s.execute(r)
       s.scheduleOnce(10, TimeUnit.MILLISECONDS, r)
-      assert(latch.await(5, TimeUnit.MINUTES), "latch.await failed")
+      assert(latch.await(15, TimeUnit.MINUTES), "latch.await failed")
     } finally {
       service.shutdown()
     }
@@ -49,7 +49,7 @@ object TestSchedulerCompanionSuite extends SimpleTestSuite {
       val r = new Runnable { def run() = latch.countDown() }
       s.execute(r)
       s.scheduleOnce(10, TimeUnit.MILLISECONDS, r)
-      assert(latch.await(5, TimeUnit.MINUTES), "latch.await failed")
+      assert(latch.await(15, TimeUnit.MINUTES), "latch.await failed")
     } finally {
       service.shutdown()
     }
@@ -62,7 +62,7 @@ object TestSchedulerCompanionSuite extends SimpleTestSuite {
     val r = new Runnable { def run() = latch.countDown() }
     s.execute(r)
     s.scheduleOnce(10, TimeUnit.MILLISECONDS, r)
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await failed")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await failed")
   }
 
   test("scheduler builder, apply, test 4") {
@@ -72,7 +72,7 @@ object TestSchedulerCompanionSuite extends SimpleTestSuite {
     val r = new Runnable { def run() = latch.countDown() }
     s.execute(r)
     s.scheduleOnce(10, TimeUnit.MILLISECONDS, r)
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await failed")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await failed")
   }
 
   test("scheduler builder, apply, test 5") {
@@ -84,7 +84,7 @@ object TestSchedulerCompanionSuite extends SimpleTestSuite {
       val r = new Runnable { def run() = latch.countDown() }
       s.execute(r)
       s.scheduleOnce(10, TimeUnit.MILLISECONDS, r)
-      assert(latch.await(5, TimeUnit.MINUTES), "latch.await failed")
+      assert(latch.await(15, TimeUnit.MINUTES), "latch.await failed")
     } finally {
       s.shutdown()
     }
@@ -99,7 +99,7 @@ object TestSchedulerCompanionSuite extends SimpleTestSuite {
       val r = new Runnable { def run() = latch.countDown() }
       s.execute(r)
       s.scheduleOnce(10, TimeUnit.MILLISECONDS, r)
-      assert(latch.await(5, TimeUnit.MINUTES), "latch.await failed")
+      assert(latch.await(15, TimeUnit.MINUTES), "latch.await failed")
     } finally {
       s.shutdown()
     }
@@ -112,7 +112,7 @@ object TestSchedulerCompanionSuite extends SimpleTestSuite {
       val r = new Runnable { def run() = latch.countDown() }
       s.execute(r)
       s.scheduleOnce(10, TimeUnit.MILLISECONDS, r)
-      assert(latch.await(5, TimeUnit.MINUTES), "latch.await failed")
+      assert(latch.await(15, TimeUnit.MINUTES), "latch.await failed")
     } finally {
       s.shutdown()
     }
@@ -125,7 +125,7 @@ object TestSchedulerCompanionSuite extends SimpleTestSuite {
       val r = new Runnable { def run() = latch.countDown() }
       s.execute(r)
       s.scheduleOnce(10, TimeUnit.MILLISECONDS, r)
-      assert(latch.await(5, TimeUnit.MINUTES), "latch.await failed")
+      assert(latch.await(15, TimeUnit.MINUTES), "latch.await failed")
     } finally {
       s.shutdown()
     }
@@ -138,7 +138,7 @@ object TestSchedulerCompanionSuite extends SimpleTestSuite {
       val r = new Runnable { def run() = latch.countDown() }
       s.execute(r)
       s.scheduleOnce(10, TimeUnit.MILLISECONDS, r)
-      assert(latch.await(5, TimeUnit.MINUTES), "latch.await failed")
+      assert(latch.await(15, TimeUnit.MINUTES), "latch.await failed")
     } finally {
       s.shutdown()
     }
@@ -151,7 +151,7 @@ object TestSchedulerCompanionSuite extends SimpleTestSuite {
       val r = new Runnable { def run() = latch.countDown() }
       s.execute(r)
       s.scheduleOnce(10, TimeUnit.MILLISECONDS, r)
-      assert(latch.await(5, TimeUnit.MINUTES), "latch.await failed")
+      assert(latch.await(15, TimeUnit.MINUTES), "latch.await failed")
     } finally {
       s.shutdown()
     }

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TestSchedulerCompanionSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TestSchedulerCompanionSuite.scala
@@ -33,7 +33,7 @@ object TestSchedulerCompanionSuite extends SimpleTestSuite {
       val r = new Runnable { def run() = latch.countDown() }
       s.execute(r)
       s.scheduleOnce(10, TimeUnit.MILLISECONDS, r)
-      assert(latch.await(10, TimeUnit.SECONDS), "latch.await failed")
+      assert(latch.await(5, TimeUnit.MINUTES), "latch.await failed")
     } finally {
       service.shutdown()
     }
@@ -49,7 +49,7 @@ object TestSchedulerCompanionSuite extends SimpleTestSuite {
       val r = new Runnable { def run() = latch.countDown() }
       s.execute(r)
       s.scheduleOnce(10, TimeUnit.MILLISECONDS, r)
-      assert(latch.await(10, TimeUnit.SECONDS), "latch.await failed")
+      assert(latch.await(5, TimeUnit.MINUTES), "latch.await failed")
     } finally {
       service.shutdown()
     }
@@ -62,7 +62,7 @@ object TestSchedulerCompanionSuite extends SimpleTestSuite {
     val r = new Runnable { def run() = latch.countDown() }
     s.execute(r)
     s.scheduleOnce(10, TimeUnit.MILLISECONDS, r)
-    assert(latch.await(10, TimeUnit.SECONDS), "latch.await failed")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await failed")
   }
 
   test("scheduler builder, apply, test 4") {
@@ -72,7 +72,7 @@ object TestSchedulerCompanionSuite extends SimpleTestSuite {
     val r = new Runnable { def run() = latch.countDown() }
     s.execute(r)
     s.scheduleOnce(10, TimeUnit.MILLISECONDS, r)
-    assert(latch.await(10, TimeUnit.SECONDS), "latch.await failed")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await failed")
   }
 
   test("scheduler builder, apply, test 5") {
@@ -84,7 +84,7 @@ object TestSchedulerCompanionSuite extends SimpleTestSuite {
       val r = new Runnable { def run() = latch.countDown() }
       s.execute(r)
       s.scheduleOnce(10, TimeUnit.MILLISECONDS, r)
-      assert(latch.await(10, TimeUnit.SECONDS), "latch.await failed")
+      assert(latch.await(5, TimeUnit.MINUTES), "latch.await failed")
     } finally {
       s.shutdown()
     }
@@ -99,7 +99,7 @@ object TestSchedulerCompanionSuite extends SimpleTestSuite {
       val r = new Runnable { def run() = latch.countDown() }
       s.execute(r)
       s.scheduleOnce(10, TimeUnit.MILLISECONDS, r)
-      assert(latch.await(10, TimeUnit.SECONDS), "latch.await failed")
+      assert(latch.await(5, TimeUnit.MINUTES), "latch.await failed")
     } finally {
       s.shutdown()
     }
@@ -112,7 +112,7 @@ object TestSchedulerCompanionSuite extends SimpleTestSuite {
       val r = new Runnable { def run() = latch.countDown() }
       s.execute(r)
       s.scheduleOnce(10, TimeUnit.MILLISECONDS, r)
-      assert(latch.await(10, TimeUnit.SECONDS), "latch.await failed")
+      assert(latch.await(5, TimeUnit.MINUTES), "latch.await failed")
     } finally {
       s.shutdown()
     }
@@ -125,7 +125,7 @@ object TestSchedulerCompanionSuite extends SimpleTestSuite {
       val r = new Runnable { def run() = latch.countDown() }
       s.execute(r)
       s.scheduleOnce(10, TimeUnit.MILLISECONDS, r)
-      assert(latch.await(10, TimeUnit.SECONDS), "latch.await failed")
+      assert(latch.await(5, TimeUnit.MINUTES), "latch.await failed")
     } finally {
       s.shutdown()
     }
@@ -138,7 +138,7 @@ object TestSchedulerCompanionSuite extends SimpleTestSuite {
       val r = new Runnable { def run() = latch.countDown() }
       s.execute(r)
       s.scheduleOnce(10, TimeUnit.MILLISECONDS, r)
-      assert(latch.await(10, TimeUnit.SECONDS), "latch.await failed")
+      assert(latch.await(5, TimeUnit.MINUTES), "latch.await failed")
     } finally {
       s.shutdown()
     }
@@ -151,7 +151,7 @@ object TestSchedulerCompanionSuite extends SimpleTestSuite {
       val r = new Runnable { def run() = latch.countDown() }
       s.execute(r)
       s.scheduleOnce(10, TimeUnit.MILLISECONDS, r)
-      assert(latch.await(10, TimeUnit.SECONDS), "latch.await failed")
+      assert(latch.await(5, TimeUnit.MINUTES), "latch.await failed")
     } finally {
       s.shutdown()
     }

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/package.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/package.scala
@@ -32,7 +32,7 @@ package object schedulers {
 
   /** Deprecated. Moved to [[monix.execution.ExecutionModel]]. */
   @deprecated("Moved to `monix.execution.ExecutionModel`", since="2.1.3")
-  object ExecutionModel {
+  object ExecutionModel extends Serializable {
     /** Deprecated. Moved to [[monix.execution.ExecutionModel.SynchronousExecution]]. */
     @deprecated("Moved to `monix.execution.ExecutionModel.SynchronousExecution`", since="2.1.3")
     def SynchronousExecution = monix.execution.ExecutionModel.SynchronousExecution

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressuredConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressuredConcurrencySuite.scala
@@ -88,7 +88,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
       assert(!completed.await(100, TimeUnit.MILLISECONDS), "completed.await shouldn't have succeeded")
 
       buffer.onComplete()
-      assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
+      assert(completed.await(15, TimeUnit.MINUTES), "completed.await should have succeeded")
     }
   }
 
@@ -115,7 +115,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
     for (i <- 0 until 100000) buffer.onNext(i)
     buffer.onComplete()
 
-    assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
+    assert(completed.await(15, TimeUnit.MINUTES), "completed.await should have succeeded")
     assert(number == 100000)
   }
 
@@ -148,7 +148,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
         buffer.onComplete()
 
     loop(10000)
-    assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
+    assert(completed.await(15, TimeUnit.MINUTES), "completed.await should have succeeded")
     assertEquals(number, 10000)
   }
 
@@ -190,7 +190,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
       for (i <- 1 to total.toInt) buffer.onNext(i)
       buffer.onComplete()
 
-      assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
+      assert(completed.await(15, TimeUnit.MINUTES), "completed.await should have succeeded")
       assertEquals(received, total)
       assertEquals(sum, total * (total + 1) / 2)
     }
@@ -233,7 +233,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
       for (i <- 1 to total.toInt) buffer.onNext(i)
       buffer.onComplete()
 
-      assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
+      assert(completed.await(15, TimeUnit.MINUTES), "completed.await should have succeeded")
       assertEquals(received, total)
       assertEquals(sum, total * (total + 1) / 2)
     }
@@ -254,7 +254,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
       }, BackPressure(5))
 
     buffer.onError(new RuntimeException("dummy"))
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
 
     val r = buffer.onNext(1)
     assertEquals(r, Stop)
@@ -275,7 +275,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
 
     buffer.onNext(1)
     buffer.onError(new RuntimeException("dummy"))
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onError when at capacity") { implicit s =>
@@ -301,7 +301,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
     buffer.onError(DummyException("dummy"))
 
     promise.success(Continue)
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onComplete when empty") { implicit s =>
@@ -315,7 +315,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
       }, BackPressure(5))
 
     buffer.onComplete()
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onComplete when in flight") { implicit s =>
@@ -331,7 +331,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
 
     buffer.onNext(1)
     buffer.onComplete()
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
     promise.success(Continue); ()
   }
 
@@ -355,7 +355,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
     assert(!latch.await(1, TimeUnit.SECONDS), "latch.await should have failed")
 
     promise.success(Continue)
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should do onComplete only after all the queue was drained") { implicit s =>
@@ -378,7 +378,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
     buffer.onComplete()
     startConsuming.success(Continue)
 
-    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
+    assert(complete.await(15, TimeUnit.MINUTES), "complete.await should have succeeded")
     assert(sum == (0 until 9999).sum)
   }
 
@@ -400,7 +400,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
     (0 until 9999).foreach(x => buffer.onNext(x))
     buffer.onComplete()
 
-    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
+    assert(complete.await(15, TimeUnit.MINUTES), "complete.await should have succeeded")
     assert(sum == (0 until 9999).sum)
   }
 
@@ -424,7 +424,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
     buffer.onError(new RuntimeException)
     startConsuming.success(Continue)
 
-    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
+    assert(complete.await(15, TimeUnit.MINUTES), "complete.await should have succeeded")
     assertEquals(sum, (0 until 9999).sum)
   }
 
@@ -446,7 +446,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
     (0 until 9999).foreach(x => buffer.onNext(x))
     buffer.onError(new RuntimeException)
 
-    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
+    assert(complete.await(15, TimeUnit.MINUTES), "complete.await should have succeeded")
     assertEquals(sum, (0 until 9999).sum)
   }
 }

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressuredConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressuredConcurrencySuite.scala
@@ -21,21 +21,30 @@ import java.util.concurrent.{CountDownLatch, TimeUnit}
 
 import minitest.TestSuite
 import monix.execution.Ack.{Continue, Stop}
-import monix.execution.{Ack, Scheduler}
-import monix.reactive.OverflowStrategy.BackPressure
+import monix.execution.ExecutionModel.BatchedExecution
 import monix.execution.exceptions.DummyException
+import monix.execution.{Ack, Scheduler}
+import monix.execution.schedulers.SchedulerService
 import monix.reactive.{Observable, Observer}
+import monix.reactive.OverflowStrategy.BackPressure
 
-import scala.concurrent.duration._
 import scala.concurrent.{Await, Future, Promise}
+import scala.concurrent.duration._
 import scala.util.Random
 
-object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler] {
-  def setup() = monix.execution.Scheduler.Implicits.global
-  def tearDown(env: Scheduler) = ()
+object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[SchedulerService] {
+  def setup() =
+    Scheduler.computation(name="monix-backpressured-test")
 
-  test("merge test should work") { implicit s =>
-    val num = 200000
+  def tearDown(env: SchedulerService) = {
+    env.shutdown()
+    Await.result(env.awaitTermination(1.hour, Scheduler.global), Duration.Inf)
+  }
+
+  test("merge test should work") { scheduler =>
+    implicit val s = scheduler.withExecutionModel(BatchedExecution(1024))
+
+    val num = 100000
     val source = Observable.repeat(1L).take(num)
     val o1 = source.map(_ + 2)
     val o2 = source.map(_ + 3)
@@ -51,7 +60,8 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
   }
 
   test("should do back-pressure") { implicit s =>
-    for (_ <- 0 until 100) {
+    // Repeating due to possible problems
+    for (_ <- 0 until 10) {
       val promise = Promise[Ack]()
       val completed = new CountDownLatch(1)
 
@@ -92,34 +102,43 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
     }
   }
 
-  test("should not lose events, test 1") { implicit s =>
-    var number = 0
-    val completed = new CountDownLatch(1)
+  test("should not lose events, test 1") { scheduler =>
+    implicit val s = scheduler.withExecutionModel(BatchedExecution(128))
 
-    val underlying = new Observer[Int] {
-      def onNext(elem: Int): Future[Ack] = {
-        number += 1
-        Continue
+    // Repeating due to problems
+    for (_ <- 0 until 10) {
+      val count = 10000
+      var received = 0
+      val completed = new CountDownLatch(1)
+
+      val underlying = new Observer[Int] {
+        def onNext(elem: Int): Future[Ack] = {
+          received += 1
+          Continue
+        }
+
+        def onError(ex: Throwable): Unit = {
+          s.reportFailure(ex)
+          completed.countDown()
+        }
+
+        def onComplete(): Unit =
+          completed.countDown()
       }
 
-      def onError(ex: Throwable): Unit = {
-        s.reportFailure(ex)
-      }
+      val buffer = BufferedSubscriber[Int](Subscriber(underlying, s), BackPressure(count))
+      for (i <- 0 until count) buffer.onNext(i)
+      buffer.onComplete()
 
-      def onComplete(): Unit = {
-        completed.countDown()
-      }
+      assert(completed.await(15, TimeUnit.MINUTES), "completed.await should have succeeded")
+      assert(received == count)
     }
-
-    val buffer = BufferedSubscriber[Int](Subscriber(underlying, s), BackPressure(100000))
-    for (i <- 0 until 100000) buffer.onNext(i)
-    buffer.onComplete()
-
-    assert(completed.await(15, TimeUnit.MINUTES), "completed.await should have succeeded")
-    assert(number == 100000)
   }
 
-  test("should not lose events, test 2") { implicit s =>
+  test("should not lose events, test 2") { scheduler =>
+    implicit val s = scheduler.withExecutionModel(BatchedExecution(128))
+    val totalCount = 10000
+
     var number = 0
     val completed = new CountDownLatch(1)
 
@@ -138,7 +157,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
       }
     }
 
-    val buffer = BufferedSubscriber[Int](Subscriber(underlying, s), BackPressure(100000))
+    val buffer = BufferedSubscriber[Int](Subscriber(underlying, s), BackPressure(totalCount))
 
     def loop(n: Int): Unit =
       if (n > 0) s.execute(new Runnable {
@@ -147,16 +166,18 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
       else
         buffer.onComplete()
 
-    loop(10000)
+    loop(totalCount)
     assert(completed.await(15, TimeUnit.MINUTES), "completed.await should have succeeded")
-    assertEquals(number, 10000)
+    assertEquals(number, totalCount)
   }
 
-  test("should not lose events with async subscriber from one publisher (with sufficient buffer)") { implicit s =>
+  test("should not lose events with async subscriber from one publisher (with sufficient buffer)") { scheduler =>
+    implicit val s = scheduler.withExecutionModel(BatchedExecution(128))
+
     // Repeating because of possible problems
-    for (_ <- 0 until 100) {
+    for (_ <- 0 until 10) {
       val completed = new CountDownLatch(1)
-      val total = 10000L
+      val total = 2000L
 
       var received = 0
       var sum = 0L
@@ -196,9 +217,11 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
     }
   }
 
-  test("should not lose events with async subscriber from one publisher (with small buffer)") { implicit s =>
+  test("should not lose events with async subscriber from one publisher (with small buffer)") { scheduler =>
+    implicit val s = scheduler.withExecutionModel(BatchedExecution(128))
+
     // Repeating because of possible problems
-    for (_ <- 0 until 100) {
+    for (_ <- 0 until 10) {
       val completed = new CountDownLatch(1)
       val total = 10000L
 
@@ -358,7 +381,10 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
     assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
-  test("should do onComplete only after all the queue was drained") { implicit s =>
+  test("should do onComplete only after all the queue was drained") { scheduler =>
+    implicit val s = scheduler.withExecutionModel(BatchedExecution(128))
+    val totalCount = 10000
+
     var sum = 0L
     val complete = new CountDownLatch(1)
     val startConsuming = Promise[Continue]()
@@ -372,17 +398,20 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
         def onError(ex: Throwable) = throw ex
         def onComplete() = complete.countDown()
         val scheduler = s
-      }, BackPressure(10000))
+      }, BackPressure(totalCount))
 
-    (0 until 9999).foreach(x => buffer.onNext(x))
+    (0 until (totalCount - 1)).foreach(x => buffer.onNext(x))
     buffer.onComplete()
     startConsuming.success(Continue)
 
     assert(complete.await(15, TimeUnit.MINUTES), "complete.await should have succeeded")
-    assert(sum == (0 until 9999).sum)
+    assert(sum == (0 until (totalCount - 1)).sum)
   }
 
-  test("should do onComplete only after all the queue was drained, test2") { implicit s =>
+  test("should do onComplete only after all the queue was drained, test2") { scheduler =>
+    implicit val s = scheduler.withExecutionModel(BatchedExecution(128))
+
+    val totalCount = 10000
     var sum = 0L
     val complete = new CountDownLatch(1)
 
@@ -395,16 +424,19 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
         def onError(ex: Throwable) = throw ex
         def onComplete() = complete.countDown()
         val scheduler = s
-      }, BackPressure(10000))
+      }, BackPressure(totalCount))
 
-    (0 until 9999).foreach(x => buffer.onNext(x))
+    (0 until (totalCount-1)).foreach(x => buffer.onNext(x))
     buffer.onComplete()
 
     assert(complete.await(15, TimeUnit.MINUTES), "complete.await should have succeeded")
-    assert(sum == (0 until 9999).sum)
+    assert(sum == (0 until (totalCount-1)).sum)
   }
 
-  test("should do onError only after the queue was drained") { implicit s =>
+  test("should do onError only after the queue was drained") { scheduler =>
+    implicit val s = scheduler.withExecutionModel(BatchedExecution(128))
+
+    val totalCount = 10000
     var sum = 0L
     val complete = new CountDownLatch(1)
     val startConsuming = Promise[Continue]()
@@ -418,17 +450,20 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
         def onError(ex: Throwable) = complete.countDown()
         def onComplete() = throw new IllegalStateException()
         val scheduler = s
-      }, BackPressure(10000))
+      }, BackPressure(totalCount))
 
-    (0 until 9999).foreach(x => buffer.onNext(x))
+    (0 until (totalCount-1)).foreach(x => buffer.onNext(x))
     buffer.onError(new RuntimeException)
     startConsuming.success(Continue)
 
     assert(complete.await(15, TimeUnit.MINUTES), "complete.await should have succeeded")
-    assertEquals(sum, (0 until 9999).sum)
+    assertEquals(sum, (0 until (totalCount-1)).sum)
   }
 
-  test("should do onError only after all the queue was drained, test2") { implicit s =>
+  test("should do onError only after all the queue was drained, test2") { scheduler =>
+    implicit val s = scheduler.withExecutionModel(BatchedExecution(128))
+    val totalCount = 10000
+
     var sum = 0L
     val complete = new CountDownLatch(1)
 
@@ -441,12 +476,12 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
         def onError(ex: Throwable) = complete.countDown()
         def onComplete() = throw new IllegalStateException()
         val scheduler = s
-      }, BackPressure(10000))
+      }, BackPressure(totalCount))
 
-    (0 until 9999).foreach(x => buffer.onNext(x))
+    (0 until (totalCount-1)).foreach(x => buffer.onNext(x))
     buffer.onError(new RuntimeException)
 
     assert(complete.await(15, TimeUnit.MINUTES), "complete.await should have succeeded")
-    assertEquals(sum, (0 until 9999).sum)
+    assertEquals(sum, (0 until (totalCount-1)).sum)
   }
 }

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressuredConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressuredConcurrencySuite.scala
@@ -88,7 +88,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
       assert(!completed.await(100, TimeUnit.MILLISECONDS), "completed.await shouldn't have succeeded")
 
       buffer.onComplete()
-      assert(completed.await(60, TimeUnit.SECONDS), "completed.await should have succeeded")
+      assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
     }
   }
 
@@ -115,7 +115,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
     for (i <- 0 until 100000) buffer.onNext(i)
     buffer.onComplete()
 
-    assert(completed.await(60, TimeUnit.SECONDS), "completed.await should have succeeded")
+    assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
     assert(number == 100000)
   }
 
@@ -148,7 +148,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
         buffer.onComplete()
 
     loop(10000)
-    assert(completed.await(60, TimeUnit.SECONDS), "completed.await should have succeeded")
+    assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
     assertEquals(number, 10000)
   }
 

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressuredConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressuredConcurrencySuite.scala
@@ -88,7 +88,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
       assert(!completed.await(100, TimeUnit.MILLISECONDS), "completed.await shouldn't have succeeded")
 
       buffer.onComplete()
-      assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
+      assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
     }
   }
 
@@ -115,7 +115,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
     for (i <- 0 until 100000) buffer.onNext(i)
     buffer.onComplete()
 
-    assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
+    assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
     assert(number == 100000)
   }
 
@@ -148,7 +148,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
         buffer.onComplete()
 
     loop(10000)
-    assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
+    assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
     assertEquals(number, 10000)
   }
 
@@ -190,7 +190,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
       for (i <- 1 to total.toInt) buffer.onNext(i)
       buffer.onComplete()
 
-      assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
+      assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
       assertEquals(received, total)
       assertEquals(sum, total * (total + 1) / 2)
     }
@@ -233,7 +233,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
       for (i <- 1 to total.toInt) buffer.onNext(i)
       buffer.onComplete()
 
-      assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
+      assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
       assertEquals(received, total)
       assertEquals(sum, total * (total + 1) / 2)
     }
@@ -254,7 +254,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
       }, BackPressure(5))
 
     buffer.onError(new RuntimeException("dummy"))
-    assert(latch.await(60, TimeUnit.SECONDS), "latch.await should have succeeded")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
 
     val r = buffer.onNext(1)
     assertEquals(r, Stop)
@@ -275,7 +275,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
 
     buffer.onNext(1)
     buffer.onError(new RuntimeException("dummy"))
-    assert(latch.await(60, TimeUnit.SECONDS), "latch.await should have succeeded")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onError when at capacity") { implicit s =>
@@ -301,7 +301,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
     buffer.onError(DummyException("dummy"))
 
     promise.success(Continue)
-    assert(latch.await(60, TimeUnit.SECONDS), "latch.await should have succeeded")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onComplete when empty") { implicit s =>
@@ -315,7 +315,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
       }, BackPressure(5))
 
     buffer.onComplete()
-    assert(latch.await(60, TimeUnit.SECONDS), "latch.await should have succeeded")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onComplete when in flight") { implicit s =>
@@ -331,7 +331,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
 
     buffer.onNext(1)
     buffer.onComplete()
-    assert(latch.await(60, TimeUnit.SECONDS), "latch.await should have succeeded")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
     promise.success(Continue); ()
   }
 
@@ -355,7 +355,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
     assert(!latch.await(1, TimeUnit.SECONDS), "latch.await should have failed")
 
     promise.success(Continue)
-    assert(latch.await(60, TimeUnit.SECONDS), "latch.await should have succeeded")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should do onComplete only after all the queue was drained") { implicit s =>
@@ -378,7 +378,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
     buffer.onComplete()
     startConsuming.success(Continue)
 
-    assert(complete.await(60, TimeUnit.SECONDS), "complete.await should have succeeded")
+    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
     assert(sum == (0 until 9999).sum)
   }
 
@@ -400,7 +400,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
     (0 until 9999).foreach(x => buffer.onNext(x))
     buffer.onComplete()
 
-    assert(complete.await(60, TimeUnit.SECONDS), "complete.await should have succeeded")
+    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
     assert(sum == (0 until 9999).sum)
   }
 
@@ -424,7 +424,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
     buffer.onError(new RuntimeException)
     startConsuming.success(Continue)
 
-    assert(complete.await(60, TimeUnit.SECONDS), "complete.await should have succeeded")
+    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
     assertEquals(sum, (0 until 9999).sum)
   }
 
@@ -446,7 +446,7 @@ object OverflowStrategyBackPressuredConcurrencySuite extends TestSuite[Scheduler
     (0 until 9999).foreach(x => buffer.onNext(x))
     buffer.onError(new RuntimeException)
 
-    assert(complete.await(60, TimeUnit.SECONDS), "complete.await should have succeeded")
+    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
     assertEquals(sum, (0 until 9999).sum)
   }
 }

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewAndSignalConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewAndSignalConcurrencySuite.scala
@@ -75,7 +75,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
     for (i <- 0 until 100000) buffer.onNext(i)
     buffer.onComplete()
 
-    assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
+    assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
     assert(number == 100000)
   }
 
@@ -107,7 +107,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
       else buffer.onComplete()
 
     loop(10000)
-    assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
+    assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
     assertEquals(number, 10000)
   }
 
@@ -149,7 +149,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
       for (i <- 1 to total.toInt) buffer.onNext(i)
       buffer.onComplete()
 
-      assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
+      assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
       assertEquals(received, total)
       assertEquals(sum, total * (total + 1) / 2)
     }
@@ -189,11 +189,11 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
 
       for (i <- 1 to 100) buffer.onNext(Right(i))
 
-      assert(started.await(60, TimeUnit.SECONDS), "started.await")
+      assert(started.await(5, TimeUnit.MINUTES), "started.await")
       promise.success(Continue)
       buffer.onComplete()
 
-      assert(completed.await(120, TimeUnit.SECONDS), "wasCompleted.await should have succeeded")
+      assert(completed.await(5, TimeUnit.MINUTES), "wasCompleted.await should have succeeded")
       assert(received <= 10, s"received $received <= 10")
       assert(dropped >= 90)
     }
@@ -212,7 +212,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
     })
 
     buffer.onError(new RuntimeException("dummy"))
-    assert(latch.await(60, TimeUnit.SECONDS), "latch.await should have succeeded")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
 
     val r = buffer.onNext(1)
     assertEquals(r, Stop)
@@ -231,7 +231,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
 
     buffer.onNext(1)
     buffer.onError(new RuntimeException("dummy"))
-    assert(latch.await(60, TimeUnit.SECONDS), "latch.await should have succeeded")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onError when at capacity") { implicit s =>
@@ -255,7 +255,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
     buffer.onError(DummyException("dummy"))
 
     promise.success(Continue)
-    assert(latch.await(60, TimeUnit.SECONDS), "latch.await should have succeeded")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onComplete when empty") { implicit s =>
@@ -267,7 +267,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
     })
 
     buffer.onComplete()
-    assert(latch.await(60, TimeUnit.SECONDS), "latch.await should have succeeded")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onComplete when in flight") { implicit s =>
@@ -281,7 +281,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
 
     buffer.onNext(1)
     buffer.onComplete()
-    assert(latch.await(60, TimeUnit.SECONDS), "latch.await should have succeeded")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onComplete when at capacity") { implicit s =>
@@ -302,7 +302,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
     assert(!latch.await(1, TimeUnit.SECONDS), "latch.await should have failed")
 
     promise.success(Continue)
-    assert(latch.await(60, TimeUnit.SECONDS), "latch.await should have succeeded")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should do onComplete only after all the queue was drained") { implicit s =>
@@ -323,7 +323,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
     buffer.onComplete()
     startConsuming.success(Continue)
 
-    assert(complete.await(60, TimeUnit.SECONDS), "complete.await should have succeeded")
+    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
     assert(sum == (0 until 9999).sum)
   }
 
@@ -343,7 +343,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
     (0 until 9999).foreach(x => buffer.onNext(x))
     buffer.onComplete()
 
-    assert(complete.await(60, TimeUnit.SECONDS), "complete.await should have succeeded")
+    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
     assert(sum == (0 until 9999).sum)
   }
 
@@ -365,7 +365,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
     buffer.onError(new RuntimeException)
     startConsuming.success(Continue)
 
-    assert(complete.await(60, TimeUnit.SECONDS), "complete.await should have succeeded")
+    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
     assertEquals(sum, (0 until 9999).sum)
   }
 
@@ -385,7 +385,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
     (0 until 9999).foreach(x => buffer.onNext(x))
     buffer.onError(new RuntimeException)
 
-    assert(complete.await(60, TimeUnit.SECONDS), "complete.await should have succeeded")
+    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
     assertEquals(sum, (0 until 9999).sum)
   }
 }

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewAndSignalConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewAndSignalConcurrencySuite.scala
@@ -75,7 +75,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
     for (i <- 0 until 100000) buffer.onNext(i)
     buffer.onComplete()
 
-    assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
+    assert(completed.await(15, TimeUnit.MINUTES), "completed.await should have succeeded")
     assert(number == 100000)
   }
 
@@ -107,7 +107,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
       else buffer.onComplete()
 
     loop(10000)
-    assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
+    assert(completed.await(15, TimeUnit.MINUTES), "completed.await should have succeeded")
     assertEquals(number, 10000)
   }
 
@@ -149,7 +149,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
       for (i <- 1 to total.toInt) buffer.onNext(i)
       buffer.onComplete()
 
-      assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
+      assert(completed.await(15, TimeUnit.MINUTES), "completed.await should have succeeded")
       assertEquals(received, total)
       assertEquals(sum, total * (total + 1) / 2)
     }
@@ -189,11 +189,11 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
 
       for (i <- 1 to 100) buffer.onNext(Right(i))
 
-      assert(started.await(5, TimeUnit.MINUTES), "started.await")
+      assert(started.await(15, TimeUnit.MINUTES), "started.await")
       promise.success(Continue)
       buffer.onComplete()
 
-      assert(completed.await(5, TimeUnit.MINUTES), "wasCompleted.await should have succeeded")
+      assert(completed.await(15, TimeUnit.MINUTES), "wasCompleted.await should have succeeded")
       assert(received <= 10, s"received $received <= 10")
       assert(dropped >= 90)
     }
@@ -212,7 +212,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
     })
 
     buffer.onError(new RuntimeException("dummy"))
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
 
     val r = buffer.onNext(1)
     assertEquals(r, Stop)
@@ -231,7 +231,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
 
     buffer.onNext(1)
     buffer.onError(new RuntimeException("dummy"))
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onError when at capacity") { implicit s =>
@@ -255,7 +255,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
     buffer.onError(DummyException("dummy"))
 
     promise.success(Continue)
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onComplete when empty") { implicit s =>
@@ -267,7 +267,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
     })
 
     buffer.onComplete()
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onComplete when in flight") { implicit s =>
@@ -281,7 +281,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
 
     buffer.onNext(1)
     buffer.onComplete()
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onComplete when at capacity") { implicit s =>
@@ -302,7 +302,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
     assert(!latch.await(1, TimeUnit.SECONDS), "latch.await should have failed")
 
     promise.success(Continue)
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should do onComplete only after all the queue was drained") { implicit s =>
@@ -323,7 +323,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
     buffer.onComplete()
     startConsuming.success(Continue)
 
-    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
+    assert(complete.await(15, TimeUnit.MINUTES), "complete.await should have succeeded")
     assert(sum == (0 until 9999).sum)
   }
 
@@ -343,7 +343,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
     (0 until 9999).foreach(x => buffer.onNext(x))
     buffer.onComplete()
 
-    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
+    assert(complete.await(15, TimeUnit.MINUTES), "complete.await should have succeeded")
     assert(sum == (0 until 9999).sum)
   }
 
@@ -365,7 +365,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
     buffer.onError(new RuntimeException)
     startConsuming.success(Continue)
 
-    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
+    assert(complete.await(15, TimeUnit.MINUTES), "complete.await should have succeeded")
     assertEquals(sum, (0 until 9999).sum)
   }
 
@@ -385,7 +385,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
     (0 until 9999).foreach(x => buffer.onNext(x))
     buffer.onError(new RuntimeException)
 
-    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
+    assert(complete.await(15, TimeUnit.MINUTES), "complete.await should have succeeded")
     assertEquals(sum, (0 until 9999).sum)
   }
 }

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewAndSignalConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewAndSignalConcurrencySuite.scala
@@ -75,7 +75,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
     for (i <- 0 until 100000) buffer.onNext(i)
     buffer.onComplete()
 
-    assert(completed.await(60, TimeUnit.SECONDS), "completed.await should have succeeded")
+    assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
     assert(number == 100000)
   }
 
@@ -107,7 +107,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
       else buffer.onComplete()
 
     loop(10000)
-    assert(completed.await(60, TimeUnit.SECONDS), "completed.await should have succeeded")
+    assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
     assertEquals(number, 10000)
   }
 
@@ -193,7 +193,7 @@ object OverflowStrategyDropNewAndSignalConcurrencySuite extends TestSuite[Schedu
       promise.success(Continue)
       buffer.onComplete()
 
-      assert(completed.await(60, TimeUnit.SECONDS), "wasCompleted.await should have succeeded")
+      assert(completed.await(120, TimeUnit.SECONDS), "wasCompleted.await should have succeeded")
       assert(received <= 10, s"received $received <= 10")
       assert(dropped >= 90)
     }

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewConcurrencySuite.scala
@@ -72,7 +72,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
     for (i <- 0 until 100000) buffer.onNext(i)
     buffer.onComplete()
 
-    assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
+    assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
     assert(number == 100000)
   }
 
@@ -104,7 +104,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
       else buffer.onComplete()
 
     loop(10000)
-    assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
+    assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
     assertEquals(number, 10000)
   }
 
@@ -146,7 +146,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
       for (i <- 1 to total.toInt) buffer.onNext(i)
       buffer.onComplete()
 
-      assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
+      assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
       assertEquals(received, total)
       assertEquals(sum, total * (total + 1) / 2)
     }
@@ -185,7 +185,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
       buffer.onComplete()
 
       promise.success(Continue)
-      assert(completed.await(120, TimeUnit.SECONDS), "wasCompleted.await should have succeeded")
+      assert(completed.await(5, TimeUnit.MINUTES), "wasCompleted.await should have succeeded")
       assert(received <= 10, s"received $received <= 10")
     }
   }
@@ -204,7 +204,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
     }, DropNew(5))
 
     buffer.onError(new RuntimeException("dummy"))
-    assert(latch.await(60, TimeUnit.SECONDS), "latch.await should have succeeded")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
 
     val r = buffer.onNext(1)
     assertEquals(r, Stop)
@@ -224,7 +224,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
 
     buffer.onNext(1)
     buffer.onError(new RuntimeException("dummy"))
-    assert(latch.await(60, TimeUnit.SECONDS), "latch.await should have succeeded")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onError when at capacity") { implicit s =>
@@ -250,7 +250,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
     buffer.onError(DummyException("dummy"))
 
     promise.success(Continue)
-    assert(latch.await(60, TimeUnit.SECONDS), "latch.await should have succeeded")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onComplete when empty") { implicit s =>
@@ -263,7 +263,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
     }, DropNew(5))
 
     buffer.onComplete()
-    assert(latch.await(60, TimeUnit.SECONDS), "latch.await should have succeeded")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onComplete when in flight") { implicit s =>
@@ -300,7 +300,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
     assert(!latch.await(1, TimeUnit.SECONDS), "latch.await should have failed")
 
     promise.success(Continue)
-    assert(latch.await(60, TimeUnit.SECONDS), "latch.await should have succeeded")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should do onComplete only after all the queue was drained") { implicit s =>
@@ -322,7 +322,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
     buffer.onComplete()
     startConsuming.success(Continue)
 
-    assert(complete.await(60, TimeUnit.SECONDS), "complete.await should have succeeded")
+    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
     assert(sum == (0 until 9999).sum)
   }
 
@@ -343,7 +343,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
     (0 until 9999).foreach(x => buffer.onNext(x))
     buffer.onComplete()
 
-    assert(complete.await(60, TimeUnit.SECONDS), "complete.await should have succeeded")
+    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
     assert(sum == (0 until 9999).sum)
   }
 
@@ -366,7 +366,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
     buffer.onError(new RuntimeException)
     startConsuming.success(Continue)
 
-    assert(complete.await(60, TimeUnit.SECONDS), "complete.await should have succeeded")
+    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
     assertEquals(sum, (0 until 9999).sum)
   }
 
@@ -388,7 +388,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
     (0 until 9999).foreach(x => buffer.onNext(x))
     buffer.onError(new RuntimeException)
 
-    assert(complete.await(60, TimeUnit.SECONDS), "complete.await should have succeeded")
+    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
     assertEquals(sum, (0 until 9999).sum)
   }
 }

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewConcurrencySuite.scala
@@ -72,7 +72,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
     for (i <- 0 until 100000) buffer.onNext(i)
     buffer.onComplete()
 
-    assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
+    assert(completed.await(15, TimeUnit.MINUTES), "completed.await should have succeeded")
     assert(number == 100000)
   }
 
@@ -104,7 +104,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
       else buffer.onComplete()
 
     loop(10000)
-    assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
+    assert(completed.await(15, TimeUnit.MINUTES), "completed.await should have succeeded")
     assertEquals(number, 10000)
   }
 
@@ -146,7 +146,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
       for (i <- 1 to total.toInt) buffer.onNext(i)
       buffer.onComplete()
 
-      assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
+      assert(completed.await(15, TimeUnit.MINUTES), "completed.await should have succeeded")
       assertEquals(received, total)
       assertEquals(sum, total * (total + 1) / 2)
     }
@@ -185,7 +185,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
       buffer.onComplete()
 
       promise.success(Continue)
-      assert(completed.await(5, TimeUnit.MINUTES), "wasCompleted.await should have succeeded")
+      assert(completed.await(15, TimeUnit.MINUTES), "wasCompleted.await should have succeeded")
       assert(received <= 10, s"received $received <= 10")
     }
   }
@@ -204,7 +204,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
     }, DropNew(5))
 
     buffer.onError(new RuntimeException("dummy"))
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
 
     val r = buffer.onNext(1)
     assertEquals(r, Stop)
@@ -224,7 +224,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
 
     buffer.onNext(1)
     buffer.onError(new RuntimeException("dummy"))
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onError when at capacity") { implicit s =>
@@ -250,7 +250,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
     buffer.onError(DummyException("dummy"))
 
     promise.success(Continue)
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onComplete when empty") { implicit s =>
@@ -263,7 +263,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
     }, DropNew(5))
 
     buffer.onComplete()
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onComplete when in flight") { implicit s =>
@@ -300,7 +300,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
     assert(!latch.await(1, TimeUnit.SECONDS), "latch.await should have failed")
 
     promise.success(Continue)
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should do onComplete only after all the queue was drained") { implicit s =>
@@ -322,7 +322,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
     buffer.onComplete()
     startConsuming.success(Continue)
 
-    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
+    assert(complete.await(15, TimeUnit.MINUTES), "complete.await should have succeeded")
     assert(sum == (0 until 9999).sum)
   }
 
@@ -343,7 +343,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
     (0 until 9999).foreach(x => buffer.onNext(x))
     buffer.onComplete()
 
-    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
+    assert(complete.await(15, TimeUnit.MINUTES), "complete.await should have succeeded")
     assert(sum == (0 until 9999).sum)
   }
 
@@ -366,7 +366,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
     buffer.onError(new RuntimeException)
     startConsuming.success(Continue)
 
-    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
+    assert(complete.await(15, TimeUnit.MINUTES), "complete.await should have succeeded")
     assertEquals(sum, (0 until 9999).sum)
   }
 
@@ -388,7 +388,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
     (0 until 9999).foreach(x => buffer.onNext(x))
     buffer.onError(new RuntimeException)
 
-    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
+    assert(complete.await(15, TimeUnit.MINUTES), "complete.await should have succeeded")
     assertEquals(sum, (0 until 9999).sum)
   }
 }

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewConcurrencySuite.scala
@@ -72,7 +72,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
     for (i <- 0 until 100000) buffer.onNext(i)
     buffer.onComplete()
 
-    assert(completed.await(60, TimeUnit.SECONDS), "completed.await should have succeeded")
+    assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
     assert(number == 100000)
   }
 
@@ -104,7 +104,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
       else buffer.onComplete()
 
     loop(10000)
-    assert(completed.await(60, TimeUnit.SECONDS), "completed.await should have succeeded")
+    assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
     assertEquals(number, 10000)
   }
 
@@ -185,7 +185,7 @@ object OverflowStrategyDropNewConcurrencySuite extends TestSuite[Scheduler] {
       buffer.onComplete()
 
       promise.success(Continue)
-      assert(completed.await(60, TimeUnit.SECONDS), "wasCompleted.await should have succeeded")
+      assert(completed.await(120, TimeUnit.SECONDS), "wasCompleted.await should have succeeded")
       assert(received <= 10, s"received $received <= 10")
     }
   }

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyFailConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyFailConcurrencySuite.scala
@@ -58,7 +58,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
     for (i <- 0 until 100000) buffer.onNext(i)
     buffer.onComplete()
 
-    assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
+    assert(completed.await(15, TimeUnit.MINUTES), "completed.await should have succeeded")
     assert(number == 100000)
   }
 
@@ -90,7 +90,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
       else buffer.onComplete()
 
     loop(10000)
-    assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
+    assert(completed.await(15, TimeUnit.MINUTES), "completed.await should have succeeded")
     assertEquals(number, 10000)
   }
 
@@ -132,7 +132,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
       for (i <- 1 to total.toInt) buffer.onNext(i)
       buffer.onComplete()
 
-      assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
+      assert(completed.await(15, TimeUnit.MINUTES), "completed.await should have succeeded")
       assertEquals(received, total)
       assertEquals(sum, total * (total + 1) / 2)
     }
@@ -179,14 +179,14 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
     assertEquals(buffer.onNext(4), Continue)
     assertEquals(buffer.onNext(5), Continue)
 
-    assert(receivedLatch.await(5, TimeUnit.MINUTES), "receivedLatch.await should have succeeded")
+    assert(receivedLatch.await(15, TimeUnit.MINUTES), "receivedLatch.await should have succeeded")
     assert(!errorCaught.await(2, TimeUnit.SECONDS), "errorCaught.await should have failed")
 
     buffer.onNext(6)
     for (_ <- 0 until 100) buffer.onNext(7)
 
     promise.success(Continue)
-    assert(errorCaught.await(5, TimeUnit.MINUTES), "errorCaught.await should have succeeded")
+    assert(errorCaught.await(15, TimeUnit.MINUTES), "errorCaught.await should have succeeded")
   }
 
   test("should send onError when empty") { implicit s =>
@@ -203,7 +203,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
     }, Fail(5))
 
     buffer.onError(new RuntimeException("dummy"))
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
 
     val r = buffer.onNext(1)
     assertEquals(r, Stop)
@@ -223,7 +223,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
 
     buffer.onNext(1)
     buffer.onError(new RuntimeException("dummy"))
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onError when at capacity") { implicit s =>
@@ -248,7 +248,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
     buffer.onError(DummyException("dummy"))
 
     promise.success(Continue)
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onComplete when empty") { implicit s =>
@@ -261,7 +261,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
     }, Fail(5))
 
     buffer.onComplete()
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onComplete without back-pressure") { implicit s =>
@@ -276,7 +276,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
 
     buffer.onNext(1)
     buffer.onComplete()
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onComplete when at capacity") { implicit s =>
@@ -298,7 +298,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
     assert(!latch.await(1, TimeUnit.SECONDS), "latch.await should have failed")
 
     promise.success(Continue)
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should do onComplete only after all the queue was drained") { implicit s =>
@@ -320,7 +320,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
     buffer.onComplete()
     startConsuming.success(Continue)
 
-    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
+    assert(complete.await(15, TimeUnit.MINUTES), "complete.await should have succeeded")
     assert(sum == (0 until 9999).sum)
   }
 
@@ -341,7 +341,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
     (0 until 9999).foreach(x => buffer.onNext(x))
     buffer.onComplete()
 
-    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
+    assert(complete.await(15, TimeUnit.MINUTES), "complete.await should have succeeded")
     assert(sum == (0 until 9999).sum)
   }
 
@@ -364,7 +364,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
     buffer.onError(new RuntimeException)
     startConsuming.success(Continue)
 
-    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
+    assert(complete.await(15, TimeUnit.MINUTES), "complete.await should have succeeded")
     assertEquals(sum, (0 until 9999).sum)
   }
 
@@ -385,7 +385,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
     (0 until 9999).foreach(x => buffer.onNext(x))
     buffer.onError(new RuntimeException)
 
-    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
+    assert(complete.await(15, TimeUnit.MINUTES), "complete.await should have succeeded")
     assertEquals(sum, (0 until 9999).sum)
   }
 }

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyFailConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyFailConcurrencySuite.scala
@@ -58,7 +58,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
     for (i <- 0 until 100000) buffer.onNext(i)
     buffer.onComplete()
 
-    assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
+    assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
     assert(number == 100000)
   }
 
@@ -90,7 +90,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
       else buffer.onComplete()
 
     loop(10000)
-    assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
+    assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
     assertEquals(number, 10000)
   }
 
@@ -132,7 +132,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
       for (i <- 1 to total.toInt) buffer.onNext(i)
       buffer.onComplete()
 
-      assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
+      assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
       assertEquals(received, total)
       assertEquals(sum, total * (total + 1) / 2)
     }
@@ -179,14 +179,14 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
     assertEquals(buffer.onNext(4), Continue)
     assertEquals(buffer.onNext(5), Continue)
 
-    assert(receivedLatch.await(60, TimeUnit.SECONDS), "receivedLatch.await should have succeeded")
+    assert(receivedLatch.await(5, TimeUnit.MINUTES), "receivedLatch.await should have succeeded")
     assert(!errorCaught.await(2, TimeUnit.SECONDS), "errorCaught.await should have failed")
 
     buffer.onNext(6)
     for (_ <- 0 until 100) buffer.onNext(7)
 
     promise.success(Continue)
-    assert(errorCaught.await(60, TimeUnit.SECONDS), "errorCaught.await should have succeeded")
+    assert(errorCaught.await(5, TimeUnit.MINUTES), "errorCaught.await should have succeeded")
   }
 
   test("should send onError when empty") { implicit s =>
@@ -203,7 +203,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
     }, Fail(5))
 
     buffer.onError(new RuntimeException("dummy"))
-    assert(latch.await(60, TimeUnit.SECONDS), "latch.await should have succeeded")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
 
     val r = buffer.onNext(1)
     assertEquals(r, Stop)
@@ -223,7 +223,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
 
     buffer.onNext(1)
     buffer.onError(new RuntimeException("dummy"))
-    assert(latch.await(60, TimeUnit.SECONDS), "latch.await should have succeeded")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onError when at capacity") { implicit s =>
@@ -248,7 +248,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
     buffer.onError(DummyException("dummy"))
 
     promise.success(Continue)
-    assert(latch.await(60, TimeUnit.SECONDS), "latch.await should have succeeded")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onComplete when empty") { implicit s =>
@@ -261,7 +261,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
     }, Fail(5))
 
     buffer.onComplete()
-    assert(latch.await(60, TimeUnit.SECONDS), "latch.await should have succeeded")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onComplete without back-pressure") { implicit s =>
@@ -276,7 +276,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
 
     buffer.onNext(1)
     buffer.onComplete()
-    assert(latch.await(60, TimeUnit.SECONDS), "latch.await should have succeeded")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onComplete when at capacity") { implicit s =>
@@ -298,7 +298,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
     assert(!latch.await(1, TimeUnit.SECONDS), "latch.await should have failed")
 
     promise.success(Continue)
-    assert(latch.await(60, TimeUnit.SECONDS), "latch.await should have succeeded")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should do onComplete only after all the queue was drained") { implicit s =>
@@ -320,7 +320,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
     buffer.onComplete()
     startConsuming.success(Continue)
 
-    assert(complete.await(60, TimeUnit.SECONDS), "complete.await should have succeeded")
+    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
     assert(sum == (0 until 9999).sum)
   }
 
@@ -341,7 +341,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
     (0 until 9999).foreach(x => buffer.onNext(x))
     buffer.onComplete()
 
-    assert(complete.await(60, TimeUnit.SECONDS), "complete.await should have succeeded")
+    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
     assert(sum == (0 until 9999).sum)
   }
 
@@ -364,7 +364,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
     buffer.onError(new RuntimeException)
     startConsuming.success(Continue)
 
-    assert(complete.await(60, TimeUnit.SECONDS), "complete.await should have succeeded")
+    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
     assertEquals(sum, (0 until 9999).sum)
   }
 
@@ -385,7 +385,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
     (0 until 9999).foreach(x => buffer.onNext(x))
     buffer.onError(new RuntimeException)
 
-    assert(complete.await(60, TimeUnit.SECONDS), "complete.await should have succeeded")
+    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
     assertEquals(sum, (0 until 9999).sum)
   }
 }

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyFailConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyFailConcurrencySuite.scala
@@ -58,7 +58,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
     for (i <- 0 until 100000) buffer.onNext(i)
     buffer.onComplete()
 
-    assert(completed.await(60, TimeUnit.SECONDS), "completed.await should have succeeded")
+    assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
     assert(number == 100000)
   }
 
@@ -90,7 +90,7 @@ object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
       else buffer.onComplete()
 
     loop(10000)
-    assert(completed.await(60, TimeUnit.SECONDS), "completed.await should have succeeded")
+    assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
     assertEquals(number, 10000)
   }
 

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyFailConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyFailConcurrencySuite.scala
@@ -18,6 +18,7 @@
 package monix.reactive.observers
 
 import java.util.concurrent.{CountDownLatch, TimeUnit}
+
 import minitest.TestSuite
 import monix.execution.{Ack, Scheduler}
 import monix.reactive.{Observer, OverflowStrategy}
@@ -25,14 +26,20 @@ import monix.execution.Ack.{Continue, Stop}
 import OverflowStrategy.Fail
 import monix.execution.exceptions.BufferOverflowException
 import monix.execution.exceptions.DummyException
-import scala.concurrent.{Future, Promise}
+import monix.execution.schedulers.SchedulerService
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future, Promise}
 import scala.util.Random
 
 
-object OverflowStrategyFailConcurrencySuite extends TestSuite[Scheduler] {
-  def tearDown(env: Scheduler) = ()
-  def setup() = {
-    monix.execution.Scheduler.Implicits.global
+object OverflowStrategyFailConcurrencySuite extends TestSuite[SchedulerService] {
+  def setup() =
+    Scheduler.computation(name="monix-fail-test")
+
+  def tearDown(env: SchedulerService) = {
+    env.shutdown()
+    Await.result(env.awaitTermination(1.hour, Scheduler.global), Duration.Inf)
   }
 
   test("should not lose events, test 1") { implicit s =>

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyUnboundedConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyUnboundedConcurrencySuite.scala
@@ -72,7 +72,7 @@ object OverflowStrategyUnboundedConcurrencySuite extends TestSuite[Scheduler] {
     for (i <- 0 until 100000) buffer.onNext(i)
     buffer.onComplete()
 
-    assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
+    assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
     assertEquals(number, 100000)
   }
 
@@ -104,7 +104,7 @@ object OverflowStrategyUnboundedConcurrencySuite extends TestSuite[Scheduler] {
       else buffer.onComplete()
 
     loop(10000)
-    assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
+    assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
     assertEquals(number, 10000)
   }
 
@@ -146,7 +146,7 @@ object OverflowStrategyUnboundedConcurrencySuite extends TestSuite[Scheduler] {
       for (i <- 1 to total.toInt) buffer.onNext(i)
       buffer.onComplete()
 
-      assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
+      assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
       assertEquals(received, total)
       assertEquals(sum, total * (total + 1) / 2)
     }
@@ -192,7 +192,7 @@ object OverflowStrategyUnboundedConcurrencySuite extends TestSuite[Scheduler] {
     // Final event
     Future.sequence(Seq(p1,p2,p3,p4)).foreach(_ => buffer.onComplete())
 
-    assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
+    assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
     assertEquals(sum, total * (total - 1) / 2)
   }
 
@@ -210,7 +210,7 @@ object OverflowStrategyUnboundedConcurrencySuite extends TestSuite[Scheduler] {
     val buffer = BufferedSubscriber[Int](Subscriber(underlying, s), Unbounded)
 
     buffer.onError(new RuntimeException("dummy"))
-    assert(latch.await(60, TimeUnit.SECONDS), "latch.await should have succeeded")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onError when in flight") { implicit s =>
@@ -228,7 +228,7 @@ object OverflowStrategyUnboundedConcurrencySuite extends TestSuite[Scheduler] {
 
     buffer.onNext(1)
     buffer.onError(new RuntimeException("dummy"))
-    assert(latch.await(60, TimeUnit.SECONDS), "latch.await should have succeeded")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onComplete when empty") { implicit s =>
@@ -242,7 +242,7 @@ object OverflowStrategyUnboundedConcurrencySuite extends TestSuite[Scheduler] {
     val buffer = BufferedSubscriber[Int](Subscriber(underlying, s), Unbounded)
 
     buffer.onComplete()
-    assert(latch.await(60, TimeUnit.SECONDS), "latch.await should have succeeded")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should not back-pressure onComplete") { implicit s =>
@@ -258,7 +258,7 @@ object OverflowStrategyUnboundedConcurrencySuite extends TestSuite[Scheduler] {
 
     buffer.onNext(1)
     buffer.onComplete()
-    assert(latch.await(60, TimeUnit.SECONDS), "latch.await should have succeeded")
+    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should do onComplete only after all the queue was drained") { implicit s =>
@@ -280,7 +280,7 @@ object OverflowStrategyUnboundedConcurrencySuite extends TestSuite[Scheduler] {
     buffer.onComplete()
     startConsuming.success(Continue)
 
-    assert(complete.await(60, TimeUnit.SECONDS), "complete.await should have succeeded")
+    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
     assert(sum == (0 until 9999).sum)
   }
 
@@ -301,7 +301,7 @@ object OverflowStrategyUnboundedConcurrencySuite extends TestSuite[Scheduler] {
     (0 until 9999).foreach(x => buffer.onNext(x))
     buffer.onComplete()
 
-    assert(complete.await(60, TimeUnit.SECONDS), "complete.await should have succeeded")
+    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
     assert(sum == (0 until 9999).sum)
   }
 
@@ -325,7 +325,7 @@ object OverflowStrategyUnboundedConcurrencySuite extends TestSuite[Scheduler] {
     buffer.onError(new RuntimeException)
     startConsuming.success(Continue)
 
-    assert(complete.await(60, TimeUnit.SECONDS), "complete.await should have succeeded")
+    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
     assertEquals(sum, (0 until 9999).sum)
   }
 
@@ -346,7 +346,7 @@ object OverflowStrategyUnboundedConcurrencySuite extends TestSuite[Scheduler] {
     (0 until 9999).foreach(x => buffer.onNext(x))
     buffer.onError(new RuntimeException)
 
-    assert(complete.await(60, TimeUnit.SECONDS), "complete.await should have succeeded")
+    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
     assertEquals(sum, (0 until 9999).sum)
   }
 }

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyUnboundedConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyUnboundedConcurrencySuite.scala
@@ -72,7 +72,7 @@ object OverflowStrategyUnboundedConcurrencySuite extends TestSuite[Scheduler] {
     for (i <- 0 until 100000) buffer.onNext(i)
     buffer.onComplete()
 
-    assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
+    assert(completed.await(15, TimeUnit.MINUTES), "completed.await should have succeeded")
     assertEquals(number, 100000)
   }
 
@@ -104,7 +104,7 @@ object OverflowStrategyUnboundedConcurrencySuite extends TestSuite[Scheduler] {
       else buffer.onComplete()
 
     loop(10000)
-    assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
+    assert(completed.await(15, TimeUnit.MINUTES), "completed.await should have succeeded")
     assertEquals(number, 10000)
   }
 
@@ -146,7 +146,7 @@ object OverflowStrategyUnboundedConcurrencySuite extends TestSuite[Scheduler] {
       for (i <- 1 to total.toInt) buffer.onNext(i)
       buffer.onComplete()
 
-      assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
+      assert(completed.await(15, TimeUnit.MINUTES), "completed.await should have succeeded")
       assertEquals(received, total)
       assertEquals(sum, total * (total + 1) / 2)
     }
@@ -192,7 +192,7 @@ object OverflowStrategyUnboundedConcurrencySuite extends TestSuite[Scheduler] {
     // Final event
     Future.sequence(Seq(p1,p2,p3,p4)).foreach(_ => buffer.onComplete())
 
-    assert(completed.await(5, TimeUnit.MINUTES), "completed.await should have succeeded")
+    assert(completed.await(15, TimeUnit.MINUTES), "completed.await should have succeeded")
     assertEquals(sum, total * (total - 1) / 2)
   }
 
@@ -210,7 +210,7 @@ object OverflowStrategyUnboundedConcurrencySuite extends TestSuite[Scheduler] {
     val buffer = BufferedSubscriber[Int](Subscriber(underlying, s), Unbounded)
 
     buffer.onError(new RuntimeException("dummy"))
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onError when in flight") { implicit s =>
@@ -228,7 +228,7 @@ object OverflowStrategyUnboundedConcurrencySuite extends TestSuite[Scheduler] {
 
     buffer.onNext(1)
     buffer.onError(new RuntimeException("dummy"))
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should send onComplete when empty") { implicit s =>
@@ -242,7 +242,7 @@ object OverflowStrategyUnboundedConcurrencySuite extends TestSuite[Scheduler] {
     val buffer = BufferedSubscriber[Int](Subscriber(underlying, s), Unbounded)
 
     buffer.onComplete()
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should not back-pressure onComplete") { implicit s =>
@@ -258,7 +258,7 @@ object OverflowStrategyUnboundedConcurrencySuite extends TestSuite[Scheduler] {
 
     buffer.onNext(1)
     buffer.onComplete()
-    assert(latch.await(5, TimeUnit.MINUTES), "latch.await should have succeeded")
+    assert(latch.await(15, TimeUnit.MINUTES), "latch.await should have succeeded")
   }
 
   test("should do onComplete only after all the queue was drained") { implicit s =>
@@ -280,7 +280,7 @@ object OverflowStrategyUnboundedConcurrencySuite extends TestSuite[Scheduler] {
     buffer.onComplete()
     startConsuming.success(Continue)
 
-    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
+    assert(complete.await(15, TimeUnit.MINUTES), "complete.await should have succeeded")
     assert(sum == (0 until 9999).sum)
   }
 
@@ -301,7 +301,7 @@ object OverflowStrategyUnboundedConcurrencySuite extends TestSuite[Scheduler] {
     (0 until 9999).foreach(x => buffer.onNext(x))
     buffer.onComplete()
 
-    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
+    assert(complete.await(15, TimeUnit.MINUTES), "complete.await should have succeeded")
     assert(sum == (0 until 9999).sum)
   }
 
@@ -325,7 +325,7 @@ object OverflowStrategyUnboundedConcurrencySuite extends TestSuite[Scheduler] {
     buffer.onError(new RuntimeException)
     startConsuming.success(Continue)
 
-    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
+    assert(complete.await(15, TimeUnit.MINUTES), "complete.await should have succeeded")
     assertEquals(sum, (0 until 9999).sum)
   }
 
@@ -346,7 +346,7 @@ object OverflowStrategyUnboundedConcurrencySuite extends TestSuite[Scheduler] {
     (0 until 9999).foreach(x => buffer.onNext(x))
     buffer.onError(new RuntimeException)
 
-    assert(complete.await(5, TimeUnit.MINUTES), "complete.await should have succeeded")
+    assert(complete.await(15, TimeUnit.MINUTES), "complete.await should have succeeded")
     assertEquals(sum, (0 until 9999).sum)
   }
 }

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyUnboundedConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyUnboundedConcurrencySuite.scala
@@ -72,7 +72,7 @@ object OverflowStrategyUnboundedConcurrencySuite extends TestSuite[Scheduler] {
     for (i <- 0 until 100000) buffer.onNext(i)
     buffer.onComplete()
 
-    assert(completed.await(60, TimeUnit.SECONDS), "completed.await should have succeeded")
+    assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
     assertEquals(number, 100000)
   }
 
@@ -104,7 +104,7 @@ object OverflowStrategyUnboundedConcurrencySuite extends TestSuite[Scheduler] {
       else buffer.onComplete()
 
     loop(10000)
-    assert(completed.await(60, TimeUnit.SECONDS), "completed.await should have succeeded")
+    assert(completed.await(120, TimeUnit.SECONDS), "completed.await should have succeeded")
     assertEquals(number, 10000)
   }
 

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/subjects/ReplaySubjectConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/subjects/ReplaySubjectConcurrencySuite.scala
@@ -56,6 +56,6 @@ object ReplaySubjectConcurrencySuite extends TestSuite[Scheduler] {
     for (_ <- 0 until (nrOfSubscribers - 2))
       s.execute(RunnableAction(subject.unsafeSubscribeFn(createObserver)))
 
-    assert(completed.await(5, TimeUnit.MINUTES), "completed.await")
+    assert(completed.await(15, TimeUnit.MINUTES), "completed.await")
   }
 }

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/subjects/ReplaySubjectConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/subjects/ReplaySubjectConcurrencySuite.scala
@@ -56,6 +56,6 @@ object ReplaySubjectConcurrencySuite extends TestSuite[Scheduler] {
     for (_ <- 0 until (nrOfSubscribers - 2))
       s.execute(RunnableAction(subject.unsafeSubscribeFn(createObserver)))
 
-    assert(completed.await(120, TimeUnit.SECONDS), "completed.await")
+    assert(completed.await(5, TimeUnit.MINUTES), "completed.await")
   }
 }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EvalOnCompleteOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EvalOnCompleteOperator.scala
@@ -17,7 +17,7 @@
 
 package monix.reactive.internal.operators
 
-import monix.eval.{Coeval, Task}
+import monix.eval.Task
 import monix.execution.Ack
 import monix.reactive.observables.ObservableLike.Operator
 import monix.reactive.observers.Subscriber
@@ -34,10 +34,10 @@ class EvalOnCompleteOperator[A](task: Task[Unit]) extends Operator[A,A] {
       def onError(ex: Throwable): Unit = out.onError(ex)
 
       def onComplete(): Unit =
-        task.materializeAttempt.foreach {
-          case Coeval.Now(()) =>
+        task.attempt.foreach {
+          case Right(()) =>
             out.onComplete()
-          case Coeval.Error(ex) =>
+          case Left(ex) =>
             out.onError(ex)
         }
     }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EvalOnErrorOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EvalOnErrorOperator.scala
@@ -17,12 +17,11 @@
 
 package monix.reactive.internal.operators
 
-import monix.eval.{Coeval, Task}
+import monix.eval.Task
 import monix.execution.Ack
 import monix.execution.misc.NonFatal
 import monix.reactive.observables.ObservableLike.Operator
 import monix.reactive.observers.Subscriber
-
 import scala.concurrent.Future
 
 private[reactive] final
@@ -38,10 +37,10 @@ class EvalOnErrorOperator[A](cb: Throwable => Task[Unit]) extends Operator[A,A] 
       def onError(ex: Throwable): Unit = {
         try {
           val task = try cb(ex) catch { case NonFatal(err) => Task.raiseError(err) }
-          task.materializeAttempt.foreach {
-            case Coeval.Now(()) =>
+          task.attempt.foreach {
+            case Right(()) =>
               out.onError(ex)
-            case Coeval.Error(err) =>
+            case Left(err) =>
               scheduler.reportFailure(err)
               out.onError(ex)
           }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EvalOnTerminateOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EvalOnTerminateOperator.scala
@@ -17,15 +17,14 @@
 
 package monix.reactive.internal.operators
 
-import monix.eval.{Callback, Coeval, Task}
+import monix.eval.{Callback, Task}
 import monix.execution.Ack
 import monix.execution.Ack.{Continue, Stop}
 import monix.execution.atomic.Atomic
 import monix.execution.misc.NonFatal
+import monix.reactive.internal.util.Instances._
 import monix.reactive.observables.ObservableLike.Operator
 import monix.reactive.observers.Subscriber
-import monix.reactive.internal.util.Instances._
-
 import scala.concurrent.Future
 import scala.util.Success
 
@@ -45,14 +44,14 @@ class EvalOnTerminateOperator[A](onTerminate: Option[Throwable] => Task[Unit], h
           try out.onNext(elem)
           catch { case NonFatal(ex) => Future.failed(ex) }
 
-        val task = Task.fromFuture(result).materializeAttempt.flatMap {
-          case Coeval.Now(ack) =>
+        val task = Task.fromFuture(result).attempt.flatMap {
+          case Right(ack) =>
             ack match {
               case Continue => ContinueTask
               case Stop =>
                 onTerminate(None).map(_ => Stop)
             }
-          case Coeval.Error(ex) =>
+          case Left(ex) =>
             onError(ex)
             onTerminate(Some(ex)).map(_ => Stop)
         }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapAsyncParallelObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapAsyncParallelObservable.scala
@@ -17,7 +17,6 @@
 
 package monix.reactive.internal.operators
 
-import monix.eval.Coeval.{Error, Now}
 import monix.eval.{Callback, Task}
 import monix.execution.Ack.{Continue, Stop}
 import monix.execution.cancelables.{CompositeCancelable, SingleAssignmentCancelable}
@@ -27,7 +26,6 @@ import monix.execution.{Ack, Cancelable}
 import monix.reactive.Observable
 import monix.reactive.OverflowStrategy.BackPressure
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
-
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
@@ -104,25 +102,25 @@ private[reactive] final class MapAsyncParallelObservable[A,B]
         composite += subscription
 
         val task = {
-          val ref = f(elem).materializeAttempt.map {
-            case Now(value) =>
-              buffer.onNext(value).syncOnComplete {
-                case Success(Stop) =>
-                  lastAck = Stop
-                  composite.cancel()
-                case Success(Continue) =>
-                  semaphore.release()
-                  composite -= subscription
-                case Failure(ex) =>
-                  lastAck = Stop
-                  composite -= subscription
-                  self.onError(ex)
-              }
-            case Error(ex) =>
+          val ref = f(elem).transform(
+            value => buffer.onNext(value).syncOnComplete {
+              case Success(Stop) =>
+                lastAck = Stop
+                composite.cancel()
+              case Success(Continue) =>
+                semaphore.release()
+                composite -= subscription
+              case Failure(ex) =>
+                lastAck = Stop
+                composite -= subscription
+                self.onError(ex)
+            },
+            error => {
               lastAck = Stop
               composite -= subscription
-              self.onError(ex)
-          }
+              self.onError(error)
+            }
+          )
 
           ref.doOnCancel(releaseTask)
         }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observables/ObservableLike.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observables/ObservableLike.scala
@@ -1003,8 +1003,8 @@ trait ObservableLike[+A, Self[+T] <: ObservableLike[T, Self]]
     findF(p).foldLeftF(false)((_, _) => true)
 
   /** Returns an observable that emits a single Throwable, in case an
-    * error was thrown by the source, otherwise it isn't
-    * going to emit anything.
+    * error was thrown by the source, otherwise it isn't going to emit
+    * anything.
     */
   def failed: Self[Throwable] =
     self.liftByOperator(FailedOperator)

--- a/monix-types/shared/src/main/scala/monix/types/MonadError.scala
+++ b/monix-types/shared/src/main/scala/monix/types/MonadError.scala
@@ -54,7 +54,7 @@ trait MonadError[F[_], E] extends Serializable with Monad.Type[F] {
   /** Recover from certain errors by mapping them to an `A` value. */
   def onErrorRecover[A](fa: F[A])(pf: PartialFunction[E, A]): F[A]
 
-  /** Handle errors by exposing them into [[scala.util.Either]] values.
+  /** Handle errors by exposing them into `Either` values.
     *
     * Returns `Right(value)` for successful values or `Left(error)` in
     * case a failure happened.

--- a/monix-types/shared/src/main/scala/monix/types/utils/Macros.scala
+++ b/monix-types/shared/src/main/scala/monix/types/utils/Macros.scala
@@ -130,6 +130,19 @@ import scala.reflect.macros.whitebox
         """
     })
 
+  def monadErrorAttempt: Tree =
+    reset(getImplicitCallParams("MonadError.Syntax", "monadErrorOps", c.prefix.tree) match {
+      case Some((valueExpr, monadErrorExpr)) =>
+        q"($monadErrorExpr).attempt($valueExpr)"
+      case None =>
+        val prefix = c.prefix.tree
+        val ops = TermName(c.freshName("ops$"))
+        q"""
+        val $ops = $prefix
+        $ops.F.attempt(($ops).self)
+        """
+    })
+
   def monadFilter(f: Tree): Tree =
     reset(getImplicitCallParams("MonadFilter.Syntax", "monadFilterOps", c.prefix.tree) match {
       case Some((valueExpr, monadFilterExpr)) =>

--- a/monix-types/shared/src/test/scala/monix/types/tests/MonadErrorLawsSuite.scala
+++ b/monix-types/shared/src/test/scala/monix/types/tests/MonadErrorLawsSuite.scala
@@ -49,7 +49,8 @@ trait MonadErrorLawsSuite[F[_],A,B,C,E] extends MonadLawsSuite[F,A,B,C] {
     arbitraryFBtoC: Arbitrary[F[B => C]],
     eqFA: Eq[F[A]],
     eqFB: Eq[F[B]],
-    eqFC: Eq[F[C]]): Unit = {
+    eqFC: Eq[F[C]],
+    eqFEitherEA: Eq[F[Either[E, A]]]): Unit = {
 
     if (includeSupertypes) monadCheck(typeName, includeSupertypes)
 
@@ -91,6 +92,14 @@ trait MonadErrorLawsSuite[F[_],A,B,C,E] extends MonadLawsSuite[F,A,B,C] {
     test(s"MonadError[$typeName].recoverConsistentWithRecoverWith") {
       check2((fa: F[A], pf: PartialFunction[E, A]) =>
         monadErrorLaws.recoverConsistentWithRecoverWith(fa, pf))
+    }
+
+    test(s"MonadError[$typeName].raiseErrorAttempt") {
+      check1 { (e: E) => monadErrorLaws.raiseErrorAttempt[A](e) }
+    }
+
+    test(s"MonadError[$typeName].pureAttempt") {
+      check1 { (a: A) => monadErrorLaws.pureAttempt(a) }
     }
   }
 }


### PR DESCRIPTION
Issues: 

- [#354](https://github.com/monix/monix/issues/354): Enable Mima and Unidoc error reporting in Travis build
- [#355](https://github.com/monix/monix/issues/355): Add `Coeval#run`
- [#356](https://github.com/monix/monix/issues/356): Add `Task#attempt` and `Coeval#attempt`
- [#358](https://github.com/monix/monix/issues/358): Deprecate `materializeAttempt` and `dematerializeAttempt` on `Task` and `Coeval` 
- [#359](https://github.com/monix/monix/issues/359): Rename `Coeval.Attempt#isFailure` to `Coeval.Attempt#isError`