### PR TITLE
Add contramap method to Callback

### DIFF
--- a/monix-eval/shared/src/main/scala/monix/eval/Callback.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Callback.scala
@@ -58,6 +58,12 @@ abstract class Callback[-A] extends Listener[A] with ((Try[A]) => Unit) {
       case Right(a) => onSuccess(a)
       case Left(e) => onError(e)
     }
+
+  /** Return a new callback that will apply the supplied function
+    * before passing the result into this callback.
+    */
+  final def contramap[B](f: B => A): Callback[B] =
+    new Callback.ContramapCallback(this, f)
 }
 
 object Callback {
@@ -161,18 +167,22 @@ object Callback {
       }
   }
 
+  private final class ContramapCallback[-A, -B](underlying: Callback[A], f: B => A)
+    extends Callback[B] {
+
+    def onSuccess(value: B): Unit =
+      try underlying.onSuccess(f(value)) catch {
+        case NonFatal(err) =>
+          underlying.onError(err)
+      }
+
+    def onError(ex: Throwable): Unit =
+      underlying.onError(ex)
+  }
+
   /** Contravariant type class instance of [[Callback]] for Cats. */
   implicit val contravariantCallback: Contravariant[Callback] = new Contravariant[Callback] {
-    override def contramap[A, B](cb: Callback[A])(f: (B) => A): Callback[B] =
-      new Callback[B] {
-        def onSuccess(value: B): Unit =
-          try cb.onSuccess(f(value)) catch {
-            case NonFatal(err) =>
-              cb.onError(err)
-          }
-
-        def onError(ex: Throwable): Unit =
-          cb.onError(ex)
-      }
+    override def contramap[A, B](cb: Callback[A])(f: B => A): Callback[B] =
+      cb.contramap(f)
   }
 }

--- a/monix-eval/shared/src/test/scala/monix/eval/CallbackSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CallbackSuite.scala
@@ -1,0 +1,64 @@
+package monix.eval
+
+import cats.functor.Contravariant
+
+import scala.util.{Failure, Success}
+
+object CallbackSuite extends BaseTestSuite {
+
+  case class TestCallback(success: Int => Unit = _ => (),
+                          error: Throwable => Unit = _ => ()) extends Callback[Int] {
+    var successCalled = false
+    var errorCalled = false
+
+    override def onSuccess(value: Int): Unit = {
+      successCalled = true
+      success(value)
+    }
+
+    override def onError(ex: Throwable): Unit = {
+      errorCalled = true
+      error(ex)
+    }
+  }
+
+  test("onValue should invoke onSuccess") { implicit s =>
+    val callback = TestCallback()
+    callback.onValue(1)
+    assert(callback.successCalled)
+  }
+
+  test("apply Success(value) should invoke onSuccess") { implicit s =>
+    val callback = TestCallback()
+    callback(Success(1))
+    assert(callback.successCalled)
+  }
+
+  test("apply Failure(ex) should invoke onError") { implicit s =>
+    val callback = TestCallback()
+    callback(Failure(new IllegalStateException()))
+    assert(callback.errorCalled)
+  }
+
+  test("contramap should invoke function before invoking callback") { implicit s =>
+    val callback = TestCallback()
+    val stringCallback = callback.contramap[String](_.toInt)
+    stringCallback.onSuccess("1")
+    assert(callback.successCalled)
+  }
+
+  test("contramap should invoke onError if the function throws") { implicit s =>
+    val callback = TestCallback()
+    val stringCallback = callback.contramap[String](_.toInt)
+    stringCallback.onSuccess("not a int")
+    assert(callback.errorCalled)
+  }
+
+  test("contramp has a cats Contramap instance") { implicit s =>
+    val instance = implicitly[Contravariant[Callback]]
+    val callback = TestCallback()
+    val stringCallback = instance.contramap(callback)((x: String) => x.toInt)
+    stringCallback.onSuccess("1")
+    assert(callback.successCalled)
+  }
+}


### PR DESCRIPTION
Allows you to perform transformations on callback based APIs. Using contramap on a callback means you don't need to provide an ExecutionContext to map on a Future.

Example: 
```scala
def example: Future[Result] = {
    val promise: Promise[Result] = Promise[Result]()
    val callback: Callback[ApiResult] =
         Callback.fromPromise(promise).contramap { apiResult: ApiResult =>
             Result.fromApiResult(apiResult)
         }
    api.method("request data", callback)
    promise.future
}
```

