### PR TITLE
Add Iterant.foldWhileLeftL and Iterant.foldWhileLeftEvalL

### DIFF
--- a/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
@@ -455,41 +455,39 @@ sealed abstract class Iterant[F[_], A] extends Product with Serializable {
     *
     * Example: {{{
     *   // Sums first 10 items
-    *   Iterant[Task].range(0, 1000).foldUntilRightL((0, 0)) {
+    *   Iterant[Task].range(0, 1000).foldWhileLeftL((0, 0)) {
     *     case ((sum, count), e) =>
     *       val next = (sum + e, count + 1)
     *       if (count + 1 < 10) Left(next) else Right(next)
     *   }
     *
     *   // Implements exists(predicate)
-    *   Iterant[Task].of(1, 2, 3, 4, 5).foldUntilRightL(false) {
+    *   Iterant[Task].of(1, 2, 3, 4, 5).foldWhileLeftL(false) {
     *     (default, e) =>
     *       if (e == 3) Right(true) else Left(default)
     *   }
     *
     *   // Implements forall(predicate)
-    *   Iterant[Task].of(1, 2, 3, 4, 5).foldUntilRightL(true) {
+    *   Iterant[Task].of(1, 2, 3, 4, 5).foldWhileLeftL(true) {
     *     (default, e) =>
     *       if (e != 3) Right(false) else Left(default)
     *   }
     * }}}
     *
-    * @see [[Iterant.foldUntilRightL]] for the lazy, potentially
-    *     asynchronous version.
-    *
+    * @see [[Iterant.foldWhileLeftL]] for the lazy, potentially
+    *      asynchronous version.
     * @param seed is the start value
     * @param op is the binary operator returning either `Left`,
     *        signaling that the state should be evolved or a `Right`,
     *        signaling that the process can be short-circuited and
     *        the result returned immediately
-    *
     * @return the result of inserting `op` between consecutive
     *         elements of this iterant, going from left to right with
     *         the `seed` as the start value, or `seed` if the iterant
     *         is empty
     */
-  final def foldUntilRightL[S](seed: => S)(op: (S, A) => Either[S, S])(implicit F: Sync[F]): F[S] =
-    IterantFoldUntilRight.strict(self, seed, op)
+  final def foldWhileLeftL[S](seed: => S)(op: (S, A) => Either[S, S])(implicit F: Sync[F]): F[S] =
+    IterantFoldWhileLeft.strict(self, seed, op)
 
   /** Left associative fold using the function `op` that can be
     * short-circuited.
@@ -505,7 +503,7 @@ sealed abstract class Iterant[F[_], A] extends Product with Serializable {
     *
     * Example using `cats.effect.IO`: {{{
     *   // Sums first 10 items
-    *   Iterant[IO].range(0, 1000).foldUntilRightEvalL(IO((0, 0))) {
+    *   Iterant[IO].range(0, 1000).foldWhileLeftEvalL(IO((0, 0))) {
     *     case ((sum, count), e) =>
     *       IO {
     *         val next = (sum + e, count + 1)
@@ -514,33 +512,31 @@ sealed abstract class Iterant[F[_], A] extends Product with Serializable {
     *   }
     *
     *   // Implements exists(predicate)
-    *   Iterant[IO].of(1, 2, 3, 4, 5).foldUntilRightEvalL(IO(false)) {
+    *   Iterant[IO].of(1, 2, 3, 4, 5).foldWhileLeftEvalL(IO(false)) {
     *     (default, e) =>
     *       IO { if (e == 3) Right(true) else Left(default) }
     *   }
     *
     *   // Implements forall(predicate)
-    *   Iterant[IO].of(1, 2, 3, 4, 5).foldUntilRightEvalL(IO(true)) {
+    *   Iterant[IO].of(1, 2, 3, 4, 5).foldWhileLeftEvalL(IO(true)) {
     *     (default, e) =>
     *       IO { if (e != 3) Right(false) else Left(default) }
     *   }
     * }}}
     *
-    * @see [[Iterant.foldUntilRightL]] for the strict version.
-    *
+    * @see [[Iterant.foldWhileLeftL]] for the strict version.
     * @param seed is the start value
     * @param op is the binary operator returning either `Left`,
     *        signaling that the state should be evolved or a `Right`,
     *        signaling that the process can be short-circuited and
     *        the result returned immediately
-    *
     * @return the result of inserting `op` between consecutive
     *         elements of this iterant, going from left to right with
     *         the `seed` as the start value, or `seed` if the iterant
     *         is empty
     */
-  final def foldUntilRightEvalL[S](seed: F[S])(op: (S, A) => F[Either[S, S]])(implicit F: Sync[F]): F[S] =
-    IterantFoldUntilRight.eval(self, seed, op)
+  final def foldWhileLeftEvalL[S](seed: F[S])(op: (S, A) => F[Either[S, S]])(implicit F: Sync[F]): F[S] =
+    IterantFoldWhileLeft.eval(self, seed, op)
 
   /** Given mapping functions from `F` to `G`, lifts the source into
     * an iterant that is going to use the resulting `G` for evaluation.

--- a/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
@@ -423,7 +423,7 @@ sealed abstract class Iterant[F[_], A] extends Product with Serializable {
   final def flatten[B](implicit ev: A <:< Iterant[F, B], F: Sync[F]): Iterant[F, B] =
     flatMap(x => x)(F)
 
-  /** Left associative fold using the function `f`.
+  /** Left associative fold using the function `op`.
     *
     * On execution the stream will be traversed from left to right,
     * and the given function will be called with the prior result,
@@ -443,7 +443,104 @@ sealed abstract class Iterant[F[_], A] extends Product with Serializable {
     *         is empty.
     */
   final def foldLeftL[S](seed: => S)(op: (S, A) => S)(implicit F: Sync[F]): F[S] =
-    IterantFoldLeftL(self, seed)(op)(F)
+    IterantFoldLeft(self, seed)(op)(F)
+
+  /** Left associative fold using the function `op` that can be
+    * short-circuited.
+    *
+    * On execution the stream will be traversed from left to right,
+    * and the given function will be called with the prior result,
+    * accumulating state either until the end, or until `op` returns
+    * a `Right` result, when the summary is returned.
+    *
+    * Example: {{{
+    *   // Sums first 10 items
+    *   Iterant[Task].range(0, 1000).foldUntilRightL((0, 0)) {
+    *     case ((sum, count), e) =>
+    *       val next = (sum + e, count + 1)
+    *       if (count + 1 < 10) Left(next) else Right(next)
+    *   }
+    *
+    *   // Implements exists(predicate)
+    *   Iterant[Task].of(1, 2, 3, 4, 5).foldUntilRightL(false) {
+    *     (default, e) =>
+    *       if (e == 3) Right(true) else Left(default)
+    *   }
+    *
+    *   // Implements forall(predicate)
+    *   Iterant[Task].of(1, 2, 3, 4, 5).foldUntilRightL(true) {
+    *     (default, e) =>
+    *       if (e != 3) Right(false) else Left(default)
+    *   }
+    * }}}
+    *
+    * @see [[Iterant.foldUntilRightL]] for the lazy, potentially
+    *     asynchronous version.
+    *
+    * @param seed is the start value
+    * @param op is the binary operator returning either `Left`,
+    *        signaling that the state should be evolved or a `Right`,
+    *        signaling that the process can be short-circuited and
+    *        the result returned immediately
+    *
+    * @return the result of inserting `op` between consecutive
+    *         elements of this iterant, going from left to right with
+    *         the `seed` as the start value, or `seed` if the iterant
+    *         is empty
+    */
+  final def foldUntilRightL[S](seed: => S)(op: (S, A) => Either[S, S])(implicit F: Sync[F]): F[S] =
+    IterantFoldUntilRight.strict(self, seed, op)
+
+  /** Left associative fold using the function `op` that can be
+    * short-circuited.
+    *
+    * On execution the stream will be traversed from left to right,
+    * and the given function will be called with the prior result,
+    * accumulating state either until the end, or until `op` returns
+    * a `Right` result, when the summary is returned.
+    *
+    * The results are returned in the `F[_]` functor context, meaning
+    * that we can have lazy or asynchronous processing and we can
+    * suspend side effects, depending on the `F` data type being used.
+    *
+    * Example using `cats.effect.IO`: {{{
+    *   // Sums first 10 items
+    *   Iterant[IO].range(0, 1000).foldUntilRightEvalL(IO((0, 0))) {
+    *     case ((sum, count), e) =>
+    *       IO {
+    *         val next = (sum + e, count + 1)
+    *         if (count + 1 < 10) Left(next) else Right(next)
+    *       }
+    *   }
+    *
+    *   // Implements exists(predicate)
+    *   Iterant[IO].of(1, 2, 3, 4, 5).foldUntilRightEvalL(IO(false)) {
+    *     (default, e) =>
+    *       IO { if (e == 3) Right(true) else Left(default) }
+    *   }
+    *
+    *   // Implements forall(predicate)
+    *   Iterant[IO].of(1, 2, 3, 4, 5).foldUntilRightEvalL(IO(true)) {
+    *     (default, e) =>
+    *       IO { if (e != 3) Right(false) else Left(default) }
+    *   }
+    * }}}
+    *
+    * @see [[Iterant.foldUntilRightL]] for the strict version.
+    *
+    * @param seed is the start value
+    * @param op is the binary operator returning either `Left`,
+    *        signaling that the state should be evolved or a `Right`,
+    *        signaling that the process can be short-circuited and
+    *        the result returned immediately
+    *
+    * @return the result of inserting `op` between consecutive
+    *         elements of this iterant, going from left to right with
+    *         the `seed` as the start value, or `seed` if the iterant
+    *         is empty
+    */
+  final def foldUntilRightEvalL[S](seed: F[S])(op: (S, A) => F[Either[S, S]])(implicit F: Sync[F]): F[S] =
+    IterantFoldUntilRight.eval(self, seed, op)
 
   /** Given mapping functions from `F` to `G`, lifts the source into
     * an iterant that is going to use the resulting `G` for evaluation.
@@ -790,7 +887,7 @@ sealed abstract class Iterant[F[_], A] extends Product with Serializable {
     * probably blowing up with an out of memory error sooner or later.
     */
   final def toListL(implicit F: Sync[F]): F[List[A]] =
-    IterantFoldLeftL.toListL(self)(F)
+    IterantFoldLeft.toListL(self)(F)
 
   /** Lazily zip two iterants together, using the given function `f` to
     * produce output values.

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFoldLeft.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFoldLeft.scala
@@ -24,7 +24,7 @@ import monix.tail.Iterant.{Halt, Last, Next, NextBatch, NextCursor, Suspend}
 import scala.collection.mutable
 import monix.execution.misc.NonFatal
 
-private[tail] object IterantFoldLeftL {
+private[tail] object IterantFoldLeft {
   /**
     * Implementation for `Iterant#foldLeftL`
     */
@@ -73,7 +73,7 @@ private[tail] object IterantFoldLeftL {
     * Implementation for `Iterant#toListL`
     */
   def toListL[F[_], A](source: Iterant[F, A])(implicit F: Sync[F]): F[List[A]] = {
-    val buffer = IterantFoldLeftL(source, mutable.ListBuffer.empty[A])((acc, a) => acc += a)
+    val buffer = IterantFoldLeft(source, mutable.ListBuffer.empty[A])((acc, a) => acc += a)
     buffer.map(_.toList)
   }
 }

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFoldUntilRight.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFoldUntilRight.scala
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.tail
+package internal
+
+import cats.effect.Sync
+import cats.syntax.all._
+import monix.execution.misc.NonFatal
+import monix.tail.Iterant.{Halt, Last, Next, NextBatch, NextCursor, Suspend}
+import monix.tail.batches.BatchCursor
+
+object IterantFoldUntilRight {
+  /** Implementation for `Iterant.foldUntilRight`. */
+  def strict[F[_], A, S](self: Iterant[F, A], seed: => S, f: (S, A) => Either[S, S])
+    (implicit F: Sync[F]): F[S] = {
+
+    def process(state: S, cursor: BatchCursor[A], rest: F[Iterant[F, A]], stop: F[Unit]) = {
+      var hasResult = false
+      var s = state
+
+      while (!hasResult && cursor.hasNext()) {
+        f(s, cursor.next()) match {
+          case Left(s2) => s = s2
+          case Right(s2) =>
+            hasResult = true
+            s = s2
+        }
+      }
+
+      if (hasResult)
+        stop.map(_ => s)
+      else
+        rest.flatMap(loop(s))
+    }
+
+    def loop(state: S)(self: Iterant[F, A]): F[S] = {
+      try self match {
+        case Next(a, rest, stop) =>
+          f(state, a) match {
+            case Left(s) => rest.flatMap(loop(s))
+            case Right(s) => stop.map(_ => s)
+          }
+
+        case NextCursor(cursor, rest, stop) =>
+          process(state, cursor, rest, stop)
+
+        case NextBatch(batch, rest, stop) =>
+          val cursor = batch.cursor()
+          process(state, cursor, rest, stop)
+
+        case Suspend(rest, _) =>
+          rest.flatMap(loop(state))
+
+        case Last(a) =>
+          F.pure(f(state, a) match {
+            case Left(s) => s
+            case Right(s) => s
+          })
+
+        case Halt(optE) =>
+          optE match {
+            case None => F.pure(state)
+            case Some(e) => F.raiseError(e)
+          }
+      }
+      catch {
+        case NonFatal(e) =>
+          self.earlyStop.followedBy(F.raiseError(e))
+      }
+    }
+
+
+    F.suspend(loop(seed)(self))
+  }
+
+  /** Implementation for `Iterant.foldUntilRightEval`. */
+  def eval[F[_], A, S](self: Iterant[F, A], seed: F[S], f: (S, A) => F[Either[S, S]])
+    (implicit F: Sync[F]): F[S] = {
+
+    def process(state: S, stop: F[Unit], rest: F[Iterant[F, A]], a: A): F[S] = {
+      val fs = f(state, a).handleErrorWith { e =>
+        stop.flatMap(_ => F.raiseError(e))
+      }
+
+      fs.flatMap {
+        case Left(s) => rest.flatMap(loop(s))
+        case Right(s) => stop.map(_ => s)
+      }
+    }
+
+    def loop(state: S)(self: Iterant[F, A]): F[S] = {
+      try self match {
+        case Next(a, rest, stop) =>
+          process(state, stop, rest, a)
+
+        case NextCursor(cursor, rest, stop) =>
+          if (!cursor.hasNext()) rest.flatMap(loop(state)) else {
+            val a = cursor.next()
+            process(state, stop, F.pure(self), a)
+          }
+
+        case NextBatch(batch, rest, stop) =>
+          val cursor = batch.cursor()
+          if (!cursor.hasNext()) rest.flatMap(loop(state)) else {
+            val a = cursor.next()
+            process(state, stop, F.pure(NextCursor(cursor, rest, stop)), a)
+          }
+
+        case Suspend(rest, _) =>
+          rest.flatMap(loop(state))
+
+        case Last(a) =>
+          f(state, a).map {
+            case Left(s) => s
+            case Right(s) => s
+          }
+
+        case Halt(optE) =>
+          optE match {
+            case None => F.pure(state)
+            case Some(e) => F.raiseError(e)
+          }
+      }
+      catch {
+        case NonFatal(e) =>
+          self.earlyStop.followedBy(F.raiseError(e))
+      }
+    }
+
+    F.suspend(seed.flatMap(s => loop(s)(self)))
+  }
+}

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFoldWhileLeft.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFoldWhileLeft.scala
@@ -24,8 +24,8 @@ import monix.execution.misc.NonFatal
 import monix.tail.Iterant.{Halt, Last, Next, NextBatch, NextCursor, Suspend}
 import monix.tail.batches.BatchCursor
 
-object IterantFoldUntilRight {
-  /** Implementation for `Iterant.foldUntilRight`. */
+object IterantFoldWhileLeft {
+  /** Implementation for `Iterant.foldWhileLeftL`. */
   def strict[F[_], A, S](self: Iterant[F, A], seed: => S, f: (S, A) => Either[S, S])
     (implicit F: Sync[F]): F[S] = {
 
@@ -88,7 +88,7 @@ object IterantFoldUntilRight {
     F.suspend(loop(seed)(self))
   }
 
-  /** Implementation for `Iterant.foldUntilRightEval`. */
+  /** Implementation for `Iterant.foldWhileLeftEvalL`. */
   def eval[F[_], A, S](self: Iterant[F, A], seed: F[S], f: (S, A) => F[Either[S, S]])
     (implicit F: Sync[F]): F[S] = {
 

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantUntilRightSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantUntilRightSuite.scala
@@ -24,22 +24,22 @@ import scala.util.{Failure, Success}
 
 object IterantUntilRightSuite extends BaseTestSuite {
   def exists(fa: Iterant[Coeval, Int], p: Int => Boolean): Coeval[Boolean] =
-    fa.foldUntilRightL(false) { (default, e) =>
+    fa.foldWhileLeftL(false) { (default, e) =>
       if (p(e)) Right(true) else Left(default)
     }
 
   def existsEval(fa: Iterant[Coeval, Int], p: Int => Boolean): Coeval[Boolean] =
-    fa.foldUntilRightEvalL(Coeval(false)) { (default, e) =>
+    fa.foldWhileLeftEvalL(Coeval(false)) { (default, e) =>
       Coeval(if (p(e)) Right(true) else Left(default))
     }
 
   def forall(ref: Iterant[Coeval, Int], p: Int => Boolean): Coeval[Boolean] =
-    ref.foldUntilRightL(true) { (default, e) =>
+    ref.foldWhileLeftL(true) { (default, e) =>
       if (!p(e)) Right(false) else Left(default)
     }
 
   def forallEval(ref: Iterant[Coeval, Int], p: Int => Boolean): Coeval[Boolean] =
-    ref.foldUntilRightEvalL(Coeval(true)) { (default, e) =>
+    ref.foldWhileLeftEvalL(Coeval(true)) { (default, e) =>
       Coeval { if (!p(e)) Right(false) else Left(default) }
     }
 
@@ -104,7 +104,7 @@ object IterantUntilRightSuite extends BaseTestSuite {
     val ref = Iterant[Coeval].of(1, 2, 3)
       .map { x => effect += 1; x }
       .doOnEarlyStop(Coeval { effect += 1 })
-      .foldUntilRightL((throw dummy) : Int)((acc, i) => Left(acc + i))
+      .foldWhileLeftL((throw dummy) : Int)((acc, i) => Left(acc + i))
 
     assertEquals(ref.runTry, Failure(dummy))
     assertEquals(effect, 0)
@@ -116,7 +116,7 @@ object IterantUntilRightSuite extends BaseTestSuite {
 
     val ref = Iterant[Coeval].of(1, 2, 3)
       .doOnEarlyStop(Coeval { effect += 1 })
-      .foldUntilRightL(0)((_, _) => throw dummy)
+      .foldWhileLeftL(0)((_, _) => throw dummy)
 
     assertEquals(effect, 0)
     assertEquals(ref.runTry, Failure(dummy))
@@ -129,7 +129,7 @@ object IterantUntilRightSuite extends BaseTestSuite {
 
     val ref = Iterant[Coeval].nextCursorS(ThrowExceptionCursor[Int](dummy), Coeval(Iterant[Coeval].empty[Int]), Coeval.unit)
       .doOnEarlyStop(Coeval { effect += 1 })
-      .foldUntilRightL(0)((a, e) => Left(a + e))
+      .foldWhileLeftL(0)((a, e) => Left(a + e))
 
     assertEquals(effect, 0)
     assertEquals(ref.runTry, Failure(dummy))
@@ -142,7 +142,7 @@ object IterantUntilRightSuite extends BaseTestSuite {
 
     val ref = Iterant[Coeval].nextBatchS(ThrowExceptionBatch[Int](dummy), Coeval(Iterant[Coeval].empty[Int]), Coeval.unit)
       .doOnEarlyStop(Coeval { effect += 1 })
-      .foldUntilRightL(0)((a, e) => Left(a + e))
+      .foldWhileLeftL(0)((a, e) => Left(a + e))
 
     assertEquals(effect, 0)
     assertEquals(ref.runTry, Failure(dummy))
@@ -156,7 +156,7 @@ object IterantUntilRightSuite extends BaseTestSuite {
     val ref = Iterant[Coeval].of(1, 2, 3)
       .map { x => effect += 1; x }
       .doOnEarlyStop(Coeval { effect += 1 })
-      .foldUntilRightEvalL(Coeval.raiseError[Int](dummy))((acc, i) => Coeval(Left(acc + i)))
+      .foldWhileLeftEvalL(Coeval.raiseError[Int](dummy))((acc, i) => Coeval(Left(acc + i)))
 
     assertEquals(ref.runTry, Failure(dummy))
     assertEquals(effect, 0)
@@ -168,7 +168,7 @@ object IterantUntilRightSuite extends BaseTestSuite {
 
     val ref = Iterant[Coeval].of(1, 2, 3)
       .doOnEarlyStop(Coeval { effect += 1 })
-      .foldUntilRightEvalL(Coeval(0))((_, _) => throw dummy)
+      .foldWhileLeftEvalL(Coeval(0))((_, _) => throw dummy)
 
     assertEquals(effect, 0)
     assertEquals(ref.runTry, Failure(dummy))
@@ -181,7 +181,7 @@ object IterantUntilRightSuite extends BaseTestSuite {
 
     val ref = Iterant[Coeval].of(1, 2, 3)
       .doOnEarlyStop(Coeval { effect += 1 })
-      .foldUntilRightEvalL(Coeval(0))((_, _) => Coeval.raiseError(dummy))
+      .foldWhileLeftEvalL(Coeval(0))((_, _) => Coeval.raiseError(dummy))
 
     assertEquals(effect, 0)
     assertEquals(ref.runTry, Failure(dummy))
@@ -194,7 +194,7 @@ object IterantUntilRightSuite extends BaseTestSuite {
 
     val ref = Iterant[Coeval].nextCursorS(ThrowExceptionCursor[Int](dummy), Coeval(Iterant[Coeval].empty[Int]), Coeval.unit)
       .doOnEarlyStop(Coeval { effect += 1 })
-      .foldUntilRightEvalL(Coeval(0))((a, e) => Coeval(Left(a + e)))
+      .foldWhileLeftEvalL(Coeval(0))((a, e) => Coeval(Left(a + e)))
 
     assertEquals(effect, 0)
     assertEquals(ref.runTry, Failure(dummy))
@@ -207,7 +207,7 @@ object IterantUntilRightSuite extends BaseTestSuite {
 
     val ref = Iterant[Coeval].nextBatchS(ThrowExceptionBatch[Int](dummy), Coeval(Iterant[Coeval].empty[Int]), Coeval.unit)
       .doOnEarlyStop(Coeval { effect += 1 })
-      .foldUntilRightEvalL(Coeval(0))((a, e) => Coeval(Left(a + e)))
+      .foldWhileLeftEvalL(Coeval(0))((a, e) => Coeval(Left(a + e)))
 
     assertEquals(effect, 0)
     assertEquals(ref.runTry, Failure(dummy))

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantUntilRightSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantUntilRightSuite.scala
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.tail
+
+import monix.eval.Coeval
+import monix.execution.exceptions.DummyException
+
+import scala.util.{Failure, Success}
+
+object IterantUntilRightSuite extends BaseTestSuite {
+  def exists(fa: Iterant[Coeval, Int], p: Int => Boolean): Coeval[Boolean] =
+    fa.foldUntilRightL(false) { (default, e) =>
+      if (p(e)) Right(true) else Left(default)
+    }
+
+  def existsEval(fa: Iterant[Coeval, Int], p: Int => Boolean): Coeval[Boolean] =
+    fa.foldUntilRightEvalL(Coeval(false)) { (default, e) =>
+      Coeval(if (p(e)) Right(true) else Left(default))
+    }
+
+  def forall(ref: Iterant[Coeval, Int], p: Int => Boolean): Coeval[Boolean] =
+    ref.foldUntilRightL(true) { (default, e) =>
+      if (!p(e)) Right(false) else Left(default)
+    }
+
+  def forallEval(ref: Iterant[Coeval, Int], p: Int => Boolean): Coeval[Boolean] =
+    ref.foldUntilRightEvalL(Coeval(true)) { (default, e) =>
+      Coeval { if (!p(e)) Right(false) else Left(default) }
+    }
+
+  test("foldUntilRightL can express exists") { implicit s =>
+    check3 { (list: List[Int], idx: Int, p: Int => Boolean) =>
+      val fa = arbitraryListToIterant[Coeval, Int](list, idx, allowErrors = false)
+      exists(fa, p) <-> Coeval(list.exists(p))
+    }
+  }
+
+  test("foldUntilRightEvalL can express exists") { implicit s =>
+    check3 { (list: List[Int], idx: Int, p: Int => Boolean) =>
+      val fa = arbitraryListToIterant[Coeval, Int](list, idx, allowErrors = false)
+      existsEval(fa, p) <-> Coeval(list.exists(p))
+    }
+  }
+
+  test("foldUntilRightL can express forall") { implicit s =>
+    check3 { (list: List[Int], idx: Int, p: Int => Boolean) =>
+      val fa = arbitraryListToIterant[Coeval, Int](list, idx, allowErrors = false)
+      forall(fa, p) <-> Coeval(list.forall(p))
+    }
+  }
+
+  test("foldUntilRightEvalL can express forall") { implicit s =>
+    check3 { (list: List[Int], idx: Int, p: Int => Boolean) =>
+      val fa = arbitraryListToIterant[Coeval, Int](list, idx, allowErrors = false)
+      forallEval(fa, p) <-> Coeval(list.forall(p))
+    }
+  }
+
+  test("foldUntilRightL can short-circuit") { implicit s =>
+    var effect = 0
+    val ref = Iterant[Coeval].of(1, 2, 3, 4).doOnEarlyStop(Coeval { effect += 1 })
+
+    val r1 = exists(ref, _ == 6)
+    assertEquals(r1.runTry, Success(false))
+    assertEquals(effect, 0)
+
+    val r2 = exists(ref, _ == 3)
+    assertEquals(r2.runTry, Success(true))
+    assertEquals(effect, 1)
+  }
+
+  test("foldUntilRightEvalL can short-circuit") { implicit s =>
+    var effect = 0
+    val ref = Iterant[Coeval].of(1, 2, 3, 4).doOnEarlyStop(Coeval { effect += 1 })
+
+    val r1 = existsEval(ref, _ == 6)
+    assertEquals(r1.runTry, Success(false))
+    assertEquals(effect, 0)
+
+    val r2 = existsEval(ref, _ == 3)
+    assertEquals(r2.runTry, Success(true))
+    assertEquals(effect, 1)
+  }
+
+  test("foldUntilRightL protects against broken seed") { implicit s =>
+    var effect = 0
+    val dummy = DummyException("dummy")
+
+    val ref = Iterant[Coeval].of(1, 2, 3)
+      .map { x => effect += 1; x }
+      .doOnEarlyStop(Coeval { effect += 1 })
+      .foldUntilRightL((throw dummy) : Int)((acc, i) => Left(acc + i))
+
+    assertEquals(ref.runTry, Failure(dummy))
+    assertEquals(effect, 0)
+  }
+
+  test("foldUntilRightL protects against broken op") { implicit s =>
+    var effect = 0
+    val dummy = DummyException("dummy")
+
+    val ref = Iterant[Coeval].of(1, 2, 3)
+      .doOnEarlyStop(Coeval { effect += 1 })
+      .foldUntilRightL(0)((_, _) => throw dummy)
+
+    assertEquals(effect, 0)
+    assertEquals(ref.runTry, Failure(dummy))
+    assertEquals(effect, 1)
+  }
+
+  test("foldUntilRightL protects against broken cursors") { implicit s =>
+    var effect = 0
+    val dummy = DummyException("dummy")
+
+    val ref = Iterant[Coeval].nextCursorS(ThrowExceptionCursor[Int](dummy), Coeval(Iterant[Coeval].empty[Int]), Coeval.unit)
+      .doOnEarlyStop(Coeval { effect += 1 })
+      .foldUntilRightL(0)((a, e) => Left(a + e))
+
+    assertEquals(effect, 0)
+    assertEquals(ref.runTry, Failure(dummy))
+    assertEquals(effect, 1)
+  }
+
+  test("foldUntilRightL protects against broken batches") { implicit s =>
+    var effect = 0
+    val dummy = DummyException("dummy")
+
+    val ref = Iterant[Coeval].nextBatchS(ThrowExceptionBatch[Int](dummy), Coeval(Iterant[Coeval].empty[Int]), Coeval.unit)
+      .doOnEarlyStop(Coeval { effect += 1 })
+      .foldUntilRightL(0)((a, e) => Left(a + e))
+
+    assertEquals(effect, 0)
+    assertEquals(ref.runTry, Failure(dummy))
+    assertEquals(effect, 1)
+  }
+  
+  test("foldUntilRightEvalL protects against broken seed") { implicit s =>
+    var effect = 0
+    val dummy = DummyException("dummy")
+
+    val ref = Iterant[Coeval].of(1, 2, 3)
+      .map { x => effect += 1; x }
+      .doOnEarlyStop(Coeval { effect += 1 })
+      .foldUntilRightEvalL(Coeval.raiseError[Int](dummy))((acc, i) => Coeval(Left(acc + i)))
+
+    assertEquals(ref.runTry, Failure(dummy))
+    assertEquals(effect, 0)
+  }
+
+  test("foldUntilRightEvalL protects against broken op") { implicit s =>
+    var effect = 0
+    val dummy = DummyException("dummy")
+
+    val ref = Iterant[Coeval].of(1, 2, 3)
+      .doOnEarlyStop(Coeval { effect += 1 })
+      .foldUntilRightEvalL(Coeval(0))((_, _) => throw dummy)
+
+    assertEquals(effect, 0)
+    assertEquals(ref.runTry, Failure(dummy))
+    assertEquals(effect, 1)
+  }
+
+  test("foldUntilRightEvalL protects against op signaling failure") { implicit s =>
+    var effect = 0
+    val dummy = DummyException("dummy")
+
+    val ref = Iterant[Coeval].of(1, 2, 3)
+      .doOnEarlyStop(Coeval { effect += 1 })
+      .foldUntilRightEvalL(Coeval(0))((_, _) => Coeval.raiseError(dummy))
+
+    assertEquals(effect, 0)
+    assertEquals(ref.runTry, Failure(dummy))
+    assertEquals(effect, 1)
+  }
+
+  test("foldUntilRightEvalL protects against broken cursors") { implicit s =>
+    var effect = 0
+    val dummy = DummyException("dummy")
+
+    val ref = Iterant[Coeval].nextCursorS(ThrowExceptionCursor[Int](dummy), Coeval(Iterant[Coeval].empty[Int]), Coeval.unit)
+      .doOnEarlyStop(Coeval { effect += 1 })
+      .foldUntilRightEvalL(Coeval(0))((a, e) => Coeval(Left(a + e)))
+
+    assertEquals(effect, 0)
+    assertEquals(ref.runTry, Failure(dummy))
+    assertEquals(effect, 1)
+  }
+
+  test("foldUntilRightEvalL protects against broken batches") { implicit s =>
+    var effect = 0
+    val dummy = DummyException("dummy")
+
+    val ref = Iterant[Coeval].nextBatchS(ThrowExceptionBatch[Int](dummy), Coeval(Iterant[Coeval].empty[Int]), Coeval.unit)
+      .doOnEarlyStop(Coeval { effect += 1 })
+      .foldUntilRightEvalL(Coeval(0))((a, e) => Coeval(Left(a + e)))
+
+    assertEquals(effect, 0)
+    assertEquals(ref.runTry, Failure(dummy))
+    assertEquals(effect, 1)
+  }
+}


### PR DESCRIPTION
This adds 2 `foldLeft`-like operators to `Iterant` that are supposed to be a more efficient, but less powerful replacement for a `foldRight`.

The strict version:
```scala
def foldWhileLeftL[S](seed: => S)(op: (S, A) => Either[S, S])
  (implicit F: Sync[F]): F[S]
```

And the lazy version:
```scala
def foldWhileLeftEvalL[S](seed: F[S])(op: (S, A) => F[Either[S, S]])
  (implicit F: Sync[F]): F[S]
```

Note, these signatures are methods, `this` is implied to be `Iterant[F, A]`.

What this adds over regular `foldLeft`:

1. the ability to short-circuit processing, such that operators like `exists` and `forall` can be expressed with it
2. the ability to describe side effects with lazy or asynchronous execution (second variant)

Examples given in the ScalaDoc:

```scala
// Sums first 10 items
Iterant[Task].range(0, 1000).foldWhileLeftL((0, 0)) {
  case ((sum, count), e) =>
    val next = (sum + e, count + 1)
    if (count + 1 < 10) Left(next) else Right(next)
}

// Implements exists(predicate)
Iterant[Task].of(1, 2, 3, 4, 5).foldWhileLeftL(false) {
  (default, e) =>
    if (e == 3) Right(true) else Left(default)
}

// Implements forall(predicate)
Iterant[Task].of(1, 2, 3, 4, 5).foldWhileLeftL(true) {
  (default, e) =>
    if (e != 3) Right(false) else Left(default)
}
```

And for the `F[_]` enabled version:
```scala
// Sums first 10 items
Iterant[IO].range(0, 1000).foldWhileLeftEvalL(IO((0, 0))) {
  case ((sum, count), e) =>
    IO {
      val next = (sum + e, count + 1)
      if (count + 1 < 10) Left(next) else Right(next)
    }
}

// Implements exists(predicate)
Iterant[IO].of(1, 2, 3, 4, 5).foldWhileLeftEvalL(IO(false)) {
  (default, e) =>
    IO { if (e == 3) Right(true) else Left(default) }
}

// Implements forall(predicate)
Iterant[IO].of(1, 2, 3, 4, 5).foldWhileLeftEvalL(IO(true)) {
  (default, e) =>
    IO { if (e != 3) Right(false) else Left(default) }
}
```