### PR TITLE
Add Iterant ops: findL, foldL, maxL, minL, reduceL

### DIFF
--- a/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
@@ -664,7 +664,7 @@ sealed abstract class Iterant[F[_], A] extends Product with Serializable {
     * `f` is different from other implementations, receiving the
     * current `earlyStop: F[Unit]` as a third parameter.
     *
-    * Here's for example how [[existsL]], [[forallL]] and [[++]] could
+    * Here's for example how [[existsL]], [[forallL]] and `++` could
     * be expressed in terms of `foldRightL`:
     *
     * {{{

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantReduce.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantReduce.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.tail
+package internal
+
+import cats.syntax.all._
+import cats.effect.Sync
+import monix.execution.misc.NonFatal
+import monix.tail.Iterant.{Halt, Last, Next, NextBatch, NextCursor, Suspend}
+
+private[tail] object IterantReduce {
+  /** Implementation for `Iterant.reduce`. */
+  def apply[F[_], A](self: Iterant[F, A], op: (A, A) => A)
+    (implicit F: Sync[F]): F[Option[A]] = {
+
+    def loop(state: A)(self: Iterant[F, A]): F[A] = {
+      try self match {
+        case Next(a, rest, _) =>
+          val newState = op(state, a)
+          rest.flatMap(loop(newState))
+        case NextCursor(cursor, rest, _) =>
+          val newState = cursor.foldLeft(state)(op)
+          rest.flatMap(loop(newState))
+        case NextBatch(gen, rest, _) =>
+          val newState = gen.foldLeft(state)(op)
+          rest.flatMap(loop(newState))
+        case Suspend(rest, _) =>
+          rest.flatMap(loop(state))
+        case Last(item) =>
+          F.pure(op(state,item))
+        case Halt(None) =>
+          F.pure(state)
+        case Halt(Some(e)) =>
+          F.raiseError(e)
+      } catch {
+        case NonFatal(e) =>
+          self.earlyStop.followedBy(F.raiseError(e))
+      }
+    }
+
+    def start(self: Iterant[F, A]): F[Option[A]] = {
+      try self match {
+        case Next(a, rest, _) =>
+          rest.flatMap(loop(a)).map(Some.apply)
+
+        case NextCursor(cursor, rest, _) =>
+          if (!cursor.hasNext())
+            rest.flatMap(start)
+          else {
+            val a = cursor.next()
+            loop(a)(self).map(Some.apply)
+          }
+
+        case NextBatch(batch, rest, stop) =>
+          start(NextCursor(batch.cursor(), rest, stop))
+
+        case Suspend(rest, _) =>
+          rest.flatMap(start)
+
+        case Last(a) =>
+          F.pure(Some(a))
+
+        case Halt(opt) =>
+          opt match {
+            case None => F.pure(None)
+            case Some(e) => F.raiseError(e)
+          }
+      } catch {
+        case NonFatal(e) =>
+          self.earlyStop.followedBy(F.raiseError(e))
+      }
+    }
+
+    F.suspend(start(self))
+  }
+}

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantUtils.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantUtils.scala
@@ -18,7 +18,6 @@
 package monix.tail.internal
 
 import cats.Functor
-import cats.effect.Sync
 import cats.syntax.all._
 import monix.tail.Iterant
 import monix.tail.Iterant._
@@ -43,12 +42,5 @@ private[tail] object IterantUtils {
       case Last(_) | Halt(_) =>
         halt
     }
-  }
-
-  /** Internal utility for signaling errors. */
-  def signalError[F[_], A](stop: F[Unit])(implicit F: Sync[F]):
-    (Throwable => F[A]) = {
-
-    ex => stop.flatMap(_ => F.raiseError(ex))
   }
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantFoldLeftSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantFoldLeftSuite.scala
@@ -211,4 +211,10 @@ object IterantFoldLeftSuite extends BaseTestSuite {
       result <-> Coeval.raiseError[Int](dummy)
     }
   }
+
+  test("Iterant[Coeval, Int].foldL is consistent with foldLeftL") { implicit s =>
+    check1 { (stream: Iterant[Coeval, Int]) =>
+      stream.foldL <-> stream.foldLeftL(0)(_ + _)
+    }
+  }
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantReduceSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantReduceSuite.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.tail
+
+import monix.eval.Coeval
+import monix.execution.exceptions.DummyException
+import scala.util.Failure
+
+object IterantReduceSuite extends BaseTestSuite {
+  test("reduce is consistent with foldLeft") { implicit s =>
+    check2 { (stream: Iterant[Coeval, Int], op: (Int, Int) => Int) =>
+      val received = stream.reduceL(op)
+      val expected = stream.foldLeftL(Option.empty[Int])((acc, e) => Some(acc.fold(e)(s => op(s, e))))
+      received <-> expected
+    }
+  }
+
+  test("maxL is consistent with List.max") { implicit s =>
+    check2 { (list: List[Int], idx: Int) =>
+      val stream = arbitraryListToIterant[Coeval, Int](list, idx, allowErrors = false)
+      val expect = if (list.isEmpty) None else Some(list.max)
+      stream.maxL <-> Coeval.pure(expect)
+    }
+  }
+
+  test("minL is consistent with List.min") { implicit s =>
+    check2 { (list: List[Int], idx: Int) =>
+      val stream = arbitraryListToIterant[Coeval, Int](list, idx, allowErrors = false)
+      val expect = if (list.isEmpty) None else Some(list.min)
+      stream.minL <-> Coeval.pure(expect)
+    }
+  }
+
+  test("protects against broken cursor, as first node") { implicit s =>
+    val dummy = DummyException("dummy")
+    var effect = 0
+
+    val stream = Iterant[Coeval].nextCursorS[Int](ThrowExceptionCursor(dummy), Coeval(Iterant[Coeval].empty), Coeval.unit)
+      .doOnEarlyStop(Coeval { effect += 1 })
+      .reduceL(_ + _)
+
+    assertEquals(effect, 0)
+    assertEquals(stream.runTry, Failure(dummy))
+    assertEquals(effect, 1)
+  }
+
+  test("protects against broken cursor, as second node") { implicit s =>
+    val dummy = DummyException("dummy")
+    var effect = 0
+
+    val source =
+      Iterant[Coeval].pure(1) ++
+      Iterant[Coeval].nextCursorS[Int](ThrowExceptionCursor(dummy), Coeval(Iterant[Coeval].empty), Coeval.unit)
+
+    val stream = source
+      .doOnEarlyStop(Coeval { effect += 1 })
+      .reduceL(_ + _)
+
+    assertEquals(effect, 0)
+    assertEquals(stream.runTry, Failure(dummy))
+    assertEquals(effect, 1)
+  }
+
+  test("protects against broken batch, as first node") { implicit s =>
+    val dummy = DummyException("dummy")
+    var effect = 0
+
+    val stream = Iterant[Coeval].nextBatchS[Int](ThrowExceptionBatch(dummy), Coeval(Iterant[Coeval].empty), Coeval.unit)
+      .doOnEarlyStop(Coeval { effect += 1 })
+      .reduceL(_ + _)
+
+    assertEquals(effect, 0)
+    assertEquals(stream.runTry, Failure(dummy))
+    assertEquals(effect, 1)
+  }
+
+  test("protects against broken batch, as second node") { implicit s =>
+    val dummy = DummyException("dummy")
+    var effect = 0
+
+    val source =
+      Iterant[Coeval].pure(1) ++
+      Iterant[Coeval].nextBatchS[Int](ThrowExceptionBatch(dummy), Coeval(Iterant[Coeval].empty), Coeval.unit)
+
+    val stream = source
+      .doOnEarlyStop(Coeval { effect += 1 })
+      .reduceL(_ + _)
+
+    assertEquals(effect, 0)
+    assertEquals(stream.runTry, Failure(dummy))
+    assertEquals(effect, 1)
+  }
+
+  test("protects against broken op") { implicit s =>
+    val dummy = DummyException("dummy")
+    var effect = 0
+
+    val stream = Iterant[Coeval].of(1, 2)
+      .doOnEarlyStop(Coeval { effect += 1 })
+      .reduceL((_, _) => (throw dummy) : Int)
+
+    assertEquals(effect, 0)
+    assertEquals(stream.runTry, Failure(dummy))
+    assertEquals(effect, 1)
+  }
+}


### PR DESCRIPTION
Related to #400 

NOTE: introducing a custom `reduceL`, being redundant with `foldLeftL`, but I don't want to box unnecessarily in `Option`