### PR TITLE
Fix 2.13 community build: add Numeric#parseString in test code

### DIFF
--- a/monix-execution/shared/src/test/scala/monix/execution/atomic/BoxedLong.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/atomic/BoxedLong.scala
@@ -44,5 +44,8 @@ object BoxedLong {
       BoxedLong(x.value - y.value)
     def compare(x: BoxedLong, y: BoxedLong): Int =
       x.value.compareTo(y.value)
+    def parseString(str: String): Option[BoxedLong] =
+      try Some(BoxedLong(str.toLong))
+      catch { case _: NumberFormatException => None }
   }
 }

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/SumSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/SumSuite.scala
@@ -47,6 +47,7 @@ object SumSuite extends BaseOperatorSuite {
       def times(x: Long, y: Long): Long = throw ex
       def minus(x: Long, y: Long): Long = throw ex
       def compare(x: Long, y: Long): Int = throw ex
+      def parseString(str: String): Option[Long] = throw ex
     }
 
     val o = Observable.range(0, sourceCount+1).sumF(num)


### PR DESCRIPTION
Numeric#parseString got newly added in 2.13 (see
scala/community-builds#572).