### PR TITLE
Update copyright headers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ All code must be licensed under the Apache 2.0 license and all files
 must include the following copyright header:
 
 ```
-Copyright (c) 2014-$today.year by its authors. Some rights reserved.
+Copyright (c) 2014-$today.year by The Monix Project Developers.
 See the project homepage at: https://monix.io
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/src/main/scala/monix/benchmarks/BackPressuredBufferBenchmark.scala
+++ b/benchmarks/src/main/scala/monix/benchmarks/BackPressuredBufferBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/src/main/scala/monix/benchmarks/DropNewBufferBenchmark.scala
+++ b/benchmarks/src/main/scala/monix/benchmarks/DropNewBufferBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/src/main/scala/monix/benchmarks/DropOldBufferBenchmark.scala
+++ b/benchmarks/src/main/scala/monix/benchmarks/DropOldBufferBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/src/main/scala/monix/benchmarks/FailBufferBenchmark.scala
+++ b/benchmarks/src/main/scala/monix/benchmarks/FailBufferBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/src/main/scala/monix/benchmarks/ObservableFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/monix/benchmarks/ObservableFlatMapBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/src/main/scala/monix/benchmarks/TaskFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/monix/benchmarks/TaskFlatMapBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/src/main/scala/monix/benchmarks/TaskFlatMapDeepBenchmark.scala
+++ b/benchmarks/src/main/scala/monix/benchmarks/TaskFlatMapDeepBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/src/main/scala/monix/benchmarks/TaskGatherBenchmark.scala
+++ b/benchmarks/src/main/scala/monix/benchmarks/TaskGatherBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/src/main/scala/monix/benchmarks/UnboundedBufferBenchmark.scala
+++ b/benchmarks/src/main/scala/monix/benchmarks/UnboundedBufferBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-cats/shared/src/main/scala/monix/cats/CatsToMonixConversions.scala
+++ b/monix-cats/shared/src/main/scala/monix/cats/CatsToMonixConversions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-cats/shared/src/main/scala/monix/cats/MonixToCatsConversions.scala
+++ b/monix-cats/shared/src/main/scala/monix/cats/MonixToCatsConversions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-cats/shared/src/main/scala/monix/cats/package.scala
+++ b/monix-cats/shared/src/main/scala/monix/cats/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-cats/shared/src/main/scala/monix/cats/reverse.scala
+++ b/monix-cats/shared/src/main/scala/monix/cats/reverse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-cats/shared/src/test/scala/monix/cats/tests/BaseLawsSuite.scala
+++ b/monix-cats/shared/src/test/scala/monix/cats/tests/BaseLawsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-cats/shared/src/test/scala/monix/cats/tests/CatsToMonixSuite.scala
+++ b/monix-cats/shared/src/test/scala/monix/cats/tests/CatsToMonixSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-cats/shared/src/test/scala/monix/cats/tests/CoevalCatsSanitySuite.scala
+++ b/monix-cats/shared/src/test/scala/monix/cats/tests/CoevalCatsSanitySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-cats/shared/src/test/scala/monix/cats/tests/CoevalLawsSuite.scala
+++ b/monix-cats/shared/src/test/scala/monix/cats/tests/CoevalLawsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-cats/shared/src/test/scala/monix/cats/tests/ObservableCatsSanitySuite.scala
+++ b/monix-cats/shared/src/test/scala/monix/cats/tests/ObservableCatsSanitySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-cats/shared/src/test/scala/monix/cats/tests/ObservableLawsSuite.scala
+++ b/monix-cats/shared/src/test/scala/monix/cats/tests/ObservableLawsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-cats/shared/src/test/scala/monix/cats/tests/ParallelTaskLawsSuite.scala
+++ b/monix-cats/shared/src/test/scala/monix/cats/tests/ParallelTaskLawsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-cats/shared/src/test/scala/monix/cats/tests/TaskCatsSanitySuite.scala
+++ b/monix-cats/shared/src/test/scala/monix/cats/tests/TaskCatsSanitySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-cats/shared/src/test/scala/monix/cats/tests/TaskLawsSuite.scala
+++ b/monix-cats/shared/src/test/scala/monix/cats/tests/TaskLawsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/js/src/main/scala/monix/eval/TaskApp.scala
+++ b/monix-eval/js/src/main/scala/monix/eval/TaskApp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/js/src/test/scala/monix/eval/TaskAppSuite.scala
+++ b/monix-eval/js/src/test/scala/monix/eval/TaskAppSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/jvm/src/main/scala/monix/eval/TaskApp.scala
+++ b/monix-eval/jvm/src/main/scala/monix/eval/TaskApp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/jvm/src/test/scala/monix/eval/TaskAppSuite.scala
+++ b/monix-eval/jvm/src/test/scala/monix/eval/TaskAppSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/jvm/src/test/scala/monix/eval/TaskBlockingSuite.scala
+++ b/monix-eval/jvm/src/test/scala/monix/eval/TaskBlockingSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/Callback.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Callback.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/Coeval.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Coeval.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/MVar.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/MVar.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/TaskCircuitBreaker.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/TaskCircuitBreaker.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/TaskSemaphore.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/TaskSemaphore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/CoevalRunLoop.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/CoevalRunLoop.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/LazyOnSuccess.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/LazyOnSuccess.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskChooseFirstOf.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskChooseFirstOf.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskChooseFirstOfList.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskChooseFirstOfList.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskCreate.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskCreate.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDeferAction.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDeferAction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDelayExecution.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDelayExecution.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDelayExecutionWith.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDelayExecutionWith.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDelayResult.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDelayResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDelayResultBySelector.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDelayResultBySelector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDoOnCancel.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDoOnCancel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskExecuteWithModel.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskExecuteWithModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskExecuteWithOptions.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskExecuteWithOptions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskFromFuture.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskFromFuture.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskGather.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskGather.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskGatherUnordered.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskGatherUnordered.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskMapBoth.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskMapBoth.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRunLoop.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRunLoop.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskSequence.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskSequence.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskToReactivePublisher.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskToReactivePublisher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/Transformation.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/Transformation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/BaseLawsSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/BaseLawsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/BaseTestSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/BaseTestSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalErrorSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalErrorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalEvalAlwaysSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalEvalAlwaysSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalEvalOnceSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalEvalOnceSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalMemoizeOnSuccessSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalMemoizeOnSuccessSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalMemoizeSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalMemoizeSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalMiscSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalMiscSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalNowSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalNowSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalSequenceSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalSequenceSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalZipSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalZipSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/MVarSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/MVarSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskApplySuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskApplySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskAsyncSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskAsyncSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskChooseFirstOfSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskChooseFirstOfSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskCircuitBreakerSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskCircuitBreakerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskCoevalDoOnFinishSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskCoevalDoOnFinishSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskCoevalForeachSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskCoevalForeachSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskCreateSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskCreateSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskDeferActionSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskDeferActionSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskDelaySuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskDelaySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskDoOnCancelSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskDoOnCancelSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskErrorSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskErrorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskEvalAlwaysSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskEvalAlwaysSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskEvalOnceSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskEvalOnceSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskExecutionModelSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskExecutionModelSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskFlatMapSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskFlatMapSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskForkSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskForkSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskGatherSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskGatherSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskGatherUnorderedSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskGatherUnorderedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskMapBothSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskMapBothSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskMemoizeOnSuccessSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskMemoizeOnSuccessSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskMemoizeSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskMemoizeSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskMiscSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskMiscSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskNowSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskNowSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskOrCoevalTransformWithSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskOrCoevalTransformWithSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskSemaphoreSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskSemaphoreSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskSequenceSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskSequenceSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskToFutureSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskToFutureSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskToStringSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskToStringSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskTraverseSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskTraverseSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskWanderSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskWanderSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskWanderUnorderedSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskWanderUnorderedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskZipSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskZipSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TypeClassLawsForCoevalSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TypeClassLawsForCoevalSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TypeClassLawsForNondetTaskSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TypeClassLawsForNondetTaskSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TypeClassLawsForTaskSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TypeClassLawsForTaskSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/package.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/Atomic.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/Atomic.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicAny.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicAny.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicBoolean.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicBoolean.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicBuilder.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicBuilder.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicByte.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicByte.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicChar.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicChar.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicDouble.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicDouble.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicFloat.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicFloat.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicInt.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicInt.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicLong.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicLong.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicNumber.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicNumber.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicNumberAny.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicNumberAny.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicShort.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicShort.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/package.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/package.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/js/src/main/scala/monix/execution/internal/Platform.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/internal/Platform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/internal/collection/ArrayQueue.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/internal/collection/ArrayQueue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/internal/collection/ArrayStackImpl.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/internal/collection/ArrayStackImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/misc/ThreadLocal.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/misc/ThreadLocal.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/schedulers/AsyncScheduler.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/schedulers/AsyncScheduler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/schedulers/SchedulerCompanionImpl.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/schedulers/SchedulerCompanionImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/schedulers/Timer.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/schedulers/Timer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/org/reactivestreams/Processor.scala
+++ b/monix-execution/js/src/main/scala/org/reactivestreams/Processor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/org/reactivestreams/Publisher.scala
+++ b/monix-execution/js/src/main/scala/org/reactivestreams/Publisher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/org/reactivestreams/Subscriber.scala
+++ b/monix-execution/js/src/main/scala/org/reactivestreams/Subscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/org/reactivestreams/Subscription.scala
+++ b/monix-execution/js/src/main/scala/org/reactivestreams/Subscription.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/test/scala/monix/execution/internal/AsyncSchedulerSuite.scala
+++ b/monix-execution/js/src/test/scala/monix/execution/internal/AsyncSchedulerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/test/scala/monix/execution/internal/PlatformSuite.scala
+++ b/monix-execution/js/src/test/scala/monix/execution/internal/PlatformSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/test/scala/monix/execution/internal/collection/ArrayQueueSuite.scala
+++ b/monix-execution/js/src/test/scala/monix/execution/internal/collection/ArrayQueueSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/BoxPaddingStrategy.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/BoxPaddingStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Factory.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Factory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left128Java7BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left128Java7BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left128Java7BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left128Java7BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left128Java7BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left128Java7BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left128Java8BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left128Java8BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left128Java8BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left128Java8BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left128Java8BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left128Java8BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left128JavaXBoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left128JavaXBoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left128JavaXBoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left128JavaXBoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left128JavaXBoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left128JavaXBoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left64Java7BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left64Java7BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left64Java7BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left64Java7BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left64Java7BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left64Java7BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left64Java8BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left64Java8BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left64Java8BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left64Java8BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left64Java8BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left64Java8BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left64JavaXBoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left64JavaXBoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left64JavaXBoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left64JavaXBoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left64JavaXBoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Left64JavaXBoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftPadding120.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftPadding120.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftPadding56.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftPadding56.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight128Java7BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight128Java7BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight128Java7BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight128Java7BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight128Java7BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight128Java7BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight128Java8BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight128Java8BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight128Java8BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight128Java8BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight128Java8BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight128Java8BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight128JavaXBoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight128JavaXBoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight128JavaXBoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight128JavaXBoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight128JavaXBoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight128JavaXBoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight256Java7BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight256Java7BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight256Java7BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight256Java7BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight256Java7BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight256Java7BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight256Java8BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight256Java8BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight256Java8BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight256Java8BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight256Java8BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight256Java8BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight256JavaXBoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight256JavaXBoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight256JavaXBoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight256JavaXBoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight256JavaXBoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/LeftRight256JavaXBoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/NormalJava7BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/NormalJava7BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/NormalJava7BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/NormalJava7BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/NormalJava7BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/NormalJava7BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/NormalJava8BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/NormalJava8BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/NormalJava8BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/NormalJava8BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/NormalJava8BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/NormalJava8BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/NormalJavaXBoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/NormalJavaXBoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/NormalJavaXBoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/NormalJavaXBoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/NormalJavaXBoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/NormalJavaXBoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right128Java7BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right128Java7BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right128Java7BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right128Java7BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right128Java7BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right128Java7BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right128Java8BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right128Java8BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right128Java8BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right128Java8BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right128Java8BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right128Java8BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right128JavaXBoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right128JavaXBoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right128JavaXBoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right128JavaXBoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right128JavaXBoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right128JavaXBoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right64Java7BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right64Java7BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right64Java7BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right64Java7BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right64Java7BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right64Java7BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right64Java8BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right64Java8BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right64Java8BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right64Java8BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right64Java8BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right64Java8BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right64JavaXBoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right64JavaXBoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right64JavaXBoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right64JavaXBoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right64JavaXBoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/Right64JavaXBoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/UnsafeAccess.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internals/atomic/UnsafeAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/Atomic.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/Atomic.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicAny.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicAny.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicBoolean.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicBoolean.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicBuilder.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicBuilder.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicByte.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicByte.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicChar.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicChar.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicDouble.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicDouble.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicFloat.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicFloat.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicInt.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicInt.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicLong.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicLong.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicNumber.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicNumber.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicNumberAny.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicNumberAny.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicShort.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicShort.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/package.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/package.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/Platform.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/Platform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/ArrayStackImpl.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/ArrayStackImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/forkJoin/AdaptedForkJoinPool.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/forkJoin/AdaptedForkJoinPool.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/forkJoin/AdaptedForkJoinTask.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/forkJoin/AdaptedForkJoinTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/forkJoin/DynamicWorkerThreadFactory.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/forkJoin/DynamicWorkerThreadFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/forkJoin/StandardWorkerThreadFactory.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/forkJoin/StandardWorkerThreadFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/misc/ThreadLocal.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/misc/ThreadLocal.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/AdaptedThreadPoolExecutorMixin.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/AdaptedThreadPoolExecutorMixin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/AsyncScheduler.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/AsyncScheduler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/Defaults.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/Defaults.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/ExecutorScheduler.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/ExecutorScheduler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/SchedulerCompanionImpl.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/SchedulerCompanionImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/ThreadFactoryBuilder.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/ThreadFactoryBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala_2.11/monix/execution/internal/forkJoin/package.scala
+++ b/monix-execution/jvm/src/main/scala_2.11/monix/execution/internal/forkJoin/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/test/scala/monix/execution/CancelableFutureJVMSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/CancelableFutureJVMSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/test/scala/monix/execution/atomic/ConcurrentAtomicNumberSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/atomic/ConcurrentAtomicNumberSuite.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/jvm/src/test/scala/monix/execution/atomic/ConcurrentAtomicSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/atomic/ConcurrentAtomicSuite.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/jvm/src/test/scala/monix/execution/internal/PlatformSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/internal/PlatformSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/AsyncSchedulerSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/AsyncSchedulerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/ExecutorSchedulerSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/ExecutorSchedulerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/ScheduledExecutorToSchedulerSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/ScheduledExecutorToSchedulerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TestSchedulerCompanionSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TestSchedulerCompanionSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TrampolineExecutionContextSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TrampolineExecutionContextSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/Ack.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/Ack.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/Cancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/Cancelable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/CancelableFuture.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/CancelableFuture.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/ExecutionModel.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/ExecutionModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/FutureUtils.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/FutureUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/Listener.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/Listener.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/Macros.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/Macros.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/Scheduler.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/Scheduler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/UncaughtExceptionReporter.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/UncaughtExceptionReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/atomic/PaddingStrategy.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/atomic/PaddingStrategy.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/AssignableCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/AssignableCancelable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/BooleanCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/BooleanCancelable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/CompositeCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/CompositeCancelable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/MultiAssignmentCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/MultiAssignmentCancelable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/RefCountCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/RefCountCancelable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/SerialCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/SerialCancelable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/SingleAssignmentCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/SingleAssignmentCancelable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/StackedCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/StackedCancelable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/package.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/exceptions/APIContractViolationException.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/exceptions/APIContractViolationException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/exceptions/BufferOverflowException.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/exceptions/BufferOverflowException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/exceptions/CompositeException.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/exceptions/CompositeException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/exceptions/DownstreamTimeoutException.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/exceptions/DownstreamTimeoutException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/exceptions/DummyException.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/exceptions/DummyException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/exceptions/ExecutionRejectedException.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/exceptions/ExecutionRejectedException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/exceptions/UpstreamTimeoutException.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/exceptions/UpstreamTimeoutException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/RunnableAction.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/RunnableAction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/collection/ArrayStack.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/collection/ArrayStack.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/collection/Buffer.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/collection/Buffer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/collection/DropAllOnOverflowQueue.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/collection/DropAllOnOverflowQueue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/collection/DropHeadOnOverflowQueue.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/collection/DropHeadOnOverflowQueue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/collection/EvictingQueue.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/collection/EvictingQueue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/math.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/math.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/misc/AsyncQueue.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/misc/AsyncQueue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/misc/AsyncSemaphore.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/misc/AsyncSemaphore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/misc/AsyncVar.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/misc/AsyncVar.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/misc/HygieneUtilMacros.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/misc/HygieneUtilMacros.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/shared/src/main/scala/monix/execution/misc/InlineMacros.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/misc/InlineMacros.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/shared/src/main/scala/monix/execution/misc/NonFatal.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/misc/NonFatal.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/misc/test/TestBox.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/misc/test/TestBox.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/shared/src/main/scala/monix/execution/misc/test/TestInlineMacros.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/misc/test/TestInlineMacros.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/shared/src/main/scala/monix/execution/rstreams/SingleAssignmentSubscription.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/rstreams/SingleAssignmentSubscription.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/rstreams/Subscription.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/rstreams/Subscription.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/BatchingScheduler.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/BatchingScheduler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/ReferenceScheduler.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/ReferenceScheduler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/SchedulerService.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/SchedulerService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/StartAsyncBatchRunnable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/StartAsyncBatchRunnable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/TestScheduler.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/TestScheduler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/TrampolineScheduler.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/TrampolineScheduler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/TrampolinedRunnable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/TrampolinedRunnable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/package.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala_2.11/monix/execution/misc/compat.scala
+++ b/monix-execution/shared/src/main/scala_2.11/monix/execution/misc/compat.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/shared/src/main/scala_2.11/monix/execution/schedulers/ExecuteExtensions.scala
+++ b/monix-execution/shared/src/main/scala_2.11/monix/execution/schedulers/ExecuteExtensions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala_2.11/monix/execution/schedulers/ExecuteMacros.scala
+++ b/monix-execution/shared/src/main/scala_2.11/monix/execution/schedulers/ExecuteMacros.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/AckSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/AckSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/CancelableFutureSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/CancelableFutureSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/CancelableSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/CancelableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/FutureUtilsSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/FutureUtilsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/atomic/AtomicBuilderSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/atomic/AtomicBuilderSuite.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/shared/src/test/scala/monix/execution/atomic/AtomicNumberSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/atomic/AtomicNumberSuite.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/shared/src/test/scala/monix/execution/atomic/BoxedLong.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/atomic/BoxedLong.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/shared/src/test/scala/monix/execution/atomic/GenericAtomicSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/atomic/GenericAtomicSuite.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/shared/src/test/scala/monix/execution/cancelables/AssignableCancelableSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/cancelables/AssignableCancelableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/cancelables/BooleanCancelableSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/cancelables/BooleanCancelableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/cancelables/CompositeCancelableSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/cancelables/CompositeCancelableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/cancelables/MultiAssignmentCancelableSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/cancelables/MultiAssignmentCancelableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/cancelables/RefCountCancelableSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/cancelables/RefCountCancelableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/cancelables/SerialCancelableSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/cancelables/SerialCancelableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/cancelables/SingleAssignmentCancelableSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/cancelables/SingleAssignmentCancelableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/cancelables/StackedCancelableSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/cancelables/StackedCancelableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/internal/MathSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/internal/MathSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/internal/collection/ArrayStackSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/internal/collection/ArrayStackSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/internal/collection/DropAllOnOverflowQueueSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/internal/collection/DropAllOnOverflowQueueSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/internal/collection/DropHeadOnOverflowQueueSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/internal/collection/DropHeadOnOverflowQueueSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/misc/AsyncQueueSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/misc/AsyncQueueSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/misc/AsyncSemaphoreSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/misc/AsyncSemaphoreSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/misc/AsyncVarSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/misc/AsyncVarSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/misc/InlineMacrosTest.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/misc/InlineMacrosTest.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016 by its authors. Some rights reserved.
- * See the project homepage at: https://sincron.org
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix-execution/shared/src/test/scala/monix/execution/misc/ThreadLocalSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/misc/ThreadLocalSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/rstreams/SingleAssignmentSubscriptionSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/rstreams/SingleAssignmentSubscriptionSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/schedulers/ExecutionModelSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/schedulers/ExecutionModelSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/schedulers/ReferenceSchedulerSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/schedulers/ReferenceSchedulerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/schedulers/TestSchedulerSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/schedulers/TestSchedulerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/schedulers/TrampolineSchedulerSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/schedulers/TrampolineSchedulerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/AbstractBackPressuredBufferedSubscriber.scala
+++ b/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/AbstractBackPressuredBufferedSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/BackPressuredBufferedSubscriber.scala
+++ b/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/BackPressuredBufferedSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/BatchedBufferedSubscriber.scala
+++ b/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/BatchedBufferedSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/BuildersImpl.scala
+++ b/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/BuildersImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/SyncBufferedSubscriber.scala
+++ b/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/SyncBufferedSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/main/java/monix/reactive/observers/buffers/CommonBufferMembers.java
+++ b/monix-reactive/jvm/src/main/java/monix/reactive/observers/buffers/CommonBufferMembers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/AbstractBackPressuredBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/AbstractBackPressuredBufferedSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/BackPressuredBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/BackPressuredBufferedSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/BatchedBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/BatchedBufferedSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/BuildersImpl.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/BuildersImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/ConcurrentQueue.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/ConcurrentQueue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/DropNewBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/DropNewBufferedSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/EvictingBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/EvictingBufferedSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/SimpleBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/SimpleBufferedSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/BaseConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/BaseConcurrencySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/consumers/LoadBalanceConsumerConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/consumers/LoadBalanceConsumerConcurrencySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/ConcatMapConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/ConcatMapConcurrencySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/MapAsyncParallelismConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/MapAsyncParallelismConcurrencySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressuredConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressuredConcurrencySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewAndSignalConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewAndSignalConcurrencySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewConcurrencySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyFailConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyFailConcurrencySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyUnboundedConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyUnboundedConcurrencySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/subjects/ReplaySubjectConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/subjects/ReplaySubjectConcurrencySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Consumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Consumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/MulticastStrategy.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/MulticastStrategy.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Notification.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Notification.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/OverflowStrategy.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/OverflowStrategy.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Pipe.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Pipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/exceptions/BufferOverflowException.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/exceptions/BufferOverflowException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/exceptions/CompositeException.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/exceptions/CompositeException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/exceptions/DownstreamTimeoutException.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/exceptions/DownstreamTimeoutException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/exceptions/MultipleSubscribersException.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/exceptions/MultipleSubscribersException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/exceptions/UpstreamTimeoutException.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/exceptions/UpstreamTimeoutException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/AsyncStateActionObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/AsyncStateActionObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CharsReaderObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CharsReaderObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest2Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest2Observable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest3Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest3Observable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest4Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest4Observable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest5Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest5Observable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest6Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest6Observable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ConsObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ConsObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CreateObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CreateObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/DeferObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/DeferObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/EmptyObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/EmptyObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ErrorObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ErrorObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/EvalAlwaysObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/EvalAlwaysObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/EvalOnceObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/EvalOnceObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ExecuteWithForkObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ExecuteWithForkObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ExecuteWithModelObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ExecuteWithModelObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/FirstStartedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/FirstStartedObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/FutureAsObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/FutureAsObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/InputStreamObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/InputStreamObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Interleave2Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Interleave2Observable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/IntervalFixedDelayObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/IntervalFixedDelayObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/IntervalFixedRateObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/IntervalFixedRateObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/IterableAsObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/IterableAsObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/IteratorAsObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/IteratorAsObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/LinesReaderObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/LinesReaderObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/NeverObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/NeverObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/NowObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/NowObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/PipeThroughSelectorObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/PipeThroughSelectorObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RangeObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RangeObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ReactiveObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ReactiveObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RepeatEvalObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RepeatEvalObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RepeatObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RepeatObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RepeatOneObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RepeatOneObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RepeatedValueObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RepeatedValueObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RunnableObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RunnableObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/StateActionObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/StateActionObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/TailRecMObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/TailRecMObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/TaskAsObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/TaskAsObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/UnsafeCreateObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/UnsafeCreateObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip2Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip2Observable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip3Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip3Observable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip4Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip4Observable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip5Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip5Observable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip6Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip6Observable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/CancelledConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/CancelledConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/CompleteConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/CompleteConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/ContraMapConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/ContraMapConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/CreateConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/CreateConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/FirstNotificationConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/FirstNotificationConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/FoldLeftAsyncConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/FoldLeftAsyncConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/FoldLeftConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/FoldLeftConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/ForeachAsyncConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/ForeachAsyncConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/ForeachConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/ForeachConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/FromObserverConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/FromObserverConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/HeadConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/HeadConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/HeadOptionConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/HeadOptionConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/LoadBalanceConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/LoadBalanceConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/MapAsyncConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/MapAsyncConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/MapConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/MapConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/RaiseErrorConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/RaiseErrorConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/TransformInputConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/TransformInputConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/AsyncBoundaryOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/AsyncBoundaryOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferIntrospectiveObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferIntrospectiveObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferSlidingOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferSlidingOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferTimedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferTimedObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferWithSelectorObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferWithSelectorObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/CollectOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/CollectOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/CompletedOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/CompletedOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ConcatMapObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ConcatMapObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/CountOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/CountOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DebounceObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DebounceObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DefaultIfEmptyOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DefaultIfEmptyOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayBySelectorObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayBySelectorObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayByTimespanObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayByTimespanObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayOnCompleteObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayOnCompleteObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelaySubscriptionByTimespanObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelaySubscriptionByTimespanObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelaySubscriptionWithTriggerObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelaySubscriptionWithTriggerObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DematerializeOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DematerializeOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DistinctByKeyOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DistinctByKeyOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DistinctOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DistinctOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DistinctUntilChangedByKeyOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DistinctUntilChangedByKeyOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DistinctUntilChangedOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DistinctUntilChangedOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnCompleteOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnCompleteOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnEarlyStopOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnEarlyStopOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnErrorOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnErrorOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnNextAckOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnNextAckOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnStartOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnStartOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnSubscribeObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnSubscribeObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnSubscriptionCancelObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnSubscriptionCancelObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnTerminateOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnTerminateOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DownstreamTimeoutObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DownstreamTimeoutObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropByPredicateOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropByPredicateOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropByPredicateWithIndexOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropByPredicateWithIndexOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropByTimespanObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropByTimespanObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropFirstOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropFirstOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropLastOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropLastOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropUntilObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropUntilObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DumpObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DumpObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EchoObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EchoObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EndWithErrorOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EndWithErrorOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EvalOnCompleteOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EvalOnCompleteOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EvalOnEarlyStopOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EvalOnEarlyStopOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EvalOnErrorOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EvalOnErrorOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EvalOnNextAckOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EvalOnNextAckOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EvalOnTerminateOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EvalOnTerminateOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ExecuteOnObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ExecuteOnObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FailedOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FailedOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FilterOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FilterOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FlatScanObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FlatScanObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FoldLeftObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FoldLeftObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FoldWhileObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FoldWhileObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/GroupByOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/GroupByOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/IsEmptyOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/IsEmptyOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapAsyncParallelObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapAsyncParallelObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapTaskObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapTaskObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MaterializeOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MaterializeOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MaxByOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MaxByOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MaxOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MaxOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MergeMapObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MergeMapObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MinByOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MinByOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MinOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MinOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ObserveOnObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ObserveOnObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/OnCancelTriggerErrorObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/OnCancelTriggerErrorObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/OnErrorRecoverWithObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/OnErrorRecoverWithObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/OnErrorRetryCountedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/OnErrorRetryCountedObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/OnErrorRetryIfObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/OnErrorRetryIfObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/PipeThroughObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/PipeThroughObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ReduceOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ReduceOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/RepeatSourceObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/RepeatSourceObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/RestartUntilObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/RestartUntilObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ScanObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ScanObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/SubscribeOnObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/SubscribeOnObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/SumOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/SumOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/SwitchIfEmptyObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/SwitchIfEmptyObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/SwitchMapObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/SwitchMapObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeByPredicateOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeByPredicateOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeEveryNthOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeEveryNthOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeLastOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeLastOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeLeftByTimespanObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeLeftByTimespanObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeLeftOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeLeftOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeUntilObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeUntilObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeWhileNotCanceledOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeWhileNotCanceledOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ThrottleFirstOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ThrottleFirstOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ThrottleLastObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ThrottleLastObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/UpstreamTimeoutObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/UpstreamTimeoutObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/WhileBusyDropEventsAndSignalOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/WhileBusyDropEventsAndSignalOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/WhileBusyDropEventsOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/WhileBusyDropEventsOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/WithLatestFromObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/WithLatestFromObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ZipWithIndexOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ZipWithIndexOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/rstreams/ReactiveSubscriberAsMonixSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/rstreams/ReactiveSubscriberAsMonixSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/rstreams/SubscriberAsReactiveSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/rstreams/SubscriberAsReactiveSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/subscribers/ForeachSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/subscribers/ForeachSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/util/Instances.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/util/Instances.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/util/PromiseCounter.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/util/PromiseCounter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observables/CachedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observables/CachedObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observables/ConnectableObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observables/ConnectableObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observables/GroupedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observables/GroupedObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observables/ObservableLike.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observables/ObservableLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observables/RefCountObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observables/RefCountObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observers/BufferedSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observers/BufferedSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observers/CacheUntilConnectSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observers/CacheUntilConnectSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observers/ConnectableSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observers/ConnectableSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observers/SafeSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observers/SafeSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observers/Subscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observers/Subscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observers/buffers/package.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observers/buffers/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/subjects/AsyncSubject.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/subjects/AsyncSubject.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/subjects/BehaviorSubject.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/subjects/BehaviorSubject.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/subjects/ConcurrentSubject.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/subjects/ConcurrentSubject.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/subjects/PublishSubject.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/subjects/PublishSubject.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/subjects/PublishToOneSubject.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/subjects/PublishToOneSubject.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/subjects/ReplaySubject.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/subjects/ReplaySubject.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/subjects/Subject.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/subjects/Subject.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/BaseLawsTestSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/BaseLawsTestSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/IsEquiv.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/IsEquiv.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/TypeClassLawsForObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/TypeClassLawsForObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/CancelConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/CancelConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/CompleteConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/CompleteConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/ContramapConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/ContramapConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/FirstNotificationConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/FirstNotificationConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/FoldLeftAsyncConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/FoldLeftAsyncConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/FoldLeftConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/FoldLeftConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/ForeachAsyncConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/ForeachAsyncConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/ForeachConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/ForeachConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/ForeachParallelAsyncConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/ForeachParallelAsyncConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/ForeachParallelConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/ForeachParallelConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/FromObserverConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/FromObserverConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/HeadConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/HeadConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/HeadOptionConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/HeadOptionConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/LoadBalanceConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/LoadBalanceConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/MapAsyncConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/MapAsyncConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/MapConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/MapConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/RaiseErrorConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/RaiseErrorConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/TransformInputConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/TransformInputConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/AsyncStateActionObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/AsyncStateActionObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/CharsReaderObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/CharsReaderObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/CreateObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/CreateObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/EmptyObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/EmptyObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/ErrorObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/ErrorObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/EvalAlwaysObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/EvalAlwaysObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/EvalObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/EvalObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/EvalOnceObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/EvalOnceObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/ExecuteWithForkObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/ExecuteWithForkObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/FirstStartedObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/FirstStartedObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/FutureAsObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/FutureAsObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/InputStreamObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/InputStreamObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/IntervalObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/IntervalObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/IterableAsObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/IterableAsObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/IteratorAsObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/IteratorAsObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/LinesReaderObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/LinesReaderObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/NeverObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/NeverObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/NowObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/NowObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/RangeObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/RangeObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/RepeatEvalObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/RepeatEvalObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/RepeatOneObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/RepeatOneObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/RepeatedValueObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/RepeatedValueObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/StateActionObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/StateActionObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/UnsafeCreateObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/UnsafeCreateObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/AsyncBoundarySuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/AsyncBoundarySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BaseOperatorSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BaseOperatorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferIntrospectiveSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferIntrospectiveSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferSlidingDropSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferSlidingDropSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferSlidingOverlapSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferSlidingOverlapSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferSlidingSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferSlidingSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferTimedOrCountedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferTimedOrCountedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferTimedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferTimedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferTumblingSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferTumblingSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferWithSelectorSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferWithSelectorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CacheSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CacheSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CollectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CollectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CombineLatest2Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CombineLatest2Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CombineLatest3Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CombineLatest3Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CombineLatest4Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CombineLatest4Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CombineLatest5Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CombineLatest5Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CombineLatest6Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CombineLatest6Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CombineLatestListSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CombineLatestListSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ConcatDelayErrorsSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ConcatDelayErrorsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ConcatManySuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ConcatManySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ConcatOneSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ConcatOneSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CountSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CountSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DebounceFlattenSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DebounceFlattenSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DebounceRepeatedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DebounceRepeatedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DebounceSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DebounceSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DelayBySelectorSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DelayBySelectorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DelayByTimespanSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DelayByTimespanSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DelayOnCompleteSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DelayOnCompleteSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DelaySubscriptionSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DelaySubscriptionSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DelaySubscriptionWithSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DelaySubscriptionWithSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DematerializeSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DematerializeSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DistinctByKeySuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DistinctByKeySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DistinctSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DistinctSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DistinctUntilChangedByKeySuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DistinctUntilChangedByKeySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DistinctUntilChangedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DistinctUntilChangedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoAfterTerminateSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoAfterTerminateSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnCompleteSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnCompleteSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnEarlyStopSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnEarlyStopSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnErrorSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnErrorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnNextAckSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnNextAckSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnNextSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnNextSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnSubscribeSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnSubscribeSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnSubscriptionCancelSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnSubscriptionCancelSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnTerminateSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnTerminateSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DropByPredicateSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DropByPredicateSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DropByPredicateWithIndexSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DropByPredicateWithIndexSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DropByTimespanSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DropByTimespanSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DropFirstSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DropFirstSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DropLastSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DropLastSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DropUntilSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DropUntilSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DumpSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DumpSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/EchoRepeatedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/EchoRepeatedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/EndWithErrorSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/EndWithErrorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/EvalAfterTerminateSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/EvalAfterTerminateSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/EvalOnCompleteSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/EvalOnCompleteSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/EvalOnEarlyStopSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/EvalOnEarlyStopSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/EvalOnErrorSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/EvalOnErrorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/EvalOnNextAckSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/EvalOnNextAckSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/EvalOnNextSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/EvalOnNextSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/EvalOnTerminateSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/EvalOnTerminateSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ExecuteOnSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ExecuteOnSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/FilterSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/FilterSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/FlatScanDelayErrorSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/FlatScanDelayErrorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/FlatScanSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/FlatScanSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/FoldLeftObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/FoldLeftObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/FoldWhileObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/FoldWhileObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/GroupBySuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/GroupBySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Interleave2Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Interleave2Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapAsyncParallelSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapAsyncParallelSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapTaskSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapTaskSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MaterializeSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MaterializeSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MaxBySuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MaxBySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MaxSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MaxSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MergeDelayErrorManySuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MergeDelayErrorManySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MergeDelayErrorOneSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MergeDelayErrorOneSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MergeManySuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MergeManySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MergeOneSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MergeOneSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MinBySuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MinBySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MinSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MinSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MiscCompleteSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MiscCompleteSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MiscDefaultIfEmptySuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MiscDefaultIfEmptySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MiscFailedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MiscFailedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MiscIsEmptySuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MiscIsEmptySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MiscNonEmptySuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MiscNonEmptySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ObservableOpsReturningTaskSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ObservableOpsReturningTaskSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ObserveOnSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ObserveOnSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/OnCancelTriggerErrorSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/OnCancelTriggerErrorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/OnErrorFallbackToSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/OnErrorFallbackToSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/OnErrorRecoverWithSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/OnErrorRecoverWithSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/OnErrorRetryCountedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/OnErrorRetryCountedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/OnErrorRetryIfSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/OnErrorRetryIfSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/OnErrorRetryUnlimitedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/OnErrorRetryUnlimitedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/PipeThroughSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/PipeThroughSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/PublishSelectorSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/PublishSelectorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ReduceSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ReduceSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/RepeatSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/RepeatSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/SampleOnceSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/SampleOnceSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/SampleRepeatedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/SampleRepeatedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ScanSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ScanSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/SumSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/SumSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/SwitchIfEmptySuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/SwitchIfEmptySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/SwitchMapSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/SwitchMapSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeByPredicateSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeByPredicateSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeByTimespanSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeByTimespanSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeEveryNthOperatorSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeEveryNthOperatorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeLastSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeLastSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeLeftSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeLeftSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeUntilObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeUntilObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeWhileNotCanceledSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeWhileNotCanceledSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ThrottleFirstSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ThrottleFirstSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TimeoutOnSlowDownstreamSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TimeoutOnSlowDownstreamSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TimeoutOnSlowUpstreamSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TimeoutOnSlowUpstreamSuite.scala
@@ -1,5 +1,5 @@
   /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WhileBusyDropEventsAndSignalOverflowSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WhileBusyDropEventsAndSignalOverflowSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WhileBusyDropEventsSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WhileBusyDropEventsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WithLatestFrom2Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WithLatestFrom2Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WithLatestFrom3Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WithLatestFrom3Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WithLatestFrom4Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WithLatestFrom4Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WithLatestFrom5Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WithLatestFrom5Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WithLatestFrom6Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WithLatestFrom6Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WithLatestFromSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WithLatestFromSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip2Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip2Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip3Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip3Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip4Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip4Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip5Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip5Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip6Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip6Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ZipListSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ZipListSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ZipWithIndexSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ZipWithIndexSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/rstreams/MonixSubscriberAsReactiveSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/rstreams/MonixSubscriberAsReactiveSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/rstreams/ObservableIsPublisherSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/rstreams/ObservableIsPublisherSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/rstreams/PublisherIsObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/rstreams/PublisherIsObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/subscribers/ObservableForeachSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/subscribers/ObservableForeachSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observables/ConnectableObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observables/ConnectableObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observables/RefCountObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observables/RefCountObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/ConnectableSubscriberSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/ConnectableSubscriberSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/DumpObserverSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/DumpObserverSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/ObserverFeedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/ObserverFeedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressureBatchedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressureBatchedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressureSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressureSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyClearBufferAndSignalSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyClearBufferAndSignalSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyClearBufferSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyClearBufferSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewAndSignalSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewAndSignalSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropOldAndSignalSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropOldAndSignalSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropOldSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropOldSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyFailSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyFailSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyUnboundedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyUnboundedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/SafeSubscriberSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/SafeSubscriberSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/SubscriberFeedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/SubscriberFeedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/subjects/AsyncSubjectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/subjects/AsyncSubjectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/subjects/BaseConcurrentSubjectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/subjects/BaseConcurrentSubjectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/subjects/BaseSubjectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/subjects/BaseSubjectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/subjects/BehaviorSubjectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/subjects/BehaviorSubjectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/subjects/ConcurrentAsyncSubjectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/subjects/ConcurrentAsyncSubjectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/subjects/ConcurrentBehaviorSubjectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/subjects/ConcurrentBehaviorSubjectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/subjects/ConcurrentPublishSubjectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/subjects/ConcurrentPublishSubjectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/subjects/ConcurrentReplaySubjectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/subjects/ConcurrentReplaySubjectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/subjects/PublishSubjectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/subjects/PublishSubjectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/subjects/ReplaySubjectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/subjects/ReplaySubjectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-scalaz/series-7.2/shared/src/main/scala/monix/scalaz/MonixToScalazConversions.scala
+++ b/monix-scalaz/series-7.2/shared/src/main/scala/monix/scalaz/MonixToScalazConversions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-scalaz/series-7.2/shared/src/main/scala/monix/scalaz/ScalazToMonixConversions.scala
+++ b/monix-scalaz/series-7.2/shared/src/main/scala/monix/scalaz/ScalazToMonixConversions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-scalaz/series-7.2/shared/src/main/scala/monix/scalaz/package.scala
+++ b/monix-scalaz/series-7.2/shared/src/main/scala/monix/scalaz/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-scalaz/series-7.2/shared/src/main/scala/monix/scalaz/reverse.scala
+++ b/monix-scalaz/series-7.2/shared/src/main/scala/monix/scalaz/reverse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-scalaz/series-7.2/shared/src/test/scala/monix/scalaz/tests/InstancesVisibilitySuite.scala
+++ b/monix-scalaz/series-7.2/shared/src/test/scala/monix/scalaz/tests/InstancesVisibilitySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-scalaz/series-7.2/shared/src/test/scala/monix/scalaz/tests/MonixToScalazSuite.scala
+++ b/monix-scalaz/series-7.2/shared/src/test/scala/monix/scalaz/tests/MonixToScalazSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-scalaz/series-7.2/shared/src/test/scala/monix/scalaz/tests/ScalazToMonixSuite.scala
+++ b/monix-scalaz/series-7.2/shared/src/test/scala/monix/scalaz/tests/ScalazToMonixSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-scalaz/series-7.2/shared/src/test/scala/monix/scalaz/tests/TaskSuite.scala
+++ b/monix-scalaz/series-7.2/shared/src/test/scala/monix/scalaz/tests/TaskSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2016 by its authors. Some rights reserved.
+# Copyright (c) 2014-2017 by The Monix Project Developers.
 # See the project homepage at: https://monix.io
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tckTests/src/test/scala/monix/tckTests/PublisherTest.scala
+++ b/tckTests/src/test/scala/monix/tckTests/PublisherTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tckTests/src/test/scala/monix/tckTests/SubscriberWhiteBoxAsyncTest.scala
+++ b/tckTests/src/test/scala/monix/tckTests/SubscriberWhiteBoxAsyncTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tckTests/src/test/scala/monix/tckTests/SubscriberWhiteBoxSyncTest.scala
+++ b/tckTests/src/test/scala/monix/tckTests/SubscriberWhiteBoxSyncTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
- updated year
- updated notice according to advice at: https://softwarefreedom.org/resources/2012/ManagingCopyrightInformation.html