### PR TITLE
Replace [T] generic param to [A], as a convention, everywhere

### DIFF
--- a/monix-eval/shared/src/main/scala/monix/eval/Callback.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Callback.scala
@@ -30,23 +30,23 @@ import scala.util.{Failure, Success, Try}
   * The `onSuccess` method should be called only once, with the successful
   * result, whereas `onError` should be called if the result is an error.
   */
-abstract class Callback[-T] extends Listener[T] with ((Try[T]) => Unit) {
-  def onSuccess(value: T): Unit
+abstract class Callback[-A] extends Listener[A] with ((Try[A]) => Unit) {
+  def onSuccess(value: A): Unit
   def onError(ex: Throwable): Unit
 
   /** An alias for [[onSuccess]], inherited
     * from [[monix.execution.Listener]].
     */
-  final def onValue(value: T): Unit =
+  final def onValue(value: A): Unit =
     onSuccess(value)
 
-  final def apply(result: Try[T]): Unit =
+  final def apply(result: Try[A]): Unit =
     result match {
       case Success(value) => onSuccess(value)
       case Failure(ex) => onError(ex)
     }
 
-  final def apply(result: Coeval[T]): Unit =
+  final def apply(result: Coeval[A]): Unit =
     result.runAttempt match {
       case Coeval.Now(value) => onSuccess(value)
       case Coeval.Error(ex) => onError(ex)
@@ -58,18 +58,18 @@ object Callback {
     * protects against grammar violations (e.g. `onSuccess` or `onError`
     * must be called at most once). For usage in `runAsync`.
     */
-  def safe[T](cb: Callback[T])
-    (implicit r: UncaughtExceptionReporter): Callback[T] =
+  def safe[A](cb: Callback[A])
+    (implicit r: UncaughtExceptionReporter): Callback[A] =
     cb match {
       case _: SafeCallback[_] => cb
-      case _ => new SafeCallback[T](cb)
+      case _ => new SafeCallback[A](cb)
     }
 
   /** Creates an empty [[Callback]], a callback that doesn't do
     * anything in `onNext` and that logs errors in `onError` with
     * the provided [[monix.execution.UncaughtExceptionReporter]].
     */
-  def empty[T](implicit r: UncaughtExceptionReporter): Callback[T] =
+  def empty[A](implicit r: UncaughtExceptionReporter): Callback[A] =
     new EmptyCallback(r)
 
   /** Returns a [[Callback]] instance that will complete the given
@@ -126,14 +126,14 @@ object Callback {
   /** A `SafeCallback` is a callback that ensures it can only be called
     * once, with a simple check.
     */
-  private final class SafeCallback[-T](underlying: Callback[T])
+  private final class SafeCallback[-A](underlying: Callback[A])
     (implicit r: UncaughtExceptionReporter)
-    extends Callback[T] {
+    extends Callback[A] {
 
     private[this] var isActive = true
 
     /** To be called only once, on successful completion of a [[monix.eval.Task Task]] */
-    def onSuccess(value: T): Unit =
+    def onSuccess(value: A): Unit =
       if (isActive) {
         isActive = false
         try underlying.onSuccess(value) catch {

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicAny.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicAny.scala
@@ -19,19 +19,19 @@ package monix.execution.atomic
 
 /** Atomic references wrapping `AnyRef` values.
   *
-  * @tparam T is forced to be an `AnyRef` because the equality test is
+  * @tparam A is forced to be an `AnyRef` because the equality test is
   *         by reference and not by value.
   */
-final class AtomicAny[T <: AnyRef] private[atomic] (initialValue: T) extends Atomic[T] {
+final class AtomicAny[A <: AnyRef] private[atomic] (initialValue: A) extends Atomic[A] {
   private[this] var ref = initialValue
 
-  def getAndSet(update: T): T = {
+  def getAndSet(update: A): A = {
     val current = ref
     ref = update
     current
   }
 
-  def compareAndSet(expect: T, update: T): Boolean = {
+  def compareAndSet(expect: A, update: A): Boolean = {
     if (ref eq expect) {
       ref = update
       true
@@ -40,11 +40,11 @@ final class AtomicAny[T <: AnyRef] private[atomic] (initialValue: T) extends Ato
       false
   }
 
-  def set(update: T): Unit = {
+  def set(update: A): Unit = {
     ref = update
   }
 
-  def get: T = ref
+  def get: A = ref
 }
 
 /** @define createDesc Constructs an [[AtomicAny]] reference, allowing

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicBuilder.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicBuilder.scala
@@ -17,7 +17,7 @@
 
 package monix.execution.atomic
 
-/** For a given `T` indicates the most specific `Atomic[T]`
+/** For a given `A` indicates the most specific `Atomic[A]`
   * reference type to use.
   *
   * In essence this is implementing a form of specialization
@@ -48,11 +48,11 @@ private[atomic] object Implicits {
 
   abstract class Level2 extends Level1 {
     /** Provides an [[AtomicBuilder]] instance for [[AtomicNumberAny]]. */
-    implicit def AtomicNumberBuilder[T  <: AnyRef : Numeric]: AtomicBuilder[T, AtomicNumberAny[T]] =
-      new AtomicBuilder[T, AtomicNumberAny[T]] {
-        def buildInstance(initialValue: T, strategy: PaddingStrategy, allowPlatformIntrinsics: Boolean) =
+    implicit def AtomicNumberBuilder[A  <: AnyRef : Numeric]: AtomicBuilder[A, AtomicNumberAny[A]] =
+      new AtomicBuilder[A, AtomicNumberAny[A]] {
+        def buildInstance(initialValue: A, strategy: PaddingStrategy, allowPlatformIntrinsics: Boolean) =
           AtomicNumberAny(initialValue)
-        def buildSafeInstance(initialValue: T, strategy: PaddingStrategy) =
+        def buildSafeInstance(initialValue: A, strategy: PaddingStrategy) =
           AtomicNumberAny(initialValue)
       }
   }

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicNumber.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicNumber.scala
@@ -22,37 +22,37 @@ import scala.language.experimental.macros
 /** Represents an Atomic reference holding a number, providing helpers
   * for easily incrementing and decrementing it.
   *
-  * @tparam T should be something that's Numeric
+  * @tparam A should be something that's Numeric
   */
-abstract class AtomicNumber[T] extends Atomic[T] {
+abstract class AtomicNumber[A] extends Atomic[A] {
   /** Increment with the given integer */
   def increment(v: Int = 1): Unit
   /** Adds to the atomic number the given value. */
-  def add(v: T): Unit
+  def add(v: A): Unit
   /** Adds to the atomic number the given value. Alias for `add`. */
-  final def `-=`(value: T): Unit = macro Atomic.Macros.subtractMacro[T]
+  final def `-=`(value: A): Unit = macro Atomic.Macros.subtractMacro[A]
   /** Decrements the atomic number with the given integer. */
   def decrement(v: Int = 1): Unit
   /** Subtracts from the atomic number the given value. */
-  def subtract(v: T): Unit
+  def subtract(v: A): Unit
   /** Subtracts from the atomic number the given value. Alias for `subtract`. */
-  final def `+=`(value: T): Unit = macro Atomic.Macros.addMacro[T]
+  final def `+=`(value: A): Unit = macro Atomic.Macros.addMacro[A]
 
   /** Increments the atomic number and returns the result. */
-  def incrementAndGet(v: Int = 1): T
+  def incrementAndGet(v: Int = 1): A
   /** Adds to the atomic number and returns the result. */
-  def addAndGet(v: T): T
+  def addAndGet(v: A): A
   /** Decrements the atomic number and returns the result. */
-  def decrementAndGet(v: Int = 1): T
+  def decrementAndGet(v: Int = 1): A
   /** Subtracts from the atomic number and returns the result. */
-  def subtractAndGet(v: T): T
+  def subtractAndGet(v: A): A
 
   /** Increments the atomic number and returns the value before the update. */
-  def getAndIncrement(v: Int = 1): T
+  def getAndIncrement(v: Int = 1): A
   /** Adds to the the atomic number and returns the value before the update. */
-  def getAndAdd(v: T): T
+  def getAndAdd(v: A): A
   /** Decrements the atomic number and returns the value before the update. */
-  def getAndDecrement(v: Int = 1): T
+  def getAndDecrement(v: Int = 1): A
   /** Subtracts from the atomic number and returns the value before the update. */
-  def getAndSubtract(v: T): T
+  def getAndSubtract(v: A): A
 }

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicNumberAny.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicNumberAny.scala
@@ -25,19 +25,19 @@ package monix.execution.atomic
   * of the JVM that's the semantic of `compareAndSet`. This behavior
   * is kept consistent even on top of Scala.js / Javascript.
   */
-final class AtomicNumberAny[T  <: AnyRef : Numeric] private[atomic] (initialValue: T)
-  extends AtomicNumber[T] {
+final class AtomicNumberAny[A  <: AnyRef : Numeric] private[atomic] (initialValue: A)
+  extends AtomicNumber[A] {
 
-  private[this] val ev = implicitly[Numeric[T]]
+  private[this] val ev = implicitly[Numeric[A]]
   private[this] var ref = initialValue
 
-  def getAndSet(update: T): T = {
+  def getAndSet(update: A): A = {
     val current = ref
     ref = update
     current
   }
 
-  def compareAndSet(expect: T, update: T): Boolean = {
+  def compareAndSet(expect: A, update: A): Boolean = {
     if (ref eq expect) {
       ref = update
       true
@@ -46,50 +46,50 @@ final class AtomicNumberAny[T  <: AnyRef : Numeric] private[atomic] (initialValu
       false
   }
 
-  def set(update: T): Unit = {
+  def set(update: A): Unit = {
     ref = update
   }
 
-  def get: T = ref
+  def get: A = ref
 
-  def getAndSubtract(v: T): T = {
+  def getAndSubtract(v: A): A = {
     val c = ref
     ref = ev.minus(ref, v)
     c
   }
 
-  def subtractAndGet(v: T): T = {
+  def subtractAndGet(v: A): A = {
     ref = ev.minus(ref, v)
     ref
   }
 
-  def subtract(v: T): Unit = {
+  def subtract(v: A): Unit = {
     ref = ev.minus(ref, v)
   }
 
-  def getAndAdd(v: T): T = {
+  def getAndAdd(v: A): A = {
     val c = ref
     ref = ev.plus(ref, v)
     c
   }
 
-  def getAndIncrement(v: Int = 1): T = {
+  def getAndIncrement(v: Int = 1): A = {
     val c = ref
     ref = ev.plus(ref, ev.fromInt(v))
     c
   }
 
-  def addAndGet(v: T): T = {
+  def addAndGet(v: A): A = {
     ref = ev.plus(ref, v)
     ref
   }
 
-  def incrementAndGet(v: Int = 1): T = {
+  def incrementAndGet(v: Int = 1): A = {
     ref = ev.plus(ref, ev.fromInt(v))
     ref
   }
 
-  def add(v: T): Unit = {
+  def add(v: A): Unit = {
     ref = ev.plus(ref, v)
   }
 
@@ -98,8 +98,8 @@ final class AtomicNumberAny[T  <: AnyRef : Numeric] private[atomic] (initialValu
   }
 
   def decrement(v: Int = 1): Unit = increment(-v)
-  def decrementAndGet(v: Int = 1): T = incrementAndGet(-v)
-  def getAndDecrement(v: Int = 1): T = getAndIncrement(-v)
+  def decrementAndGet(v: Int = 1): A = incrementAndGet(-v)
+  def getAndDecrement(v: Int = 1): A = getAndIncrement(-v)
 }
 
 /** @define createDesc Constructs an [[AtomicNumberAny]] reference, allowing

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/package.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/package.scala
@@ -31,8 +31,9 @@ package monix.execution
   * the `expect` value, reporting `true` on success or `false` on failure. The classes in this package
   * also contain methods to get and unconditionally set values.
   *
-  * Building a reference is easy with the provided constructor, which will automatically return the
-  * most specific type needed (in the following sample, that's an `AtomicDouble`, inheriting from `AtomicNumber[T]`):
+  * Building a reference is easy with the provided constructor, which will automatically
+  * return the most specific type needed (in the following sample, that's an `AtomicDouble`,
+  * inheriting from `AtomicNumber[A]`):
   * {{{
   *   val atomicNumber = Atomic(12.2)
   *

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/Atomic.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/Atomic.scala
@@ -128,11 +128,11 @@ abstract class Atomic[A] extends Serializable {
 }
 
 object Atomic {
-  /** Constructs an `Atomic[T]` reference.
+  /** Constructs an `Atomic[A]` reference.
     *
     * Based on the `initialValue`, it will return the best, most
     * specific type. E.g. you give it a number, it will return
-    * something inheriting from `AtomicNumber[T]`. That's why it takes
+    * something inheriting from `AtomicNumber[A]`. That's why it takes
     * an `AtomicBuilder[T, R]` as an implicit parameter - but worry
     * not about such details as it just works.
     *
@@ -142,17 +142,17 @@ object Atomic {
     * @param builder is the builder that helps us to build the
     *        best reference possible, based on our `initialValue`
     */
-  def apply[T, R <: Atomic[T]](initialValue: T)(implicit builder: AtomicBuilder[T, R]): R =
-    macro Atomic.Macros.buildAnyMacro[T, R]
+  def apply[A, R <: Atomic[A]](initialValue: A)(implicit builder: AtomicBuilder[A, R]): R =
+    macro Atomic.Macros.buildAnyMacro[A, R]
 
-  /** Constructs an `Atomic[T]` reference, applying the provided
+  /** Constructs an `Atomic[A]` reference, applying the provided
     * [[PaddingStrategy]] in order to counter the "false sharing"
     * problem.
     *
     * Based on the `initialValue`, it will return the best, most
     * specific type. E.g. you give it a number, it will return
-    * something inheriting from `AtomicNumber[T]`. That's why it takes
-    * an `AtomicBuilder[T, R]` as an implicit parameter - but worry
+    * something inheriting from `AtomicNumber[A]`. That's why it takes
+    * an `AtomicBuilder[A, R]` as an implicit parameter - but worry
     * not about such details as it just works.
     *
     * Note that for ''Scala.js'' we aren't applying any padding, as it
@@ -169,13 +169,13 @@ object Atomic {
     * @param builder is the builder that helps us to build the
     *        best reference possible, based on our `initialValue`
     */
-  def withPadding[T, R <: Atomic[T]](initialValue: T, padding: PaddingStrategy)(implicit builder: AtomicBuilder[T, R]): R =
-    macro Atomic.Macros.buildAnyWithPaddingMacro[T, R]
+  def withPadding[A, R <: Atomic[A]](initialValue: A, padding: PaddingStrategy)(implicit builder: AtomicBuilder[A, R]): R =
+    macro Atomic.Macros.buildAnyWithPaddingMacro[A, R]
 
   /** Returns the builder that would be chosen to construct Atomic
     * references for the given `initialValue`.
     */
-  def builderFor[T, R <: Atomic[T]](initialValue: T)(implicit builder: AtomicBuilder[T, R]): AtomicBuilder[T, R] =
+  def builderFor[A, R <: Atomic[A]](initialValue: A)(implicit builder: AtomicBuilder[A, R]): AtomicBuilder[A, R] =
     builder
 
   /** Macros implementations for the [[Atomic]] type */
@@ -183,8 +183,8 @@ object Atomic {
   class Macros(override val c: whitebox.Context) extends HygieneUtilMacros with InlineMacros {
     import c.universe._
 
-    def transformMacro[T : c.WeakTypeTag](cb: c.Expr[T => T]): c.Expr[Unit] = {
-      val selfExpr = c.Expr[Atomic[T]](c.prefix.tree)
+    def transformMacro[A : c.WeakTypeTag](cb: c.Expr[A => A]): c.Expr[Unit] = {
+      val selfExpr = c.Expr[Atomic[A]](c.prefix.tree)
       val self = util.name("self")
       val current = util.name("current")
       val update = util.name("update")
@@ -224,8 +224,8 @@ object Atomic {
       inlineAndReset[Unit](tree)
     }
 
-    def transformAndGetMacro[T : c.WeakTypeTag](cb: c.Expr[T => T]): c.Expr[T] = {
-      val selfExpr = c.Expr[Atomic[T]](c.prefix.tree)
+    def transformAndGetMacro[A : c.WeakTypeTag](cb: c.Expr[A => A]): c.Expr[A] = {
+      val selfExpr = c.Expr[Atomic[A]](c.prefix.tree)
       val self = util.name("self")
       val current = util.name("current")
       val update = util.name("update")
@@ -264,11 +264,11 @@ object Atomic {
           """
         }
 
-      inlineAndReset[T](tree)
+      inlineAndReset[A](tree)
     }
 
-    def getAndTransformMacro[T : c.WeakTypeTag](cb: c.Expr[T => T]): c.Expr[T] = {
-      val selfExpr = c.Expr[Atomic[T]](c.prefix.tree)
+    def getAndTransformMacro[A : c.WeakTypeTag](cb: c.Expr[A => A]): c.Expr[A] = {
+      val selfExpr = c.Expr[Atomic[A]](c.prefix.tree)
       val self = util.name("self")
       val current = util.name("current")
       val update = util.name("update")
@@ -307,7 +307,7 @@ object Atomic {
           """
         }
 
-      inlineAndReset[T](tree)
+      inlineAndReset[A](tree)
     }
 
     def transformAndExtractMacro[S : c.WeakTypeTag, A : c.WeakTypeTag]
@@ -363,9 +363,9 @@ object Atomic {
       inlineAndReset[A](tree)
     }
 
-    def buildAnyMacro[T : c.WeakTypeTag, R <: Atomic[T] : c.WeakTypeTag]
-      (initialValue: c.Expr[T])
-      (builder: c.Expr[AtomicBuilder[T, R]]): c.Expr[R] = {
+    def buildAnyMacro[A : c.WeakTypeTag, R <: Atomic[A] : c.WeakTypeTag]
+      (initialValue: c.Expr[A])
+      (builder: c.Expr[AtomicBuilder[A, R]]): c.Expr[R] = {
 
       val expr = reify {
         builder.splice.buildInstance(
@@ -377,9 +377,9 @@ object Atomic {
       inlineAndReset[R](expr.tree)
     }
 
-    def buildAnyWithPaddingMacro[T : c.WeakTypeTag, R <: Atomic[T] : c.WeakTypeTag]
-      (initialValue: c.Expr[T], padding: c.Expr[PaddingStrategy])
-      (builder: c.Expr[AtomicBuilder[T, R]]): c.Expr[R] = {
+    def buildAnyWithPaddingMacro[A : c.WeakTypeTag, R <: Atomic[A] : c.WeakTypeTag]
+      (initialValue: c.Expr[A], padding: c.Expr[PaddingStrategy])
+      (builder: c.Expr[AtomicBuilder[A, R]]): c.Expr[R] = {
 
       val expr = reify {
         builder.splice.buildInstance(
@@ -391,26 +391,26 @@ object Atomic {
       inlineAndReset[R](expr.tree)
     }
 
-    def applyMacro[T : c.WeakTypeTag](): c.Expr[T] = {
-      val selfExpr = c.Expr[Atomic[T]](c.prefix.tree)
+    def applyMacro[A : c.WeakTypeTag](): c.Expr[A] = {
+      val selfExpr = c.Expr[Atomic[A]](c.prefix.tree)
       val tree = q"""$selfExpr.get"""
-      inlineAndReset[T](tree)
+      inlineAndReset[A](tree)
     }
 
-    def setMacro[T : c.WeakTypeTag](value: c.Expr[T]): c.Expr[Unit] = {
-      val selfExpr = c.Expr[Atomic[T]](c.prefix.tree)
+    def setMacro[A : c.WeakTypeTag](value: c.Expr[A]): c.Expr[Unit] = {
+      val selfExpr = c.Expr[Atomic[A]](c.prefix.tree)
       val tree = q"""$selfExpr.set($value)"""
       inlineAndReset[Unit](tree)
     }
 
-    def addMacro[T : c.WeakTypeTag](value: c.Expr[T]): c.Expr[Unit] = {
-      val selfExpr = c.Expr[Atomic[T]](c.prefix.tree)
+    def addMacro[A : c.WeakTypeTag](value: c.Expr[A]): c.Expr[Unit] = {
+      val selfExpr = c.Expr[Atomic[A]](c.prefix.tree)
       val tree = q"""$selfExpr.add($value)"""
       inlineAndReset[Unit](tree)
     }
 
-    def subtractMacro[T : c.WeakTypeTag](value: c.Expr[T]): c.Expr[Unit] = {
-      val selfExpr = c.Expr[Atomic[T]](c.prefix.tree)
+    def subtractMacro[A : c.WeakTypeTag](value: c.Expr[A]): c.Expr[Unit] = {
+      val selfExpr = c.Expr[Atomic[A]](c.prefix.tree)
       val tree = q"""$selfExpr.subtract($value)"""
       inlineAndReset[Unit](tree)
     }

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicAny.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicAny.scala
@@ -22,20 +22,20 @@ import monix.execution.internals.atomic.{BoxedObject, Factory}
 
 /** Atomic references wrapping `AnyRef` values.
   *
-  * @tparam T is forced to be an `AnyRef` because the equality test is
+  * @tparam A is forced to be an `AnyRef` because the equality test is
   *         by reference and not by value.
   */
-final class AtomicAny[T <: AnyRef] private (private[this] val ref: BoxedObject) extends Atomic[T] {
-  def get: T = ref.volatileGet().asInstanceOf[T]
-  def set(update: T): Unit = ref.volatileSet(update)
+final class AtomicAny[A <: AnyRef] private (private[this] val ref: BoxedObject) extends Atomic[A] {
+  def get: A = ref.volatileGet().asInstanceOf[A]
+  def set(update: A): Unit = ref.volatileSet(update)
 
-  def compareAndSet(expect: T, update: T): Boolean =
+  def compareAndSet(expect: A, update: A): Boolean =
     ref.compareAndSet(expect, update)
 
-  def getAndSet(update: T): T =
-    ref.getAndSet(update).asInstanceOf[T]
+  def getAndSet(update: A): A =
+    ref.getAndSet(update).asInstanceOf[A]
 
-  def lazySet(update: T): Unit =
+  def lazySet(update: A): Unit =
     ref.lazySet(update)
 }
 

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicNumber.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicNumber.scala
@@ -22,37 +22,37 @@ import scala.language.experimental.macros
 /** Represents an Atomic reference holding a number, providing helpers
   * for easily incrementing and decrementing it.
   *
-  * @tparam T should be something that's Numeric
+  * @tparam A should be something that's Numeric
   */
-abstract class AtomicNumber[T] extends Atomic[T] {
+abstract class AtomicNumber[A] extends Atomic[A] {
   /** Increment with the given integer */
   def increment(v: Int = 1): Unit
   /** Adds to the atomic number the given value. */
-  def add(v: T): Unit
+  def add(v: A): Unit
   /** Adds to the atomic number the given value. Alias for `add`. */
-  final def `-=`(value: T): Unit = macro Atomic.Macros.subtractMacro[T]
+  final def `-=`(value: A): Unit = macro Atomic.Macros.subtractMacro[A]
   /** Decrements the atomic number with the given integer. */
   def decrement(v: Int = 1): Unit
   /** Subtracts from the atomic number the given value. */
-  def subtract(v: T): Unit
+  def subtract(v: A): Unit
   /** Subtracts from the atomic number the given value. Alias for `subtract`. */
-  final def `+=`(value: T): Unit = macro Atomic.Macros.addMacro[T]
+  final def `+=`(value: A): Unit = macro Atomic.Macros.addMacro[A]
 
   /** Increments the atomic number and returns the result. */
-  def incrementAndGet(v: Int = 1): T
+  def incrementAndGet(v: Int = 1): A
   /** Adds to the atomic number and returns the result. */
-  def addAndGet(v: T): T
+  def addAndGet(v: A): A
   /** Decrements the atomic number and returns the result. */
-  def decrementAndGet(v: Int = 1): T
+  def decrementAndGet(v: Int = 1): A
   /** Subtracts from the atomic number and returns the result. */
-  def subtractAndGet(v: T): T
+  def subtractAndGet(v: A): A
 
   /** Increments the atomic number and returns the value before the update. */
-  def getAndIncrement(v: Int = 1): T
+  def getAndIncrement(v: Int = 1): A
   /** Adds to the the atomic number and returns the value before the update. */
-  def getAndAdd(v: T): T
+  def getAndAdd(v: A): A
   /** Decrements the atomic number and returns the value before the update. */
-  def getAndDecrement(v: Int = 1): T
+  def getAndDecrement(v: Int = 1): A
   /** Subtracts from the atomic number and returns the value before the update. */
-  def getAndSubtract(v: T): T
+  def getAndSubtract(v: A): A
 }

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicNumberAny.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicNumberAny.scala
@@ -30,23 +30,23 @@ import scala.annotation.tailrec
   * of the JVM that's the semantic of `compareAndSet`. This behavior
   * is kept consistent even on top of Scala.js / Javascript.
   */
-final class AtomicNumberAny[T <: AnyRef : Numeric] private (private[this] val ref: BoxedObject)
-  extends AtomicNumber[T] {
+final class AtomicNumberAny[A <: AnyRef : Numeric] private (private[this] val ref: BoxedObject)
+  extends AtomicNumber[A] {
 
-  private[this] val ev = implicitly[Numeric[T]]
+  private[this] val ev = implicitly[Numeric[A]]
 
-  def get: T = ref.volatileGet().asInstanceOf[T]
-  def set(update: T): Unit = ref.volatileSet(update)
+  def get: A = ref.volatileGet().asInstanceOf[A]
+  def set(update: A): Unit = ref.volatileSet(update)
 
-  def compareAndSet(expect: T, update: T): Boolean = {
+  def compareAndSet(expect: A, update: A): Boolean = {
     ref.compareAndSet(expect, update)
   }
 
-  def getAndSet(update: T): T = {
-    ref.getAndSet(update).asInstanceOf[T]
+  def getAndSet(update: A): A = {
+    ref.getAndSet(update).asInstanceOf[A]
   }
 
-  def lazySet(update: T): Unit = {
+  def lazySet(update: A): Unit = {
     ref.lazySet(update)
   }
 
@@ -58,7 +58,7 @@ final class AtomicNumberAny[T <: AnyRef : Numeric] private (private[this] val re
   }
 
   @tailrec
-  def incrementAndGet(v: Int = 1): T = {
+  def incrementAndGet(v: Int = 1): A = {
     val current = get
     val update = ev.plus(current, ev.fromInt(v))
     if (!compareAndSet(current, update))
@@ -68,7 +68,7 @@ final class AtomicNumberAny[T <: AnyRef : Numeric] private (private[this] val re
   }
 
   @tailrec
-  def getAndIncrement(v: Int = 1): T = {
+  def getAndIncrement(v: Int = 1): A = {
     val current = get
     val update = ev.plus(current, ev.fromInt(v))
     if (!compareAndSet(current, update))
@@ -78,7 +78,7 @@ final class AtomicNumberAny[T <: AnyRef : Numeric] private (private[this] val re
   }
 
   @tailrec
-  def getAndAdd(v: T): T = {
+  def getAndAdd(v: A): A = {
     val current = get
     val update = ev.plus(current, v)
     if (!compareAndSet(current, update))
@@ -88,7 +88,7 @@ final class AtomicNumberAny[T <: AnyRef : Numeric] private (private[this] val re
   }
 
   @tailrec
-  def addAndGet(v: T): T = {
+  def addAndGet(v: A): A = {
     val current = get
     val update = ev.plus(current, v)
     if (!compareAndSet(current, update))
@@ -98,7 +98,7 @@ final class AtomicNumberAny[T <: AnyRef : Numeric] private (private[this] val re
   }
 
   @tailrec
-  def add(v: T): Unit = {
+  def add(v: A): Unit = {
     val current = get
     val update = ev.plus(current, v)
     if (!compareAndSet(current, update))
@@ -106,7 +106,7 @@ final class AtomicNumberAny[T <: AnyRef : Numeric] private (private[this] val re
   }
 
   @tailrec
-  def subtract(v: T): Unit = {
+  def subtract(v: A): Unit = {
     val current = get
     val update = ev.minus(current, v)
     if (!compareAndSet(current, update))
@@ -114,7 +114,7 @@ final class AtomicNumberAny[T <: AnyRef : Numeric] private (private[this] val re
   }
 
   @tailrec
-  def getAndSubtract(v: T): T = {
+  def getAndSubtract(v: A): A = {
     val current = get
     val update = ev.minus(current, v)
     if (!compareAndSet(current, update))
@@ -124,7 +124,7 @@ final class AtomicNumberAny[T <: AnyRef : Numeric] private (private[this] val re
   }
 
   @tailrec
-  def subtractAndGet(v: T): T = {
+  def subtractAndGet(v: A): A = {
     val current = get
     val update = ev.minus(current, v)
     if (!compareAndSet(current, update))
@@ -134,8 +134,8 @@ final class AtomicNumberAny[T <: AnyRef : Numeric] private (private[this] val re
   }
 
   def decrement(v: Int = 1): Unit = increment(-v)
-  def decrementAndGet(v: Int = 1): T = incrementAndGet(-v)
-  def getAndDecrement(v: Int = 1): T = getAndIncrement(-v)
+  def decrementAndGet(v: Int = 1): A = incrementAndGet(-v)
+  def getAndDecrement(v: Int = 1): A = getAndIncrement(-v)
 }
 
 /** @define createDesc Constructs an [[AtomicNumberAny]] reference, allowing

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/package.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/package.scala
@@ -41,7 +41,7 @@ import monix.execution.internals.atomic.BoxPaddingStrategy
   * Building a reference is easy with the provided constructor, which
   * will automatically return the most specific type needed (in the
   * following sample, that's an `AtomicDouble`, inheriting from
-  * `AtomicNumber[T]`):
+  * `AtomicNumber[A]`):
   *
   * {{{
   *   val atomicNumber = Atomic(12.2)

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/forkJoin/DynamicWorkerThreadFactory.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/forkJoin/DynamicWorkerThreadFactory.scala
@@ -70,7 +70,7 @@ private[monix] final class DynamicWorkerThreadFactory(
         final override def onTermination(exception: Throwable): Unit =
           deregisterThread()
 
-        final override def blockOn[T](thunk: =>T)(implicit permission: CanAwait): T = {
+        final override def blockOn[T](thunk: => T)(implicit permission: CanAwait): T = {
           var result: T = null.asInstanceOf[T]
           ForkJoinPool.managedBlock(new ManagedBlocker {
             @volatile

--- a/monix-execution/jvm/src/test/scala/monix/execution/atomic/ConcurrentAtomicNumberSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/atomic/ConcurrentAtomicNumberSuite.scala
@@ -23,13 +23,13 @@ import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 
-abstract class ConcurrentAtomicNumberSuite[T, R <: AtomicNumber[T]]
-  (builder: AtomicBuilder[T, R], strategy: PaddingStrategy,
-   value: T, nan1: Option[T], maxValue: T, minValue: T,
-   allowPlatformIntrinsics: Boolean)(implicit ev: Numeric[T])
+abstract class ConcurrentAtomicNumberSuite[A, R <: AtomicNumber[A]]
+  (builder: AtomicBuilder[A, R], strategy: PaddingStrategy,
+   value: A, nan1: Option[A], maxValue: A, minValue: A,
+   allowPlatformIntrinsics: Boolean)(implicit ev: Numeric[A])
   extends SimpleTestSuite {
 
-  def Atomic(initial: T): R = builder.buildInstance(initial, strategy, allowPlatformIntrinsics)
+  def Atomic(initial: A): R = builder.buildInstance(initial, strategy, allowPlatformIntrinsics)
 
   val two = ev.plus(ev.one, ev.one)
 

--- a/monix-execution/jvm/src/test/scala/monix/execution/atomic/ConcurrentAtomicSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/atomic/ConcurrentAtomicSuite.scala
@@ -24,13 +24,13 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
 
-abstract class ConcurrentAtomicSuite[T, R <: Atomic[T]](
-  builder: AtomicBuilder[T, R], strategy: PaddingStrategy,
-  valueFromInt: Int => T, valueToInt: T => Int,
+abstract class ConcurrentAtomicSuite[A, R <: Atomic[A]](
+  builder: AtomicBuilder[A, R], strategy: PaddingStrategy,
+  valueFromInt: Int => A, valueToInt: A => Int,
   allowPlatformIntrinsics: Boolean)
   extends SimpleTestSuite {
 
-  def Atomic(initial: T): R = builder.buildInstance(initial, strategy, allowPlatformIntrinsics)
+  def Atomic(initial: A): R = builder.buildInstance(initial, strategy, allowPlatformIntrinsics)
   def zero = valueFromInt(0)
   def one = valueFromInt(1)
   def two = valueFromInt(2)

--- a/monix-execution/shared/src/main/scala/monix/execution/Ack.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/Ack.scala
@@ -143,7 +143,7 @@ object Ack {
     /** If the source completes with a `Stop`, then complete the given
       * promise with a value.
       */
-    def syncOnContinueFollow[T](p: Promise[T], value: T)(implicit s: Scheduler): Self = {
+    def syncOnContinueFollow[A](p: Promise[A], value: A)(implicit s: Scheduler): Self = {
       if (source eq Continue)
         p.trySuccess(value)
       else if (source ne Stop)
@@ -158,7 +158,7 @@ object Ack {
     /** If the source completes with a `Stop`, then complete the given
       * promise with a value.
       */
-    def syncOnStopFollow[T](p: Promise[T], value: T)(implicit s: Scheduler): Self = {
+    def syncOnStopFollow[A](p: Promise[A], value: A)(implicit s: Scheduler): Self = {
       if (source eq Stop)
         p.trySuccess(value)
       else if (source ne Continue)

--- a/monix-execution/shared/src/main/scala/monix/execution/CancelableFuture.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/CancelableFuture.scala
@@ -25,40 +25,40 @@ import scala.util.{Failure, Success, Try}
 /** Represents an asynchronous computation that can be canceled
   * as long as it isn't complete.
   */
-trait CancelableFuture[+T] extends Future[T] with Cancelable {
+trait CancelableFuture[+A] extends Future[A] with Cancelable {
   // Overriding methods for getting CancelableFuture in return
 
   override def failed: CancelableFuture[Throwable] =
     CancelableFuture(super.failed, this)
-  override def transform[S](s: (T) => S, f: (Throwable) => Throwable)(implicit executor: ExecutionContext): CancelableFuture[S] =
+  override def transform[S](s: (A) => S, f: (Throwable) => Throwable)(implicit executor: ExecutionContext): CancelableFuture[S] =
     CancelableFuture(super.transform(s, f), this)
-  override def map[S](f: (T) => S)(implicit executor: ExecutionContext): CancelableFuture[S] =
+  override def map[S](f: (A) => S)(implicit executor: ExecutionContext): CancelableFuture[S] =
     CancelableFuture(super.map(f), this)
-  override def flatMap[S](f: (T) => Future[S])(implicit executor: ExecutionContext): CancelableFuture[S] =
+  override def flatMap[S](f: (A) => Future[S])(implicit executor: ExecutionContext): CancelableFuture[S] =
     CancelableFuture(super.flatMap(f), this)
-  override def filter(p: (T) => Boolean)(implicit executor: ExecutionContext): CancelableFuture[T] =
+  override def filter(p: (A) => Boolean)(implicit executor: ExecutionContext): CancelableFuture[A] =
     CancelableFuture(super.filter(p), this)
-  override def collect[S](pf: PartialFunction[T, S])(implicit executor: ExecutionContext): CancelableFuture[S] =
+  override def collect[S](pf: PartialFunction[A, S])(implicit executor: ExecutionContext): CancelableFuture[S] =
     CancelableFuture(super.collect(pf), this)
-  override def recover[U >: T](pf: PartialFunction[Throwable, U])(implicit executor: ExecutionContext): CancelableFuture[U] =
+  override def recover[U >: A](pf: PartialFunction[Throwable, U])(implicit executor: ExecutionContext): CancelableFuture[U] =
     CancelableFuture(super.recover(pf), this)
-  override def recoverWith[U >: T](pf: PartialFunction[Throwable, Future[U]])(implicit executor: ExecutionContext): CancelableFuture[U] =
+  override def recoverWith[U >: A](pf: PartialFunction[Throwable, Future[U]])(implicit executor: ExecutionContext): CancelableFuture[U] =
     CancelableFuture(super.recoverWith(pf), this)
-  override def zip[U](that: Future[U]): CancelableFuture[(T, U)] =
+  override def zip[U](that: Future[U]): CancelableFuture[(A, U)] =
     CancelableFuture(super.zip(that), this)
-  override def fallbackTo[U >: T](that: Future[U]): CancelableFuture[U] =
+  override def fallbackTo[U >: A](that: Future[U]): CancelableFuture[U] =
     CancelableFuture(super.fallbackTo(that), this)
   override def mapTo[S](implicit tag: ClassTag[S]): CancelableFuture[S] =
     CancelableFuture(super.mapTo(tag), this)
-  override def andThen[U](pf: PartialFunction[Try[T], U])(implicit executor: ExecutionContext): CancelableFuture[T] =
+  override def andThen[U](pf: PartialFunction[Try[A], U])(implicit executor: ExecutionContext): CancelableFuture[A] =
     CancelableFuture(super.andThen(pf), this)
 
   // Needed for Scala 2.12 compatibility
-  def transform[S](f: Try[T] => Try[S])(implicit executor: ExecutionContext): CancelableFuture[S] =
+  def transform[S](f: Try[A] => Try[S])(implicit executor: ExecutionContext): CancelableFuture[S] =
     CancelableFuture(FutureUtils.transform(this, f), this)
 
   // Needed for Scala 2.12 compatibility
-  def transformWith[S](f: Try[T] => Future[S])(implicit executor: ExecutionContext): CancelableFuture[S] =
+  def transformWith[S](f: Try[A] => Future[S])(implicit executor: ExecutionContext): CancelableFuture[S] =
     CancelableFuture(FutureUtils.transformWith(this, f), this)
 }
 
@@ -69,28 +69,28 @@ object CancelableFuture {
     * @param cancelable is a [[monix.execution.Cancelable Cancelable]]
     *        that can be used to cancel the active computation
     */
-  def apply[T](underlying: Future[T], cancelable: Cancelable): CancelableFuture[T] =
-    new Implementation[T](underlying, cancelable)
+  def apply[A](underlying: Future[A], cancelable: Cancelable): CancelableFuture[A] =
+    new Implementation[A](underlying, cancelable)
 
   /** Promotes a strict `value` to a [[CancelableFuture]] that's already complete. */
-  def successful[T](value: T): CancelableFuture[T] =
-    new Now[T](Success(value))
+  def successful[A](value: A): CancelableFuture[A] =
+    new Now[A](Success(value))
 
   /** Promotes a strict `Throwable` to a [[CancelableFuture]] that's already complete. */
-  def failed[T](ex: Throwable): CancelableFuture[T] =
-    new Now[T](Failure(ex))
+  def failed[A](ex: Throwable): CancelableFuture[A] =
+    new Now[A](Failure(ex))
 
   /** An already completed [[CancelableFuture]]. */
   final val unit: CancelableFuture[Unit] =
     successful(())
 
   /** Returns a [[CancelableFuture]] instance that will never complete. */
-  final def never[T]: CancelableFuture[T] =
+  final def never[A]: CancelableFuture[A] =
     Never
 
-  /** Promotes a strict `Try[T]` to a [[CancelableFuture]] that's already complete. */
-  def fromTry[T](value: Try[T]): CancelableFuture[T] =
-    new Now[T](value)
+  /** Promotes a strict `Try[A]` to a [[CancelableFuture]] that's already complete. */
+  def fromTry[A](value: Try[A]): CancelableFuture[A] =
+    new Now[A](value)
 
   /** A [[CancelableFuture]] instance that will never complete. */
   private object Never extends CancelableFuture[Nothing] {
@@ -113,15 +113,15 @@ object CancelableFuture {
   }
 
   /** An internal [[CancelableFuture]] implementation. */
-  private final class Now[+T](immediate: Try[T]) extends CancelableFuture[T] {
+  private final class Now[+A](immediate: Try[A]) extends CancelableFuture[A] {
     def ready(atMost: Duration)(implicit permit: CanAwait): this.type = this
-    def result(atMost: Duration)(implicit permit: CanAwait): T = immediate.get
+    def result(atMost: Duration)(implicit permit: CanAwait): A = immediate.get
 
     def cancel(): Unit = ()
     def isCompleted: Boolean = true
-    val value: Some[Try[T]] = Some(immediate)
+    val value: Some[Try[A]] = Some(immediate)
 
-    def onComplete[U](f: (Try[T]) => U)(implicit executor: ExecutionContext): Unit =
+    def onComplete[U](f: (Try[A]) => U)(implicit executor: ExecutionContext): Unit =
       executor.execute(new Runnable { def run(): Unit = f(immediate) })
 
     // Overriding methods for getting CancelableFuture in return
@@ -133,18 +133,18 @@ object CancelableFuture {
   }
 
   /** An actual [[CancelableFuture]] implementation; internal. */
-  private final class Implementation[+T](underlying: Future[T], cancelable: Cancelable)
-    extends CancelableFuture[T] {
+  private final class Implementation[+A](underlying: Future[A], cancelable: Cancelable)
+    extends CancelableFuture[A] {
 
-    override def onComplete[U](f: (Try[T]) => U)(implicit executor: ExecutionContext): Unit =
+    override def onComplete[U](f: (Try[A]) => U)(implicit executor: ExecutionContext): Unit =
       underlying.onComplete(f)(executor)
     override def isCompleted: Boolean =
       underlying.isCompleted
-    override def value: Option[Try[T]] =
+    override def value: Option[Try[A]] =
       underlying.value
 
     @throws[Exception](classOf[Exception])
-    def result(atMost: Duration)(implicit permit: CanAwait): T =
+    def result(atMost: Duration)(implicit permit: CanAwait): A =
       underlying.result(atMost)(permit)
 
     @throws[InterruptedException](classOf[InterruptedException])
@@ -160,36 +160,36 @@ object CancelableFuture {
     // Overriding methods for getting CancelableFuture in return
     override def failed: CancelableFuture[Throwable] =
       new Implementation(underlying.failed, cancelable)
-    override def transform[S](s: (T) => S, f: (Throwable) => Throwable)(implicit executor: ExecutionContext): CancelableFuture[S] =
+    override def transform[S](s: (A) => S, f: (Throwable) => Throwable)(implicit executor: ExecutionContext): CancelableFuture[S] =
       new Implementation(underlying.transform(s, f), cancelable)
-    override def map[S](f: (T) => S)(implicit executor: ExecutionContext): CancelableFuture[S] =
+    override def map[S](f: (A) => S)(implicit executor: ExecutionContext): CancelableFuture[S] =
       new Implementation(underlying.map(f), cancelable)
-    override def flatMap[S](f: (T) => Future[S])(implicit executor: ExecutionContext): CancelableFuture[S] =
+    override def flatMap[S](f: (A) => Future[S])(implicit executor: ExecutionContext): CancelableFuture[S] =
       new Implementation(underlying.flatMap(f), cancelable)
-    override def filter(p: (T) => Boolean)(implicit executor: ExecutionContext): CancelableFuture[T] =
+    override def filter(p: (A) => Boolean)(implicit executor: ExecutionContext): CancelableFuture[A] =
       new Implementation(underlying.filter(p), cancelable)
-    override def collect[S](pf: PartialFunction[T, S])(implicit executor: ExecutionContext): CancelableFuture[S] =
+    override def collect[S](pf: PartialFunction[A, S])(implicit executor: ExecutionContext): CancelableFuture[S] =
       new Implementation(underlying.collect(pf), cancelable)
-    override def recover[U >: T](pf: PartialFunction[Throwable, U])(implicit executor: ExecutionContext): CancelableFuture[U] =
+    override def recover[U >: A](pf: PartialFunction[Throwable, U])(implicit executor: ExecutionContext): CancelableFuture[U] =
       new Implementation(underlying.recover(pf), cancelable)
-    override def recoverWith[U >: T](pf: PartialFunction[Throwable, Future[U]])(implicit executor: ExecutionContext): CancelableFuture[U] =
+    override def recoverWith[U >: A](pf: PartialFunction[Throwable, Future[U]])(implicit executor: ExecutionContext): CancelableFuture[U] =
       new Implementation(underlying.recoverWith(pf), cancelable)
-    override def zip[U](that: Future[U]): CancelableFuture[(T, U)] =
+    override def zip[U](that: Future[U]): CancelableFuture[(A, U)] =
       new Implementation(underlying.zip(that), cancelable)
-    override def fallbackTo[U >: T](that: Future[U]): CancelableFuture[U] =
+    override def fallbackTo[U >: A](that: Future[U]): CancelableFuture[U] =
       new Implementation(underlying.fallbackTo(that), cancelable)
     override def mapTo[S](implicit tag: ClassTag[S]): CancelableFuture[S] =
       new Implementation(underlying.mapTo[S], cancelable)
-    override def andThen[U](pf: PartialFunction[Try[T], U])(implicit executor: ExecutionContext): CancelableFuture[T] =
+    override def andThen[U](pf: PartialFunction[Try[A], U])(implicit executor: ExecutionContext): CancelableFuture[A] =
       new Implementation(underlying.andThen(pf), cancelable)
 
     // Needed for Scala 2.12 compatibility
-    override def transform[S](f: Try[T] => Try[S])
+    override def transform[S](f: Try[A] => Try[S])
       (implicit executor: ExecutionContext): CancelableFuture[S] =
       new Implementation[S](FutureUtils.transform(underlying, f), cancelable)
 
     // Needed for Scala 2.12 compatibility
-    override def transformWith[S](f: Try[T] => Future[S])
+    override def transformWith[S](f: Try[A] => Future[S])
       (implicit executor: ExecutionContext): CancelableFuture[S] =
       new Implementation[S](FutureUtils.transformWith(underlying, f), cancelable)
   }

--- a/monix-execution/shared/src/main/scala/monix/execution/Listener.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/Listener.scala
@@ -30,7 +30,7 @@ import scala.concurrent.Promise
   * `Listener` semantics to types that cannot be `Function1[A,Unit]`.
   *
   * In particular `monix.eval.Callback` is a supertype of
-  * `Listener`, even though `Callback` is a `Try[T] => Unit`.
+  * `Listener`, even though `Callback` is a `Try[A] => Unit`.
   */
 trait Listener[-A] extends Serializable {
   def onValue(value: A): Unit

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/collection/Buffer.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/collection/Buffer.scala
@@ -21,7 +21,7 @@ package monix.execution.internal.collection
  * A `Buffer` is a data-structure that can be appended in constant time
  * constant time and that can be iterated efficiently.
  */
-private[monix] trait Buffer[T] extends Iterable[T] {
+private[monix] trait Buffer[A] extends Iterable[A] {
   /**
    * Pushes a new element in the queue. Depending on
    * implementation, on overflow it might start to evict
@@ -30,7 +30,7 @@ private[monix] trait Buffer[T] extends Iterable[T] {
    * @return the number of elements that were evicted in case of
    *         overflow or zero otherwise
    */
-  def offer(elem: T): Int
+  def offer(elem: A): Int
 
   /**
    * Pushes the given sequence on the queue. Depending on
@@ -40,7 +40,7 @@ private[monix] trait Buffer[T] extends Iterable[T] {
    * @return the number of elements that were evicted in case of
    *         overflow or zero otherwise
    */
-  def offerMany(seq: T*): Long
+  def offerMany(seq: A*): Long
 
   /**
    * Clears all items in this buffer leaving it empty.

--- a/monix-execution/shared/src/main/scala/monix/execution/misc/InlineMacros.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/misc/InlineMacros.scala
@@ -26,8 +26,8 @@ trait InlineMacros {
 
   import c.universe._
 
-  def inlineAndReset[T](tree: Tree): c.Expr[T] = {
-    c.Expr[T](inlineAndResetTree(tree))
+  def inlineAndReset[A](tree: Tree): c.Expr[A] = {
+    c.Expr[A](inlineAndResetTree(tree))
   }
 
   def inlineAndResetTree(tree: Tree): Tree = {

--- a/monix-execution/shared/src/test/scala/monix/execution/atomic/AtomicNumberSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/atomic/AtomicNumberSuite.scala
@@ -20,13 +20,13 @@ package monix.execution.atomic
 import minitest.SimpleTestSuite
 import monix.execution.atomic.PaddingStrategy._
 
-abstract class AtomicNumberSuite[T, R <: AtomicNumber[T]]
-  (builder: AtomicBuilder[T, R], strategy: PaddingStrategy,
-  value: T, maxValue: T, minValue: T, hasOverflow: Boolean = true,
-  allowPlatformIntrinsics: Boolean, allowUnsafe: Boolean)(implicit ev: Numeric[T])
+abstract class AtomicNumberSuite[A, R <: AtomicNumber[A]]
+  (builder: AtomicBuilder[A, R], strategy: PaddingStrategy,
+  value: A, maxValue: A, minValue: A, hasOverflow: Boolean = true,
+  allowPlatformIntrinsics: Boolean, allowUnsafe: Boolean)(implicit ev: Numeric[A])
   extends SimpleTestSuite {
 
-  def Atomic(initial: T): R = {
+  def Atomic(initial: A): R = {
     if (allowUnsafe)
       builder.buildInstance(initial, strategy, allowPlatformIntrinsics)
     else
@@ -269,7 +269,7 @@ abstract class AtomicNumberSuite[T, R <: AtomicNumber[T]]
 
   test("should transform(function)") {
     val r = Atomic(value)
-    def fn(x: T): T = ev.plus(x, x)
+    def fn(x: A): A = ev.plus(x, x)
     r.transform(fn)
     assert(r.get == ev.plus(value, value))
   }
@@ -286,7 +286,7 @@ abstract class AtomicNumberSuite[T, R <: AtomicNumber[T]]
 
   test("should transformAndGet(function)") {
     val r = Atomic(value)
-    def fn(x: T) = ev.plus(x,x)
+    def fn(x: A) = ev.plus(x,x)
     assert(r.transformAndGet(fn) == ev.plus(value, value))
   }
 
@@ -304,7 +304,7 @@ abstract class AtomicNumberSuite[T, R <: AtomicNumber[T]]
 
   test("should getAndTransform(function)") {
     val r = Atomic(value)
-    def fn(x: T) = ev.plus(x,x)
+    def fn(x: A) = ev.plus(x,x)
     assert(r.getAndTransform(fn) == value)
     assert(r.get == ev.plus(value, value))
   }

--- a/monix-execution/shared/src/test/scala/monix/execution/atomic/GenericAtomicSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/atomic/GenericAtomicSuite.scala
@@ -21,12 +21,12 @@ import minitest.SimpleTestSuite
 import monix.execution.atomic.PaddingStrategy._
 import monix.execution.misc.NonFatal
 
-abstract class GenericAtomicSuite[T, R <: Atomic[T]]
-  (builder: AtomicBuilder[T, R], strategy: PaddingStrategy, valueFromInt: Int => T, valueToInt: T => Int,
+abstract class GenericAtomicSuite[A, R <: Atomic[A]]
+  (builder: AtomicBuilder[A, R], strategy: PaddingStrategy, valueFromInt: Int => A, valueToInt: A => Int,
    allowPlatformIntrinsics: Boolean, allowUnsafe: Boolean)
   extends SimpleTestSuite {
 
-  def Atomic(initial: T): R = {
+  def Atomic(initial: A): R = {
     if (allowUnsafe)
       builder.buildInstance(initial, strategy, allowPlatformIntrinsics)
     else
@@ -77,15 +77,15 @@ abstract class GenericAtomicSuite[T, R <: Atomic[T]]
   test("should transform with dirty function #1") {
     val r = Atomic(zero)
     r.transform {
-      def increment(y: T): T = valueFromInt(valueToInt(y) + 1)
-      x: T => increment(x)
+      def increment(y: A): A = valueFromInt(valueToInt(y) + 1)
+      x: A => increment(x)
     }
     assert(r.get == one)
   }
 
   test("should transform with dirty function #2") {
     val r = Atomic(zero)
-    def increment(y: T): T = valueFromInt(valueToInt(y) + 1)
+    def increment(y: A): A = valueFromInt(valueToInt(y) + 1)
 
     r.transform(increment)
     assert(r.get == one)
@@ -125,15 +125,15 @@ abstract class GenericAtomicSuite[T, R <: Atomic[T]]
   test("should transformAndGet with dirty function #1") {
     val r = Atomic(zero)
     val result = r.transformAndGet {
-      def increment(y: T): T = valueFromInt(valueToInt(y) + 1)
-      x: T => increment(x)
+      def increment(y: A): A = valueFromInt(valueToInt(y) + 1)
+      x: A => increment(x)
     }
     assertEquals(result, one)
   }
 
   test("should transformAndGet with dirty function #2") {
     val r = Atomic(zero)
-    def increment(y: T): T = valueFromInt(valueToInt(y) + 1)
+    def increment(y: A): A = valueFromInt(valueToInt(y) + 1)
 
     val result = r.transformAndGet(increment)
     assertEquals(result, one)
@@ -172,8 +172,8 @@ abstract class GenericAtomicSuite[T, R <: Atomic[T]]
   test("should getAndTransform with dirty function #1") {
     val r = Atomic(zero)
     val result = r.getAndTransform {
-      def increment(y: T): T = valueFromInt(valueToInt(y) + 1)
-      x: T => increment(x)
+      def increment(y: A): A = valueFromInt(valueToInt(y) + 1)
+      x: A => increment(x)
     }
     assertEquals(result, zero)
     assertEquals(r.get, one)
@@ -181,7 +181,7 @@ abstract class GenericAtomicSuite[T, R <: Atomic[T]]
 
   test("should getAndTransform with dirty function #2") {
     val r = Atomic(zero)
-    def increment(y: T): T = valueFromInt(valueToInt(y) + 1)
+    def increment(y: A): A = valueFromInt(valueToInt(y) + 1)
 
     val result = r.getAndTransform(increment)
     assertEquals(result, zero)
@@ -224,8 +224,8 @@ abstract class GenericAtomicSuite[T, R <: Atomic[T]]
   test("should transformAndExtract with dirty function #1") {
     val r = Atomic(zero)
     val result = r.transformAndExtract {
-      def increment(y: T): T = valueFromInt(valueToInt(y) + 1)
-      x: T => (x, increment(x))
+      def increment(y: A): A = valueFromInt(valueToInt(y) + 1)
+      x: A => (x, increment(x))
     }
 
     assertEquals(result, zero)
@@ -234,7 +234,7 @@ abstract class GenericAtomicSuite[T, R <: Atomic[T]]
 
   test("should transformAndExtract with dirty function #2") {
     val r = Atomic(zero)
-    def increment(y: T) = (y, valueFromInt(valueToInt(y) + 1))
+    def increment(y: A) = (y, valueFromInt(valueToInt(y) + 1))
 
     val result = r.transformAndExtract(increment)
     assertEquals(result, zero)

--- a/monix-execution/shared/src/test/scala/monix/execution/schedulers/TestSchedulerSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/schedulers/TestSchedulerSuite.scala
@@ -292,16 +292,16 @@ object TestSchedulerSuite extends TestSuite[TestScheduler] {
   def action(f: => Unit): Runnable =
     new Runnable { def run() = f }
 
-  def delayedResult[T](delay: FiniteDuration, timeout: FiniteDuration)(r: => T)(implicit s: Scheduler) = {
+  def delayedResult[A](delay: FiniteDuration, timeout: FiniteDuration)(r: => A)(implicit s: Scheduler) = {
     val f1 = {
-      val p = Promise[T]()
+      val p = Promise[A]()
       s.scheduleOnce(delay.length, delay.unit, action(p.success(r)))
       p.future
     }
 
     // catching the exception here, for non-useless stack traces
     val err = Try(throw new TimeoutException)
-    val promise = Promise[T]()
+    val promise = Promise[A]()
     val task = s.scheduleOnce(timeout.length, timeout.unit, action(promise.tryComplete(err)))
 
     f1.onComplete { result =>

--- a/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/BatchedBufferedSubscriber.scala
+++ b/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/BatchedBufferedSubscriber.scala
@@ -39,6 +39,6 @@ private[monix] final class BatchedBufferedSubscriber[A] private
 
 private[monix] object BatchedBufferedSubscriber {
   /** Builder for [[BatchedBufferedSubscriber]] */
-  def apply[T](underlying: Subscriber[List[T]], bufferSize: Int): BatchedBufferedSubscriber[T] =
-    new BatchedBufferedSubscriber[T](underlying, bufferSize)
+  def apply[A](underlying: Subscriber[List[A]], bufferSize: Int): BatchedBufferedSubscriber[A] =
+    new BatchedBufferedSubscriber[A](underlying, bufferSize)
 }

--- a/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/SyncBufferedSubscriber.scala
+++ b/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/SyncBufferedSubscriber.scala
@@ -243,9 +243,9 @@ private[monix] object SyncBufferedSubscriber {
     * for the [[monix.reactive.OverflowStrategy.DropNew DropNew]]
     * overflow strategy.
     */
-  def unbounded[T](underlying: Subscriber[T]): Subscriber.Sync[T] = {
-    val buffer = ArrayQueue.unbounded[T]
-    new SyncBufferedSubscriber[T](underlying, buffer, null)
+  def unbounded[A](underlying: Subscriber[A]): Subscriber.Sync[A] = {
+    val buffer = ArrayQueue.unbounded[A]
+    new SyncBufferedSubscriber[A](underlying, buffer, null)
   }
 
   /**
@@ -253,15 +253,15 @@ private[monix] object SyncBufferedSubscriber {
     * for the [[monix.reactive.OverflowStrategy.DropNew DropNew]]
     * overflow strategy.
     */
-  def bounded[T](underlying: Subscriber[T], bufferSize: Int): Subscriber.Sync[T] = {
+  def bounded[A](underlying: Subscriber[A], bufferSize: Int): Subscriber.Sync[A] = {
     require(bufferSize > 1, "bufferSize must be strictly higher than 1")
-    val buffer = ArrayQueue.bounded[T](bufferSize, capacity => {
+    val buffer = ArrayQueue.bounded[A](bufferSize, _ => {
       BufferOverflowException.build(
         s"Downstream observer is too slow, buffer over capacity with a " +
-          s"specified buffer size of $bufferSize")
+        s"specified buffer size of $bufferSize")
     })
 
-    new SyncBufferedSubscriber[T](underlying, buffer, null)
+    new SyncBufferedSubscriber[A](underlying, buffer, null)
   }
 
   /**
@@ -269,10 +269,10 @@ private[monix] object SyncBufferedSubscriber {
     * for the [[monix.reactive.OverflowStrategy.DropNew DropNew]]
     * overflow strategy.
     */
-  def dropNew[T](underlying: Subscriber[T], bufferSize: Int): Subscriber.Sync[T] = {
+  def dropNew[A](underlying: Subscriber[A], bufferSize: Int): Subscriber.Sync[A] = {
     require(bufferSize > 1, "bufferSize must be strictly higher than 1")
-    val buffer = ArrayQueue.bounded[T](bufferSize)
-    new SyncBufferedSubscriber[T](underlying, buffer, null)
+    val buffer = ArrayQueue.bounded[A](bufferSize)
+    new SyncBufferedSubscriber[A](underlying, buffer, null)
   }
 
   /**
@@ -280,10 +280,10 @@ private[monix] object SyncBufferedSubscriber {
     * for the [[monix.reactive.OverflowStrategy.DropNew DropNew]]
     * overflow strategy.
     */
-  def dropNewAndSignal[T](underlying: Subscriber[T], bufferSize: Int, onOverflow: Long => Option[T]): Subscriber.Sync[T] = {
+  def dropNewAndSignal[A](underlying: Subscriber[A], bufferSize: Int, onOverflow: Long => Option[A]): Subscriber.Sync[A] = {
     require(bufferSize > 1, "bufferSize must be strictly higher than 1")
-    val buffer = ArrayQueue.bounded[T](bufferSize)
-    new SyncBufferedSubscriber[T](underlying, buffer, onOverflow)
+    val buffer = ArrayQueue.bounded[A](bufferSize)
+    new SyncBufferedSubscriber[A](underlying, buffer, onOverflow)
   }
 
   /**
@@ -291,10 +291,10 @@ private[monix] object SyncBufferedSubscriber {
     * for the [[monix.reactive.OverflowStrategy.DropOld DropOld]]
     * overflow strategy.
     */
-  def dropOld[T](underlying: Subscriber[T], bufferSize: Int): Subscriber.Sync[T] = {
+  def dropOld[A](underlying: Subscriber[A], bufferSize: Int): Subscriber.Sync[A] = {
     require(bufferSize > 1, "bufferSize must be strictly higher than 1")
-    val buffer = DropHeadOnOverflowQueue[AnyRef](bufferSize).asInstanceOf[EvictingQueue[T]]
-    new SyncBufferedSubscriber[T](underlying, buffer, null)
+    val buffer = DropHeadOnOverflowQueue[AnyRef](bufferSize).asInstanceOf[EvictingQueue[A]]
+    new SyncBufferedSubscriber[A](underlying, buffer, null)
   }
 
   /**
@@ -303,10 +303,10 @@ private[monix] object SyncBufferedSubscriber {
     * overflow strategy, with signaling of the number of events that
     * were dropped.
     */
-  def dropOldAndSignal[T](underlying: Subscriber[T], bufferSize: Int, onOverflow: Long => Option[T]): Subscriber.Sync[T] = {
+  def dropOldAndSignal[A](underlying: Subscriber[A], bufferSize: Int, onOverflow: Long => Option[A]): Subscriber.Sync[A] = {
     require(bufferSize > 1, "bufferSize must be strictly higher than 1")
-    val buffer = DropHeadOnOverflowQueue[AnyRef](bufferSize).asInstanceOf[EvictingQueue[T]]
-    new SyncBufferedSubscriber[T](underlying, buffer, onOverflow)
+    val buffer = DropHeadOnOverflowQueue[AnyRef](bufferSize).asInstanceOf[EvictingQueue[A]]
+    new SyncBufferedSubscriber[A](underlying, buffer, onOverflow)
   }
 
   /**
@@ -314,10 +314,10 @@ private[monix] object SyncBufferedSubscriber {
     * [[monix.reactive.OverflowStrategy.ClearBuffer ClearBuffer]]
     * overflow strategy.
     */
-  def clearBuffer[T](underlying: Subscriber[T], bufferSize: Int): Subscriber.Sync[T] = {
+  def clearBuffer[A](underlying: Subscriber[A], bufferSize: Int): Subscriber.Sync[A] = {
     require(bufferSize > 1, "bufferSize must be strictly higher than 1")
-    val buffer = DropAllOnOverflowQueue[AnyRef](bufferSize).asInstanceOf[EvictingQueue[T]]
-    new SyncBufferedSubscriber[T](underlying, buffer, null)
+    val buffer = DropAllOnOverflowQueue[AnyRef](bufferSize).asInstanceOf[EvictingQueue[A]]
+    new SyncBufferedSubscriber[A](underlying, buffer, null)
   }
 
   /**
@@ -326,9 +326,9 @@ private[monix] object SyncBufferedSubscriber {
     * overflow strategy, with signaling of the number of events that
     * were dropped.
     */
-  def clearBufferAndSignal[T](underlying: Subscriber[T], bufferSize: Int, onOverflow: Long => Option[T]): Subscriber.Sync[T] = {
+  def clearBufferAndSignal[A](underlying: Subscriber[A], bufferSize: Int, onOverflow: Long => Option[A]): Subscriber.Sync[A] = {
     require(bufferSize > 1, "bufferSize must be strictly higher than 1")
-    val buffer = DropAllOnOverflowQueue[AnyRef](bufferSize).asInstanceOf[EvictingQueue[T]]
-    new SyncBufferedSubscriber[T](underlying, buffer, onOverflow)
+    val buffer = DropAllOnOverflowQueue[AnyRef](bufferSize).asInstanceOf[EvictingQueue[A]]
+    new SyncBufferedSubscriber[A](underlying, buffer, onOverflow)
   }
 }

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/BatchedBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/BatchedBufferedSubscriber.scala
@@ -46,6 +46,6 @@ private[monix] final class BatchedBufferedSubscriber[A] private
 
 private[monix] object BatchedBufferedSubscriber {
   /** Builder for [[BatchedBufferedSubscriber]] */
-  def apply[T](underlying: Subscriber[List[T]], bufferSize: Int): BatchedBufferedSubscriber[T] =
-    new BatchedBufferedSubscriber[T](underlying, bufferSize)
+  def apply[A](underlying: Subscriber[List[A]], bufferSize: Int): BatchedBufferedSubscriber[A] =
+    new BatchedBufferedSubscriber[A](underlying, bufferSize)
 }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Notification.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Notification.scala
@@ -18,10 +18,10 @@
 package monix.reactive
 
 /** Used by [[Observable.materialize]]. */
-sealed abstract class Notification[+T] extends Serializable
+sealed abstract class Notification[+A] extends Serializable
 
 object Notification {
-  final case class OnNext[+T](elem: T) extends Notification[T]
+  final case class OnNext[+A](elem: A) extends Notification[A]
 
   final case class OnError(ex: Throwable) extends Notification[Nothing]
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -235,7 +235,7 @@ trait Observable[+A] extends ObservableLike[A, Observable] { self =>
     *
     * @param maxCapacity is the maximum buffer size after which old events
     *        start being dropped (according to what happens when using
-    *        [[monix.reactive.subjects.ReplaySubject.createLimited[T](capacity:Int,initial* ReplaySubject.createLimited]])
+    *        [[monix.reactive.subjects.ReplaySubject.createLimited[A](capacity:Int,initial* ReplaySubject.createLimited]])
     *
     * @return an Observable that, when first subscribed to, caches all of its
     *         items and notifications for the benefit of subsequent subscribers

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/FirstStartedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/FirstStartedObservable.scala
@@ -26,10 +26,10 @@ import monix.reactive.observers.Subscriber
 import monix.reactive.{Observable, Observer}
 import scala.concurrent.{Future, Promise}
 
-private[reactive] final class FirstStartedObservable[T](source: Observable[T]*)
-  extends Observable[T] {
+private[reactive] final class FirstStartedObservable[A](source: Observable[A]*)
+  extends Observable[A] {
 
-  override def unsafeSubscribeFn(subscriber: Subscriber[T]): Cancelable = {
+  override def unsafeSubscribeFn(subscriber: Subscriber[A]): Cancelable = {
     import subscriber.scheduler
     val finishLine = Atomic(-1)
     var idx = 0
@@ -64,11 +64,11 @@ private[reactive] final class FirstStartedObservable[T](source: Observable[T]*)
   }
 
   // Helper function used for creating a subscription that uses `finishLine` as guard
-  def createSubscription(observable: Observable[T], observer: Observer[T],
+  def createSubscription(observable: Observable[A], observer: Observer[A],
     finishLine: AtomicInt, idx: Int, p: Promise[Int])
     (implicit s: Scheduler): Cancelable = {
 
-    observable.unsafeSubscribeFn(new Observer[T] {
+    observable.unsafeSubscribeFn(new Observer[A] {
       // for fast path
       private[this] var finishLineCache = -1
 
@@ -85,7 +85,7 @@ private[reactive] final class FirstStartedObservable[T](source: Observable[T]*)
         }
       }
 
-      def onNext(elem: T): Future[Ack] = {
+      def onNext(elem: A): Future[Ack] = {
         if (shouldStream())
           observer.onNext(elem)
         else

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/FutureAsObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/FutureAsObservable.scala
@@ -26,10 +26,10 @@ import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
 /** Converts any `Future` into an observable */
-private[reactive] final class FutureAsObservable[T](factory: => Future[T])
-  extends Observable[T] {
+private[reactive] final class FutureAsObservable[A](factory: => Future[A])
+  extends Observable[A] {
 
-  def unsafeSubscribeFn(subscriber: Subscriber[T]): Cancelable = {
+  def unsafeSubscribeFn(subscriber: Subscriber[A]): Cancelable = {
     import subscriber.{scheduler => s}
     // Protects calls to user code
     var streamErrors = true

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/IterableAsObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/IterableAsObservable.scala
@@ -23,11 +23,8 @@ import monix.reactive.observers.Subscriber
 
 /** Converts any `Iterable` into an observable */
 private[reactive] final
-class IterableAsObservable[T](
-  iterable: Iterable[T])
-  extends Observable[T] {
-
-  def unsafeSubscribeFn(subscriber: Subscriber[T]): Cancelable = {
+class IterableAsObservable[A](iterable: Iterable[A]) extends Observable[A] {
+  def unsafeSubscribeFn(subscriber: Subscriber[A]): Cancelable = {
     new IteratorAsObservable(iterable.iterator, Cancelable.empty)
       .unsafeSubscribeFn(subscriber)
   }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/IteratorAsObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/IteratorAsObservable.scala
@@ -31,13 +31,13 @@ import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
 /** Converts any `Iterator` into an observable */
-private[reactive] final class IteratorAsObservable[T](
-  iterator: Iterator[T],
-  onFinish: Cancelable) extends Observable[T] {
+private[reactive] final class IteratorAsObservable[A](
+  iterator: Iterator[A],
+  onFinish: Cancelable) extends Observable[A] {
 
   private[this] val wasSubscribed = Atomic(false)
 
-  def unsafeSubscribeFn(out: Subscriber[T]): Cancelable = {
+  def unsafeSubscribeFn(out: Subscriber[A]): Cancelable = {
     if (wasSubscribed.getAndSet(true)) {
       out.onError(MultipleSubscribersException.build("InputStreamObservable"))
       Cancelable.empty
@@ -46,7 +46,7 @@ private[reactive] final class IteratorAsObservable[T](
     }
   }
 
-  private def startLoop(subscriber: Subscriber[T]): Cancelable = {
+  private def startLoop(subscriber: Subscriber[A]): Cancelable = {
     import subscriber.{scheduler => s}
     // Protect against contract violations - we are only allowed to
     // call onError if no other terminal event has been called.
@@ -98,8 +98,8 @@ private[reactive] final class IteratorAsObservable[T](
     * NOTE: the assumption of this method is that `iter` is
     * NOT empty, so the first call is `next()` and not `hasNext()`.
     */
-  private def reschedule(ack: Future[Ack], iter: Iterator[T],
-    out: Subscriber[T], c: BooleanCancelable, em: ExecutionModel)
+  private def reschedule(ack: Future[Ack], iter: Iterator[A],
+    out: Subscriber[A], c: BooleanCancelable, em: ExecutionModel)
     (implicit s: Scheduler): Unit = {
 
     ack.onComplete {
@@ -138,7 +138,7 @@ private[reactive] final class IteratorAsObservable[T](
     * NOT empty, so the first call is `next()` and not `hasNext()`.
     */
   @tailrec private
-  def fastLoop(iter: Iterator[T], out: Subscriber[T], c: BooleanCancelable,
+  def fastLoop(iter: Iterator[A], out: Subscriber[A], c: BooleanCancelable,
     em: ExecutionModel, syncIndex: Int)(implicit s: Scheduler): Unit = {
 
     // The result of onNext calls, on which we must do back-pressure

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RepeatObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RepeatObservable.scala
@@ -22,7 +22,7 @@ import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 
 /** Repeats the given elements */
-private[reactive] final class RepeatObservable[T](elems: T*) extends Observable[T] {
+private[reactive] final class RepeatObservable[A](elems: A*) extends Observable[A] {
   private[this] val source =
     if (elems.isEmpty) Observable.empty
     else if (elems.length == 1)
@@ -30,6 +30,6 @@ private[reactive] final class RepeatObservable[T](elems: T*) extends Observable[
     else
       Observable.fromIterable(elems).repeat
 
-  def unsafeSubscribeFn(subscriber: Subscriber[T]): Cancelable =
+  def unsafeSubscribeFn(subscriber: Subscriber[A]): Cancelable =
     source.unsafeSubscribeFn(subscriber)
 }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RepeatedValueObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RepeatedValueObservable.scala
@@ -27,10 +27,10 @@ import scala.concurrent.duration.FiniteDuration
 import scala.util.{Failure, Success, Try}
 
 private[reactive] final
-class RepeatedValueObservable[T](initialDelay: FiniteDuration, period: FiniteDuration, unit: T)
-  extends Observable[T] {
+class RepeatedValueObservable[A](initialDelay: FiniteDuration, period: FiniteDuration, unit: A)
+  extends Observable[A] {
 
-  def unsafeSubscribeFn(subscriber: Subscriber[T]): Cancelable = {
+  def unsafeSubscribeFn(subscriber: Subscriber[A]): Cancelable = {
     val task = MultiAssignmentCancelable()
     val r = runnable(subscriber, task)
 
@@ -44,7 +44,7 @@ class RepeatedValueObservable[T](initialDelay: FiniteDuration, period: FiniteDur
     task
   }
 
-  private[this] def runnable(subscriber: Subscriber[T], task: MultiAssignmentCancelable): Runnable =
+  private[this] def runnable(subscriber: Subscriber[A], task: MultiAssignmentCancelable): Runnable =
     new Runnable { self =>
       private[this] implicit val s = subscriber.scheduler
       private[this] val periodMs = period.toMillis

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DumpObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DumpObservable.scala
@@ -27,13 +27,13 @@ import monix.reactive.observers.Subscriber
 import scala.concurrent.Future
 
 private[reactive] final
-class DumpObservable[T](source: Observable[T], prefix: String, out: PrintStream)
-  extends Observable[T] {
+class DumpObservable[A](source: Observable[A], prefix: String, out: PrintStream)
+  extends Observable[A] {
 
-  def unsafeSubscribeFn(subscriber: Subscriber[T]): Cancelable = {
+  def unsafeSubscribeFn(subscriber: Subscriber[A]): Cancelable = {
     var pos = 0
 
-    val upstream = source.unsafeSubscribeFn(new Subscriber[T] {
+    val upstream = source.unsafeSubscribeFn(new Subscriber[A] {
       implicit val scheduler = subscriber.scheduler
 
       private[this] val downstreamActive = Cancelable { () =>
@@ -41,7 +41,7 @@ class DumpObservable[T](source: Observable[T], prefix: String, out: PrintStream)
         out.println(s"$pos: $prefix stopped")
       }
 
-      def onNext(elem: T): Future[Ack] = {
+      def onNext(elem: A): Future[Ack] = {
         try {
           out.println(s"$pos: $prefix-->$elem")
           pos += 1

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/rstreams/ReactiveSubscriberAsMonixSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/rstreams/ReactiveSubscriberAsMonixSubscriber.scala
@@ -32,10 +32,10 @@ import scala.concurrent.{Future, Promise}
   * into an [[monix.reactive.Observer Observer]] instance that
   * respect the `Observer` contract.
   */
-private[reactive] final class ReactiveSubscriberAsMonixSubscriber[T] private
-    (subscriber: RSubscriber[T], subscription: Cancelable)
-    (implicit val scheduler: Scheduler)
-  extends Subscriber[T] with Cancelable { self =>
+private[reactive] final class ReactiveSubscriberAsMonixSubscriber[A] private
+  (subscriber: RSubscriber[A], subscription: Cancelable)
+  (implicit val scheduler: Scheduler)
+  extends Subscriber[A] with Cancelable { self =>
 
   if (subscriber == null) throw null
 
@@ -51,7 +51,7 @@ private[reactive] final class ReactiveSubscriberAsMonixSubscriber[T] private
   }
 
   @tailrec
-  def onNext(elem: T): Future[Ack] = {
+  def onNext(elem: A): Future[Ack] = {
     if (isComplete)
       Stop
     else if (firstEvent) {
@@ -110,9 +110,9 @@ private[reactive] object ReactiveSubscriberAsMonixSubscriber {
     * specification, it builds an [[monix.reactive.Observer]]
     * instance compliant with the Monix Rx implementation.
     */
-  def apply[T](subscriber: RSubscriber[T], subscription: Cancelable)
-    (implicit s: Scheduler): ReactiveSubscriberAsMonixSubscriber[T] =
-    new ReactiveSubscriberAsMonixSubscriber[T](subscriber, subscription)
+  def apply[A](subscriber: RSubscriber[A], subscription: Cancelable)
+    (implicit s: Scheduler): ReactiveSubscriberAsMonixSubscriber[A] =
+    new ReactiveSubscriberAsMonixSubscriber[A](subscriber, subscription)
 
   /** An asynchronous queue implementation for dealing with
     * requests from a Subscriber.

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/util/PromiseCounter.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/util/PromiseCounter.scala
@@ -24,13 +24,13 @@ import scala.concurrent.{Future, Promise}
   * Represents a Promise that completes with `value` after
   * receiving a `countdownUntil` number of `countdown()` calls.
   */
-private[monix] final class PromiseCounter[T] private (value: T, initial: Int) {
+private[monix] final class PromiseCounter[A] private (value: A, initial: Int) {
   require(initial > 0, "length must be strictly positive")
 
-  private[this] val promise = Promise[T]()
+  private[this] val promise = Promise[A]()
   private[this] val counter = Atomic(initial)
 
-  def future: Future[T] =
+  def future: Future[A] =
     promise.future
 
   def acquire(): Unit =
@@ -41,11 +41,11 @@ private[monix] final class PromiseCounter[T] private (value: T, initial: Int) {
     if (update == 0) promise.success(value)
   }
 
-  def success(value: T): Unit =
+  def success(value: A): Unit =
     promise.success(value)
 }
 
 private[monix] object PromiseCounter {
-  def apply[T](value: T, initial: Int): PromiseCounter[T] =
-    new PromiseCounter[T](value, initial)
+  def apply[A](value: A, initial: Int): PromiseCounter[A] =
+    new PromiseCounter[A](value, initial)
 }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observables/CachedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observables/CachedObservable.scala
@@ -34,16 +34,16 @@ import monix.execution.atomic.Atomic
   * @param source - the observable we are wrapping
   * @param maxCapacity - the buffer capacity, or 0 for usage of an unbounded buffer
   */
-final class CachedObservable[+T] private (source: Observable[T], maxCapacity: Int)
-  extends Observable[T] {
+final class CachedObservable[+A] private (source: Observable[A], maxCapacity: Int)
+  extends Observable[A] {
 
   private[this] val isStarted = Atomic(false)
   private[this] val subject = {
-    if (maxCapacity > 0) ReplaySubject.createLimited[T](maxCapacity) else
-      ReplaySubject[T]()
+    if (maxCapacity > 0) ReplaySubject.createLimited[A](maxCapacity) else
+      ReplaySubject[A]()
   }
 
-  def unsafeSubscribeFn(subscriber: Subscriber[T]): Cancelable = {
+  def unsafeSubscribeFn(subscriber: Subscriber[A]): Cancelable = {
     import subscriber.scheduler
     if (isStarted.compareAndSet(expect = false, update = true))
       source.unsafeSubscribeFn(Subscriber(subject, scheduler))
@@ -56,7 +56,7 @@ object CachedObservable {
     *
     * @param observable - is the observable we are wrapping
     */
-  def create[T](observable: Observable[T]): Observable[T] =
+  def create[A](observable: Observable[A]): Observable[A] =
     new CachedObservable(observable, 0)
 
   /** Builder for [[CachedObservable]]
@@ -64,7 +64,7 @@ object CachedObservable {
     * @param observable - is the observable we are wrapping
     * @param maxCapacity - the buffer capacity, with old elements being dropped on overflow
     */
-  def create[T](observable: Observable[T], maxCapacity: Int): Observable[T] = {
+  def create[A](observable: Observable[A], maxCapacity: Int): Observable[A] = {
     require(maxCapacity > 0, "capacity must be strictly positive")
     new CachedObservable(observable, maxCapacity)
   }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observables/RefCountObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observables/RefCountObservable.scala
@@ -31,15 +31,15 @@ import scala.concurrent.Future
   *
   * @param source - the connectable observable we are wrapping
   */
-final class RefCountObservable[+T] private (source: ConnectableObservable[T])
-  extends Observable[T] {
+final class RefCountObservable[+A] private (source: ConnectableObservable[A])
+  extends Observable[A] {
 
   private[this] val refs = Atomic(-1)
   private[this] lazy val connection: Cancelable =
     source.connect()
 
   @tailrec
-  def unsafeSubscribeFn(subscriber: Subscriber[T]): Cancelable = {
+  def unsafeSubscribeFn(subscriber: Subscriber[A]): Cancelable = {
     val current = refs.get
     val update = current match {
       case x if x < 0 => 1
@@ -66,7 +66,7 @@ final class RefCountObservable[+T] private (source: ConnectableObservable[T])
     }
   }
 
-  private def wrap[U >: T](downstream: Subscriber[U], subscription: Cancelable): Subscriber[U] =
+  private def wrap[U >: A](downstream: Subscriber[U], subscription: Cancelable): Subscriber[U] =
     new Subscriber[U] {
       implicit val scheduler = downstream.scheduler
 
@@ -102,6 +102,6 @@ final class RefCountObservable[+T] private (source: ConnectableObservable[T])
 
 object RefCountObservable {
   /** Builder for [[RefCountObservable]] */
-  def apply[T](connectable: ConnectableObservable[T]): Observable[T] =
+  def apply[A](connectable: ConnectableObservable[A]): Observable[A] =
     new RefCountObservable(connectable)
 }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observers/BufferedSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observers/BufferedSubscriber.scala
@@ -61,7 +61,7 @@ import monix.reactive.observers.buffers.BuildersImpl
   * See [[OverflowStrategy OverflowStrategy]] for the buffer
   * policies available.
   */
-trait BufferedSubscriber[-T] extends Subscriber[T]
+trait BufferedSubscriber[-A] extends Subscriber[A]
 
 private[reactive] trait Builders {
   /** Given an [[OverflowStrategy]] wraps a [[Subscriber]] into a

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observers/CacheUntilConnectSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observers/CacheUntilConnectSubscriber.scala
@@ -30,12 +30,12 @@ import scala.util.{Failure, Success}
   * the buffer is drained into the `underlying` observer, after which all
   * subsequent events are pushed directly.
   */
-final class CacheUntilConnectSubscriber[-T] private (downstream: Subscriber[T])
-  extends Subscriber[T] { self =>
+final class CacheUntilConnectSubscriber[-A] private (downstream: Subscriber[A])
+  extends Subscriber[A] { self =>
 
   implicit val scheduler = downstream.scheduler
   // MUST BE synchronized by `self`, only available if isConnected == false
-  private[this] var queue = mutable.ArrayBuffer.empty[T]
+  private[this] var queue = mutable.ArrayBuffer.empty[A]
   // MUST BE synchronized by `self`
   private[this] var isConnectionStarted = false
   // MUST BE synchronized by `self`, as long as isConnected == false
@@ -72,7 +72,7 @@ final class CacheUntilConnectSubscriber[-T] private (downstream: Subscriber[T])
       isConnectionStarted = true
       val bufferWasDrained = Promise[Ack]()
 
-      val cancelable = Observable.fromIterable(queue).unsafeSubscribeFn(new Subscriber[T] {
+      val cancelable = Observable.fromIterable(queue).unsafeSubscribeFn(new Subscriber[A] {
         implicit val scheduler = downstream.scheduler
         private[this] var ack: Future[Ack] = Continue
 
@@ -110,7 +110,7 @@ final class CacheUntilConnectSubscriber[-T] private (downstream: Subscriber[T])
             connectionRef = CancelableFuture.failed(ex)
         }
 
-        def onNext(elem: T): Future[Ack] = {
+        def onNext(elem: A): Future[Ack] = {
           ack = downstream.onNext(elem).syncOnStopFollow(bufferWasDrained, Stop)
           ack
         }
@@ -142,7 +142,7 @@ final class CacheUntilConnectSubscriber[-T] private (downstream: Subscriber[T])
     * until [[connect]] happens and the underlying queue of
     * cached events have been drained.
     */
-  def onNext(elem: T): Future[Ack] = {
+  def onNext(elem: A): Future[Ack] = {
     if (!isConnected) self.synchronized {
       // checking again because of multi-threading concerns
       if (!isConnected && !isConnectionStarted) {
@@ -200,6 +200,6 @@ final class CacheUntilConnectSubscriber[-T] private (downstream: Subscriber[T])
 
 object CacheUntilConnectSubscriber {
   /** Builder for [[CacheUntilConnectSubscriber]] */
-  def apply[T](underlying: Subscriber[T]): CacheUntilConnectSubscriber[T] =
+  def apply[A](underlying: Subscriber[A]): CacheUntilConnectSubscriber[A] =
     new CacheUntilConnectSubscriber(underlying)
 }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observers/SafeSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observers/SafeSubscriber.scala
@@ -35,14 +35,14 @@ import scala.util.Try
   *  - if downstream signals a `Stop`, the observer no longer accepts any events,
   *    ensuring that the grammar is respected
   */
-final class SafeSubscriber[-T] private (subscriber: Subscriber[T])
-  extends Subscriber[T] {
+final class SafeSubscriber[-A] private (subscriber: Subscriber[A])
+  extends Subscriber[A] {
 
   implicit val scheduler = subscriber.scheduler
   private[this] var isDone = false
   private[this] var ack: Future[Ack] = Continue
 
-  def onNext(elem: T): Future[Ack] = {
+  def onNext(elem: A): Future[Ack] = {
     if (!isDone) {
       ack = try {
         flattenAndCatchFailures(subscriber.onNext(elem))
@@ -112,9 +112,9 @@ object SafeSubscriber {
   /**
     * Wraps an Observer instance into a SafeObserver.
     */
-  def apply[T](subscriber: Subscriber[T]): SafeSubscriber[T] =
+  def apply[A](subscriber: Subscriber[A]): SafeSubscriber[A] =
     subscriber match {
-      case ref: SafeSubscriber[_] => ref.asInstanceOf[SafeSubscriber[T]]
-      case _ => new SafeSubscriber[T](subscriber)
+      case ref: SafeSubscriber[_] => ref.asInstanceOf[SafeSubscriber[A]]
+      case _ => new SafeSubscriber[A](subscriber)
     }
 }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/subjects/AsyncSubject.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/subjects/AsyncSubject.scala
@@ -31,20 +31,20 @@ import scala.annotation.tailrec
   * items to subsequent subscribers, but will simply pass along the error
   * notification from the source Observable.
   */
-final class AsyncSubject[T] extends Subject[T,T] { self =>
+final class AsyncSubject[A] extends Subject[A,A] { self =>
   /*
    * NOTE: the stored vector value can be null and if it is, then
    * that means our subject has been terminated.
    */
-  private[this] val stateRef = Atomic(State[T]())
+  private[this] val stateRef = Atomic(State[A]())
 
   private[this] var onNextHappened = false
-  private[this] var cachedElem: T = _
+  private[this] var cachedElem: A = _
 
   def size: Int =
     stateRef.get.subscribers.size
 
-  def onNext(elem: T): Ack = {
+  def onNext(elem: A): Ack = {
     if (stateRef.get.isDone) Stop else {
       if (!onNextHappened) onNextHappened = true
       cachedElem = elem
@@ -61,7 +61,7 @@ final class AsyncSubject[T] extends Subject[T,T] { self =>
   }
 
   @tailrec
-  def unsafeSubscribeFn(subscriber: Subscriber[T]): Cancelable = {
+  def unsafeSubscribeFn(subscriber: Subscriber[A]): Cancelable = {
     val state = stateRef.get
     val subscribers = state.subscribers
 
@@ -117,7 +117,7 @@ final class AsyncSubject[T] extends Subject[T,T] { self =>
     }
   }
 
-  @tailrec private def unsubscribe(s: Subscriber[T]): Unit = {
+  @tailrec private def unsubscribe(s: Subscriber[A]): Unit = {
     val current = stateRef.get
     if (current.subscribers ne null) {
       val update = current.copy(subscribers = current.subscribers - s)
@@ -128,6 +128,6 @@ final class AsyncSubject[T] extends Subject[T,T] { self =>
 }
 
 object AsyncSubject {
-  def apply[T](): AsyncSubject[T] =
-    new AsyncSubject[T]()
+  def apply[A](): AsyncSubject[A] =
+    new AsyncSubject[A]()
 }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/subjects/ReplaySubject.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/subjects/ReplaySubject.scala
@@ -32,8 +32,8 @@ import scala.concurrent.Future
 /** `ReplaySubject` emits to any observer all of the items that were emitted
   * by the source, regardless of when the observer subscribes.
   */
-final class ReplaySubject[T] private (initialState: ReplaySubject.State[T])
-  extends Subject[T,T] { self =>
+final class ReplaySubject[A] private (initialState: ReplaySubject.State[A])
+  extends Subject[A,A] { self =>
 
   private[this] val stateRef = Atomic(initialState)
 
@@ -41,14 +41,14 @@ final class ReplaySubject[T] private (initialState: ReplaySubject.State[T])
     stateRef.get.subscribers.size
 
   @tailrec
-  def unsafeSubscribeFn(subscriber: Subscriber[T]): Cancelable = {
-    def streamOnDone(buffer: Iterable[T], errorThrown: Throwable): Cancelable = {
+  def unsafeSubscribeFn(subscriber: Subscriber[A]): Cancelable = {
+    def streamOnDone(buffer: Iterable[A], errorThrown: Throwable): Cancelable = {
       implicit val s = subscriber.scheduler
 
-      Observable.fromIterable(buffer).unsafeSubscribeFn(new Subscriber[T] {
+      Observable.fromIterable(buffer).unsafeSubscribeFn(new Subscriber[A] {
         implicit val scheduler = subscriber.scheduler
 
-        def onNext(elem: T) =
+        def onNext(elem: A) =
           subscriber.onNext(elem)
         def onError(ex: Throwable) =
           subscriber.onError(ex)
@@ -90,7 +90,7 @@ final class ReplaySubject[T] private (initialState: ReplaySubject.State[T])
   }
 
   @tailrec
-  def onNext(elem: T): Future[Ack] = {
+  def onNext(elem: A): Future[Ack] = {
     val state = stateRef.get
 
     if (state.isDone) Stop else {
@@ -173,7 +173,7 @@ final class ReplaySubject[T] private (initialState: ReplaySubject.State[T])
   }
 
   @tailrec
-  private def removeSubscriber(s: ConnectableSubscriber[T]): Unit = {
+  private def removeSubscriber(s: ConnectableSubscriber[A]): Unit = {
     val state = stateRef.get
     val newState = state.removeSubscriber(s)
     if (!stateRef.compareAndSet(state, newState))
@@ -183,12 +183,12 @@ final class ReplaySubject[T] private (initialState: ReplaySubject.State[T])
 
 object ReplaySubject {
   /** Creates an unbounded replay subject. */
-  def apply[T](initial: T*): ReplaySubject[T] =
+  def apply[A](initial: A*): ReplaySubject[A] =
     create(initial)
 
   /** Creates an unbounded replay subject. */
-  def create[T](initial: Seq[T]): ReplaySubject[T] =
-    new ReplaySubject[T](State[T](initial.toVector, 0))
+  def create[A](initial: Seq[A]): ReplaySubject[A] =
+    new ReplaySubject[A](State[A](initial.toVector, 0))
 
   /** Creates a size-bounded replay subject.
     *
@@ -197,9 +197,9 @@ object ReplaySubject {
     *
     * @param capacity is the maximum size of the internal buffer
     */
-  def createLimited[T](capacity: Int): ReplaySubject[T] = {
+  def createLimited[A](capacity: Int): ReplaySubject[A] = {
     require(capacity > 0, "capacity must be strictly positive")
-    new ReplaySubject[T](State[T](Queue.empty, capacity))
+    new ReplaySubject[A](State[A](Queue.empty, capacity))
   }
 
   /** Creates a size-bounded replay subject, prepopulated.
@@ -210,22 +210,22 @@ object ReplaySubject {
     * @param capacity is the maximum size of the internal buffer
     * @param initial is an initial sequence of elements to prepopulate the buffer
     */
-  def createLimited[T](capacity: Int, initial: Seq[T]): ReplaySubject[T] = {
+  def createLimited[A](capacity: Int, initial: Seq[A]): ReplaySubject[A] = {
     require(capacity > 0, "capacity must be strictly positive")
     val elems = initial.takeRight(capacity)
-    new ReplaySubject[T](State[T](Queue(elems:_*), capacity))
+    new ReplaySubject[A](State[A](Queue(elems:_*), capacity))
   }
 
   /** Internal state for [[monix.reactive.subjects.ReplaySubject]] */
-  private final case class State[T](
-    buffer: Seq[T],
+  private final case class State[A](
+    buffer: Seq[A],
     capacity: Int,
-    subscribers: Set[ConnectableSubscriber[T]] = Set.empty[ConnectableSubscriber[T]],
+    subscribers: Set[ConnectableSubscriber[A]] = Set.empty[ConnectableSubscriber[A]],
     length: Int = 0,
     isDone: Boolean = false,
     errorThrown: Throwable = null) {
 
-    def appendElem(elem: T): State[T] = {
+    def appendElem(elem: A): State[A] = {
       if (capacity == 0)
         copy(buffer = buffer :+ elem)
       else if (length >= capacity)
@@ -234,15 +234,15 @@ object ReplaySubject {
         copy(buffer = buffer :+ elem, length = length + 1)
     }
 
-    def addNewSubscriber(s: ConnectableSubscriber[T]): State[T] =
+    def addNewSubscriber(s: ConnectableSubscriber[A]): State[A] =
       copy(subscribers = subscribers + s)
 
-    def removeSubscriber(toRemove: ConnectableSubscriber[T]): State[T] = {
+    def removeSubscriber(toRemove: ConnectableSubscriber[A]): State[A] = {
       val newSet = subscribers - toRemove
       copy(subscribers = newSet)
     }
 
-    def markDone(ex: Throwable): State[T] = {
+    def markDone(ex: Throwable): State[A] = {
       copy(subscribers = Set.empty, isDone = true, errorThrown = ex)
     }
   }

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ConcatOneSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ConcatOneSuite.scala
@@ -66,8 +66,8 @@ object ConcatOneSuite extends BaseOperatorSuite {
     Sample(o, count(sourceCount-1), sum(sourceCount-1), waitFirst, waitNext)
   }
 
-  def toList[T](o: Observable[T])(implicit s: Scheduler) = {
-    o.foldLeftF(Vector.empty[T])(_ :+ _).runAsyncGetLast
+  def toList[A](o: Observable[A])(implicit s: Scheduler) = {
+    o.foldLeftF(Vector.empty[A])(_ :+ _).runAsyncGetLast
       .map(_.getOrElse(Vector.empty))
   }
 

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapTaskSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapTaskSuite.scala
@@ -63,8 +63,8 @@ object MapTaskSuite extends BaseOperatorSuite {
     Sample(o, count(sourceCount-1), sum(sourceCount-1), waitFirst, waitNext)
   }
 
-  def toList[T](o: Observable[T])(implicit s: Scheduler) = {
-    o.foldLeftF(Vector.empty[T])(_ :+ _).runAsyncGetLast
+  def toList[A](o: Observable[A])(implicit s: Scheduler) = {
+    o.foldLeftF(Vector.empty[A])(_ :+ _).runAsyncGetLast
       .map(_.getOrElse(Vector.empty))
   }
 

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MergeOneSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MergeOneSuite.scala
@@ -67,8 +67,8 @@ object MergeOneSuite extends BaseOperatorSuite {
     Sample(o, count(sourceCount-1), sum(sourceCount-1), Zero, Zero)
   }
 
-  def toList[T](o: Observable[T])(implicit s: Scheduler) = {
-    o.foldLeftF(Vector.empty[T])(_ :+ _).runAsyncGetLast
+  def toList[A](o: Observable[A])(implicit s: Scheduler) = {
+    o.foldLeftF(Vector.empty[A])(_ :+ _).runAsyncGetLast
       .map(_.getOrElse(Vector.empty))
   }
 

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/ConnectableSubscriberSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/ConnectableSubscriberSuite.scala
@@ -142,6 +142,6 @@ object ConnectableSubscriberSuite extends TestSuite[TestScheduler] {
     assertEquals(errorThrown, DummyException("dummy"))
   }
 
-  def create[T](o: Observer[T])(implicit s: Scheduler) =
+  def create[A](o: Observer[A])(implicit s: Scheduler) =
     ConnectableSubscriber(Subscriber(o, s))
 }

--- a/monix-types/shared/src/test/scala/monix/types/tests/BaseLawsSuite.scala
+++ b/monix-types/shared/src/test/scala/monix/types/tests/BaseLawsSuite.scala
@@ -23,6 +23,6 @@ import monix.types.utils.IsEquiv
 import org.scalacheck.Prop
 
 trait BaseLawsSuite extends SimpleTestSuite with Checkers {
-  implicit def isEqToProp[T](isEq: IsEquiv[T])(implicit eq: Eq[T]): Prop =
+  implicit def isEqToProp[A](isEq: IsEquiv[A])(implicit eq: Eq[A]): Prop =
     Prop(eq(isEq.lh, isEq.rh))
 }

--- a/monix-types/shared/src/test/scala/monix/types/tests/Eq.scala
+++ b/monix-types/shared/src/test/scala/monix/types/tests/Eq.scala
@@ -20,7 +20,7 @@ package monix.types.tests
 import scala.concurrent.ExecutionException
 
 /** Type-class for testing equality, used only in tests. */
-trait Eq[T] { def apply(x: T, y: T): Boolean }
+trait Eq[A] { def apply(x: A, y: A): Boolean }
 
 object Eq {
   implicit val intEq: Eq[Int] = new Eq[Int] {


### PR DESCRIPTION
A pet peeve of mine is to use the same naming conventions everywhere.

In the beginning we used `T` as the default type parameter. Now we are using `A`. So I renamed `T` to `A` everywhere that I could find it being used.

This should not have an impact on backwards compatibility.