### PR TITLE
Add scanEval for Iterant / Observable and Task.fromEffect

### DIFF
--- a/benchmarks/vnext/src/main/scala/monix/benchmarks/ScanEvalBenchmark.scala
+++ b/benchmarks/vnext/src/main/scala/monix/benchmarks/ScanEvalBenchmark.scala
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.benchmarks
+
+import java.util.concurrent.TimeUnit
+import monix.eval.Task
+import monix.execution.ExecutionModel.SynchronousExecution
+import monix.reactive.Observable
+import monix.tail.Iterant
+import org.openjdk.jmh.annotations._
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+/** To run the benchmark from within SBT:
+  *
+  *     jmh:run -i 10 -wi 10 -f 2 -t 1 monix.benchmarks.ScanEvalBenchmark
+  *
+  * Which means "10 iterations", "10 warm-up iterations", "2 fork", "1 thread".
+  * Please note that benchmarks should be usually executed at least in
+  * 10 iterations (as a rule of thumb), but more is better.
+  */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class ScanEvalBenchmark {
+  @Param(Array("10000"))
+  var size: Int = _
+
+  @Benchmark
+  def obsScanEvalPure() = {
+    import ScanEvalBenchmark.monixScheduler
+
+    val f = Observable.range(0, size)
+      .scanTask(Task.now(0L)) { (s, a) => Task.now(s + a) }
+      .foldLeftL(0L)(_ + _)
+      .runAsync
+
+    Await.result(f, Duration.Inf)
+  }
+
+  @Benchmark
+  def obsScanEvalDelay() = {
+    import ScanEvalBenchmark.monixScheduler
+
+    val f = Observable.range(0, size)
+      .scanTask(Task.eval(0L)) { (s, a) => Task.eval(s + a) }
+      .foldLeftL(0L)(_ + _)
+      .runAsync
+
+    Await.result(f, Duration.Inf)
+  }
+
+  @Benchmark
+  def obsScanEvalFork() = {
+    import ScanEvalBenchmark.monixScheduler
+
+    val f = Observable.range(0, size)
+      .scanTask(Task(0L)) { (s, a) => Task(s + a) }
+      .foldLeftL(0L)(_ + _)
+      .runAsync
+
+    Await.result(f, Duration.Inf)
+  }
+
+  @Benchmark
+  def obsFlatScanPure() = {
+    import ScanEvalBenchmark.monixScheduler
+
+    val f = Observable.range(0, size)
+      .flatScan(0L) { (s, a) => Observable.now(s + a) }
+      .foldLeftL(0L)(_ + _)
+      .runAsync
+
+    Await.result(f, Duration.Inf)
+  }
+
+  @Benchmark
+  def obsFlatScanDelay() = {
+    import ScanEvalBenchmark.monixScheduler
+
+    val f = Observable.range(0, size)
+      .flatScan(0L) { (s, a) => Observable.eval(s + a) }
+      .foldLeftL(0L)(_ + _)
+      .runAsync
+
+    Await.result(f, Duration.Inf)
+  }
+
+  @Benchmark
+  def obsFlatScanFork() = {
+    import ScanEvalBenchmark.monixScheduler
+
+    val f = Observable.range(0, size)
+      .flatScan(0L) { (s, a) => Observable.eval(s + a).executeWithFork }
+      .foldLeftL(0L)(_ + _)
+      .runAsync
+
+    Await.result(f, Duration.Inf)
+  }
+
+
+  @Benchmark
+  def iterScanEvalPure() = {
+    import ScanEvalBenchmark.monixScheduler
+
+    val f = Iterant[Task].range(0, size)
+      .scanEval(Task.now(0L)) { (s, a) => Task.now(s + a) }
+      .foldLeftL(0L)(_ + _)
+      .runAsync
+
+    Await.result(f, Duration.Inf)
+  }
+
+  @Benchmark
+  def iterScanEvalDelay() = {
+    import ScanEvalBenchmark.monixScheduler
+
+    val f = Iterant[Task].range(0, size)
+      .scanEval(Task.eval(0L)) { (s, a) => Task.eval(s + a) }
+      .foldLeftL(0L)(_ + _)
+      .runAsync
+
+    Await.result(f, Duration.Inf)
+  }
+
+  @Benchmark
+  def iterScanEvalFork() = {
+    import ScanEvalBenchmark.monixScheduler
+
+    val f = Iterant[Task].range(0, size)
+      .scanEval(Task(0L)) { (s, a) => Task(s + a) }
+      .foldLeftL(0L)(_ + _)
+      .runAsync
+
+    Await.result(f, Duration.Inf)
+  }
+}
+
+object ScanEvalBenchmark {
+  import monix.execution.Scheduler
+
+  implicit val monixScheduler: Scheduler = {
+    import monix.execution.Scheduler.global
+    global.withExecutionModel(SynchronousExecution)
+  }
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,7 +8,7 @@ comment:
 coverage:
   precision: 2
   range:
-  - 80.0
+  - 90.0
   - 100.0
   round: down
   status:

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,7 +4,7 @@ codecov:
 comment:
   behavior: default
   layout: header, diff
-  require_changes: false
+  require_changes: true
 coverage:
   precision: 2
   range:

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskConversionsSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskConversionsSuite.scala
@@ -107,6 +107,10 @@ object TaskConversionsSuite extends BaseTestSuite {
     val f2 = Task.fromEffect(io2).runAsync
     assertEquals(f2.value, None); s.tick()
     assertEquals(f2.value, Some(Success(1)))
+
+    val dummy = DummyException("dummy")
+    val f3 = Task.fromEffect(IO.raiseError(dummy)).runAsync
+    assertEquals(f3.value, Some(Failure(dummy)))
   }
 
   test("Task.fromEffect(io) with broken Effect") { implicit s =>

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapTaskObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapTaskObservable.scala
@@ -286,6 +286,7 @@ private[reactive] final class MapTaskObservable[A,B]
     def onError(ex: Throwable): Unit =
       signalFinish(Some(ex))
 
+    // $COVERAGE-OFF$
     private def reportInvalidState(state: MapTaskState, method: String): Unit = {
       scheduler.reportFailure(
         new IllegalStateException(
@@ -294,6 +295,7 @@ private[reactive] final class MapTaskObservable[A,B]
           "please open an issue, see: https://monix.io"
         ))
     }
+    // $COVERAGE-ON$
   }
 }
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapTaskObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapTaskObservable.scala
@@ -277,7 +277,9 @@ private[reactive] final class MapTaskObservable[A,B]
 
         case WaitActiveTask =>
           // Something is screwed up in our state machine :-(
+          // $COVERAGE-OFF$
           reportInvalidState(WaitActiveTask, "signalFinish")
+          // $COVERAGE-ON$
       }
     }
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ScanTaskObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ScanTaskObservable.scala
@@ -94,18 +94,24 @@ private[reactive] final class ScanTaskObservable[A, S]
         case current @ Active(ref) =>
           if (stateRef.compareAndSet(current, Cancelled))
             ref.cancel()
+          // $COVERAGE-OFF$
           else
             cancel() // retry
+          // $COVERAGE-ON$
         case current @ WaitComplete(_, ref) =>
           if (ref != null) {
             if (stateRef.compareAndSet(current, Cancelled))
               ref.cancel()
+            // $COVERAGE-OFF$
             else
               cancel() // retry
+            // $COVERAGE-ON$
           }
         case current @ (WaitOnNext | WaitActiveTask) =>
           if (!stateRef.compareAndSet(current, Cancelled))
+            // $COVERAGE-OFF$
             cancel() // retry
+            // $COVERAGE-ON$
         case Cancelled =>
           () // do nothing else
       }
@@ -217,10 +223,12 @@ private[reactive] final class ScanTaskObservable[A, S]
             Stop
 
           case state @ Active(_) =>
+            // $COVERAGE-OFF$
             // This should never, ever happen!
             // Something is screwed up in our state machine :-(
             reportInvalidState(state, "onNext")
             Stop
+            // $COVERAGE-ON$
         }
       } catch {
         case NonFatal(ex) =>
@@ -228,8 +236,10 @@ private[reactive] final class ScanTaskObservable[A, S]
             onError(ex)
             Stop
           } else {
+            // $COVERAGE-OFF$
             scheduler.reportFailure(ex)
             Stop
+            // $COVERAGE-ON$
           }
       }
     }
@@ -283,6 +293,7 @@ private[reactive] final class ScanTaskObservable[A, S]
     def onError(ex: Throwable): Unit =
       signalFinish(Some(ex))
 
+    // $COVERAGE-OFF$
     private def reportInvalidState(state: MapTaskState, method: String): Unit = {
       scheduler.reportFailure(
         new IllegalStateException(
@@ -291,5 +302,6 @@ private[reactive] final class ScanTaskObservable[A, S]
           "please open an issue, see: https://monix.io"
         ))
     }
+    // $COVERAGE-ON$
   }
 }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ScanTaskObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ScanTaskObservable.scala
@@ -17,71 +17,60 @@
 
 package monix.reactive.internal.operators
 
-import monix.eval.Task
+import monix.eval.{Callback, Task}
 import monix.execution.Ack.Stop
 import monix.execution.atomic.Atomic
 import monix.execution.atomic.PaddingStrategy.LeftRight128
+import monix.execution.cancelables.MultiAssignmentCancelable
 import monix.execution.misc.NonFatal
 import monix.execution.{Ack, Cancelable}
 import monix.reactive.Observable
+import monix.reactive.observables.ChainedObservable
 import monix.reactive.observers.Subscriber
 
 import scala.annotation.tailrec
 import scala.concurrent.Future
 
-/** Implementation for `Observable.mapTask`.
+/** Implementation for `Observable.scanTask`.
   *
-  * Example of what we want to achieve:
-  * {{{
-  *   observable.mapTask(x => Task(x + 1))
-  * }}}
+  * Implementation is based on [[ScanTaskObservable]].
   *
-  * This is basically equivalent with:
-  * {{{
-  *   observable.concatMap(x => Observable.fromTask(Task(x + 1)))
-  * }}}
-  *
-  * The implementation has to be faster than `concatMap`.
-  * The challenges are:
-  *
-  *  - keeping track of the `Cancelable` for the active task
-  *
-  *  - dealing with the concurrency between the last `onNext` and the
-  *    final `onComplete` or `onError`, because with the `Observer`
-  *    contract we are allowed to send a final event after the last
-  *    `onNext` is called, but before its `Future[Ack]` is finished
-  *
-  * This implementation is fast because:
-  *
-  *  - the state is stored and synchronized using an atomic reference
-  *    that is padded to avoid false sharing
-  *
-  *  - in order to evolve the state we are NOT using intrinsic
-  *    monitors (`synchronize`), or `compareAndSet`, but plain writes,
-  *    along with `getAndSet`
-  *
-  *  - currently for each `onNext` we are doing 2 `getAndSet`
-  *    operations per `onNext` call, which is awesome because on top
-  *    of Java 8 `getAndSet` operations are cheaper than
-  *    `compareAndSet`. It is more of a problem on Java 7 and below,
-  *    however it's OK-ish, since these CAS operations are not going
-  *    to be contended
+  * Tricky concurrency handling within, here be dragons!
+  * See the description on [[ScanTaskObservable]] for details.
   */
-private[reactive] final class MapTaskObservable[A,B]
-  (source: Observable[A], f: A => Task[B])
-  extends Observable[B] {
+private[reactive] final class ScanTaskObservable[A, S]
+  (source: Observable[A], seed: Task[S], op: (S, A) => Task[S])
+  extends ChainedObservable[S] {
 
-  def unsafeSubscribeFn(out: Subscriber[B]): Cancelable = {
-    val subscriber = new MapAsyncSubscriber(out)
-    val mainSubscription = source.unsafeSubscribeFn(subscriber)
+  def unsafeSubscribeFn(conn: MultiAssignmentCancelable, out: Subscriber[S]): Unit = {
+    val order = conn.currentOrder
+    val cb = new Callback[S] {
+      def onSuccess(initial: S): Unit = {
+        val subscriber = new ScanTaskSubscriber(out, initial)
+        val mainSubscription = source.unsafeSubscribeFn(subscriber)
 
-    Cancelable { () =>
-      try mainSubscription.cancel()
-      finally subscriber.cancel()
+        val c = Cancelable { () =>
+          try mainSubscription.cancel()
+          finally subscriber.cancel()
+        }
+
+        conn.orderedUpdate(c, order + 2)
+      }
+
+      def onError(ex: Throwable): Unit =
+        out.onError(ex)
     }
+
+    conn.orderedUpdate(seed.runAsync(cb)(out.scheduler), order + 1)
   }
 
-  private final class MapAsyncSubscriber(out: Subscriber[B])
+  def unsafeSubscribeFn(out: Subscriber[S]): Cancelable = {
+    val conn = MultiAssignmentCancelable()
+    unsafeSubscribeFn(conn, out)
+    conn
+  }
+
+  private final class ScanTaskSubscriber(out: Subscriber[S], initial: S)
     extends Subscriber[A] with Cancelable { self =>
 
     import MapTaskObservable.MapTaskState
@@ -93,11 +82,14 @@ private[reactive] final class MapTaskObservable[A,B]
     private[this] val stateRef =
       Atomic.withPadding(WaitOnNext : MapTaskState, LeftRight128)
 
+    // Current state, keeps getting updated by the task in `onNext`
+    private[this] var currentS = initial
+
     /** For canceling the current active task, in case there is any. Here
       * we can afford a `compareAndSet`, not being a big deal since
       * cancellation only happens once.
       */
-    @tailrec def cancel(): Unit =
+    @tailrec def cancel(): Unit = {
       stateRef.get match {
         case current @ Active(ref) =>
           if (stateRef.compareAndSet(current, Cancelled))
@@ -117,6 +109,7 @@ private[reactive] final class MapTaskObservable[A,B]
         case Cancelled =>
           () // do nothing else
       }
+    }
 
     def onNext(elem: A): Future[Ack] = {
       // For protecting against user code, without violating the
@@ -124,8 +117,12 @@ private[reactive] final class MapTaskObservable[A,B]
       // we can no longer stream errors downstream
       var streamErrors = true
       try {
-        val task = f(elem).transformWith(
+        val task = op(currentS, elem).transformWith(
           value => {
+            // Updating mutable shared state, no need for synchronization
+            // because `onNext` operations are ordered
+            currentS = value
+
             // Shoot first, ask questions later :-)
             val next = out.onNext(value)
 
@@ -289,77 +286,10 @@ private[reactive] final class MapTaskObservable[A,B]
     private def reportInvalidState(state: MapTaskState, method: String): Unit = {
       scheduler.reportFailure(
         new IllegalStateException(
-          s"State $state in the Monix MapTask.$method implementation is invalid, " +
+          s"State $state in the Monix ScanAsync.$method implementation is invalid, " +
           "due to either a broken Subscriber implementation, or a bug, " +
           "please open an issue, see: https://monix.io"
         ))
     }
-  }
-}
-
-private[reactive] object MapTaskObservable {
-  /** Internal, private state for the [[MapTaskObservable]]
-    * implementation, modeling its state machine for managing
-    * the active task.
-    */
-  private[internal] sealed abstract class MapTaskState
-
-  private[internal] object MapTaskState {
-    /** The initial state of our internal atomic in [[MapTaskObservable]].
-      *
-      * This state is being set in `onNext` and when it is observed it
-      * means that no task is currently being executed. If during this
-      * state the `onComplete` or `onError` final events are signaled
-      * by the source observable, then we are free to signal these
-      * events downstream directly. Because otherwise, if we have an
-      * active task, it becomes the responsibility of that active task
-      * to signal these events.
-      */
-    case object WaitOnNext extends MapTaskState
-
-    /** A state that when observed it means that an `onNext` call is
-      * currently in progress, but its corresponding task wasn't
-      * executed yet.
-      *
-      * This state is meant to detect synchronous execution in
-      * `onNext`, and it can never be seen outside `onNext`. This
-      * means that if it is observed in `onComplete` or `onError`,
-      * then it's a bug.
-      */
-    case object WaitActiveTask extends MapTaskState
-
-    /** A state that happens after the user cancelled his subscription.
-      *
-      * Handling of this state is not accurate, meaning that we could
-      * have logic being executed and states being evolved after a
-      * cancel took place, but if we observe a cancel took place prior
-      * to one of our `getAndSet` calls, then we trigger the `cancel`
-      * again within a safe compare-and-set loop.
-      */
-    case object Cancelled extends MapTaskState
-
-    /** This state is triggered by `onComplete` or `onError` while there
-      * is an active task being executed.
-      *
-      * The contract of `Observer` allows for `onComplete` and
-      * `onError` events to be sent before the `Future[Ack]` of the
-      * last `onNext` call is complete. But at the same time we can
-      * never send an `onNext` event after an `onComplete` or an
-      * `onError`. So while a task is being processed, but before the
-      * `onNext` event is sent, if a complete event happens it becomes
-      * the responsibility of the active task (initialized in
-      * `onNext`) to send this final event.
-      */
-    final case class WaitComplete(ex: Option[Throwable], ref: Cancelable) extends MapTaskState
-
-    /** State that happens after a task has been executed, but before the
-      * following `onNext` call on the downstream subscriber.
-      *
-      * Tasks are cancelable and the reference kept when in this state
-      * can be used to cancel it, the final cancelable triggering a
-      * cancellation on both the source and the active task when
-      * possible.
-      */
-    final case class Active(ref: Cancelable) extends MapTaskState
   }
 }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observables/ObservableLike.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observables/ObservableLike.scala
@@ -19,6 +19,7 @@ package monix.reactive.observables
 
 import java.io.PrintStream
 
+import cats.effect.Effect
 import cats.{Eq, Monoid, Order}
 import monix.eval.Task
 import monix.execution.cancelables.BooleanCancelable
@@ -2035,8 +2036,122 @@ trait ObservableLike[+A, Self[+T] <: ObservableLike[T, Self]]
     * Similar to [[foldLeftF]], but emits the state on each
     * step. Useful for modeling finite state machines.
     */
-  def scan[R](initial: => R)(f: (R, A) => R): Self[R] =
-    self.transform(source => new ScanObservable[A,R](source, initial _, f))
+  def scan[S](seed: => S)(op: (S, A) => S): Self[S] =
+    self.transform(source => new ScanObservable[A,S](source, seed _, op))
+
+  /** Applies a binary operator to a start value and all elements of
+    * this stream, going left to right and returns a new stream that
+    * emits on each step the result of the applied function.
+    *
+    * Similar with [[scan]], but this can suspend and evaluate
+    * side effects with an `F[_]` data type that implements the
+    * `cats.effect.Effect` type class, thus allowing for lazy or
+    * asynchronous data processing.
+    *
+    * Similar to [[foldLeftF]] and [[foldWhileLeftF]], but emits the
+    * state on each step. Useful for modeling finite state machines.
+    *
+    * Example showing how state can be evolved and acted upon:
+    *
+    * {{{
+    *   // Using cats.effect.IO for evaluating our side effects
+    *   import cats.effect.IO
+    *
+    *   sealed trait State[+A] { def count: Int }
+    *   case object Init extends State[Nothing] { def count = 0 }
+    *   case class Current[A](current: Option[A], count: Int)
+    *     extends State[A]
+    *
+    *   case class Person(id: Int, name: String)
+    *
+    *   // Initial state
+    *   val seed = IO.pure(Init : State[Person])
+    *
+    *   val scanned = source.scanEval(seed) { (state, id) =>
+    *     requestPersonDetails(id).map { person =>
+    *       state match {
+    *         case Init =>
+    *           Current(person, 1)
+    *         case Current(_, count) =>
+    *           Current(person, count + 1)
+    *       }
+    *     }
+    *   }
+    *
+    *   scanned
+    *     .takeWhile(_.count < 10)
+    *     .collect { case Current(a, _) => a }
+    * }}}
+    *
+    * @see [[scan]] for the synchronous, non-lazy version, or
+    *      [[scanTask]] for the [[monix.eval.Task Task]]-specialized
+    *      version.
+    *
+    * @param seed is the initial state
+    * @param op is the function that evolves the current state
+    *
+    * @param F is the `cats.effect.Effect` type class implementation
+    *        for type `F`, which controls the evaluation. `F` can be
+    *        a data type such as [[monix.eval.Task]] or `cats.effect.IO`,
+    *        which implement `Effect`.
+    *
+    * @return a new observable that emits all intermediate states being
+    *         resulted from applying the given function
+    */
+  def scanEval[F[_], S](seed: F[S])(op: (S, A) => F[S])(implicit F: Effect[F]): Self[S] =
+    scanTask(Task.fromEffect(seed)(F))((s, a) => Task.fromEffect(op(s, a))(F))
+
+  /** Applies a binary operator to a start value and all elements of
+    * this stream, going left to right and returns a new stream that
+    * emits on each step the result of the applied function.
+    *
+    * Similar with [[scan]], but this can suspend and evaluate
+    * side effects with [[monix.eval.Task Task]], thus allowing for
+    * asynchronous data processing.
+    *
+    * Similar to [[foldLeftF]] and [[foldWhileLeftF]], but emits the
+    * state on each step. Useful for modeling finite state machines.
+    *
+    * Example showing how state can be evolved and acted upon:
+    *
+    * {{{
+    *   sealed trait State[+A] { def count: Int }
+    *   case object Init extends State[Nothing] { def count = 0 }
+    *   case class Current[A](current: Option[A], count: Int)
+    *     extends State[A]
+    *
+    *   case class Person(id: Int, name: String)
+    *
+    *   // Initial state
+    *   val seed = Task.now(Init : State[Person])
+    *
+    *   val scanned = source.scanTask(seed) { (state, id) =>
+    *     requestPersonDetails(id).map { person =>
+    *       state match {
+    *         case Init =>
+    *           Current(person, 1)
+    *         case Current(_, count) =>
+    *           Current(person, count + 1)
+    *       }
+    *     }
+    *   }
+    *
+    *   scanned
+    *     .takeWhile(_.count < 10)
+    *     .collect { case Current(a, _) => a }
+    * }}}
+    *
+    * @see [[scan]] for the version that does not require using `Task`
+    *      in the provided operator
+    *
+    * @param seed is the initial state
+    * @param op is the function that evolves the current state
+    *
+    * @return a new observable that emits all intermediate states being
+    *         resulted from applying the given function
+    */
+  def scanTask[S](seed: Task[S])(op: (S, A) => Task[S]): Self[S] =
+    self.transform(source => new ScanTaskObservable(source, seed, op))
 
   /** Creates a new Observable that emits the given elements and then it
     * also emits the events of the source (prepend operation).

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ScanEffectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ScanEffectSuite.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.reactive.internal.operators
+
+import cats.effect.IO
+import monix.reactive.Observable
+import scala.concurrent.duration._
+
+object ScanEffectSuite extends BaseOperatorSuite {
+  def createObservable(sourceCount: Int) = Some {
+    val o = Observable.range(0, sourceCount).scanEval(IO.pure(0L)) {
+      (s, x) => IO(s + x)
+    }
+
+    Sample(o, count(sourceCount), sum(sourceCount), waitFirst, waitNext)
+  }
+
+  def count(sourceCount: Int) =
+    sourceCount
+  def sum(sourceCount: Int) =
+    0.until(sourceCount).scan(0)(_ + _).sum
+
+  def waitFirst = Duration.Zero
+  def waitNext = Duration.Zero
+
+  def observableInError(sourceCount: Int, ex: Throwable) =
+    if (sourceCount == 1) None else Some {
+      val o = createObservableEndingInError(Observable.range(0, sourceCount), ex)
+        .scanEval(IO.pure(0L)) { (s, x) => IO(s + x) }
+
+      Sample(o, count(sourceCount), sum(sourceCount), waitFirst, waitNext)
+    }
+
+  def brokenUserCodeObservable(sourceCount: Int, ex: Throwable) = Some {
+    val o = Observable.range(0, sourceCount)
+      .scanEval(IO.pure(0L)) { (s, i) =>
+        if (i == sourceCount-1)
+          throw ex
+        else
+          IO(s + i)
+      }
+
+    Sample(o, count(sourceCount-1), sum(sourceCount-1), waitFirst, waitNext)
+  }
+
+  override def cancelableObservables(): Seq[Sample] = {
+    val sample = Observable.range(0, 100)
+      .delayOnNext(1.second)
+      .scanEval(IO.pure(0L))((s, i) => IO(s + i))
+
+    Seq(
+      Sample(sample, 0, 0, 0.seconds, 0.seconds),
+      Sample(sample, 1, 1, 1.seconds, 0.seconds)
+    )
+  }
+}

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ScanTaskSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ScanTaskSuite.scala
@@ -17,9 +17,14 @@
 
 package monix.reactive.internal.operators
 
+import java.util.concurrent.TimeUnit
+
 import monix.eval.Task
+import monix.execution.exceptions.DummyException
 import monix.reactive.Observable
+
 import scala.concurrent.duration._
+import scala.util.Failure
 
 object ScanTaskSuite extends BaseOperatorSuite {
   def createObservable(sourceCount: Int) = Some {
@@ -67,12 +72,149 @@ object ScanTaskSuite extends BaseOperatorSuite {
       .scanTask(Task.now(0L))((s, i) => Task.eval(s + i).delayExecution(1.second))
     val sample2 = Observable.range(0, 100)
       .delayOnNext(1.second)
-      .scanTask(Task.now(0L))((s, i) => Task.eval(s + i).delayExecution(1.second))
+      .scanTask(Task.now(0L))((s, i) => Task.eval(s + i).delayExecution(2.second))
 
     Seq(
       Sample(sample1, 0, 0, 0.seconds, 0.seconds),
       Sample(sample1, 1, 1, 1.seconds, 0.seconds),
-      Sample(sample2, 0, 0, 0.seconds, 0.seconds)
+      Sample(sample2, 0, 0, 0.seconds, 0.seconds),
+      Sample(sample2, 0, 0, 1.seconds, 0.seconds),
+      Sample(sample2, 0, 0, 2.seconds, 0.seconds),
+      Sample(sample2, 1, 1, 3.seconds, 0.seconds)
     )
+  }
+
+  test("should protect against errors in seed") { implicit s =>
+    val dummy = DummyException("dummy")
+    var effect = 0
+
+    val obs = Observable.range(0, 100)
+      .doOnTerminate(_ => { effect += 1 })
+      .scanTask(Task.raiseError[Long](dummy))((s, a) => Task(s + a))
+      .doOnError(_ => { effect += 1 })
+      .lastL
+
+    val f = obs.runAsync; s.tick()
+    assertEquals(f.value, Some(Failure(dummy)))
+    assertEquals(effect, 1)
+  }
+
+  test("should protect against exceptions thrown in op") { implicit s =>
+    val dummy = DummyException("dummy")
+    var effect = 0
+
+    val obs = Observable.range(0, 100)
+      .doOnTerminate(_ => { effect += 1 })
+      .scanTask(Task.now(0))((_, _) => throw dummy)
+      .doOnError(_ => { effect += 1 })
+      .lastL
+
+    val f = obs.runAsync; s.tick()
+    assertEquals(f.value, Some(Failure(dummy)))
+    assertEquals(effect, 2)
+  }
+
+  test("should protect against errors raised in op") { implicit s =>
+    val dummy = DummyException("dummy")
+    var effect = 0
+
+    val obs = Observable.range(0, 100)
+      .doOnTerminate(_ => { effect += 1 })
+      .scanTask(Task.now(0))((_, _) => Task.raiseError(dummy))
+      .doOnError(_ => { effect += 1 })
+      .lastL
+
+    val f = obs.runAsync; s.tick()
+    assertEquals(f.value, Some(Failure(dummy)))
+    assertEquals(effect, 2)
+  }
+
+  test("back-pressure with onError") { implicit s =>
+    val dummy = DummyException("dummy")
+    var sum = 0
+    var effect = 0
+
+    val f = Observable.now(10).endWithError(dummy)
+      .doOnError { _ => effect += 1 }
+      .scanTask(Task.now(11))((s, a) => Task(s + a).delayExecution(1.second))
+      .doOnNext { x => sum += x }
+      .doOnError { _ => effect += 1 }
+      .lastL
+      .runAsync
+
+    assertEquals(effect, 1)
+    assertEquals(sum, 0)
+    assertEquals(f.value, None)
+
+    s.tick()
+    assertEquals(effect, 1)
+    assertEquals(sum, 0)
+    assertEquals(f.value, None)
+
+    s.tick(1.second)
+    assertEquals(effect, 2)
+    assertEquals(sum, 21)
+    assertEquals(f.value, Some(Failure(dummy)))
+  }
+
+  test("onError from source + error in task") { implicit s =>
+    val dummy1 = DummyException("dummy1")
+    val dummy2 = DummyException("dummy2")
+    var effect = 0
+
+    val f = Observable.now(10).endWithError(dummy1)
+      .doOnError { _ => effect += 1 }
+      .scanTask(Task.now(0))((_, _) => Task.raiseError[Int](dummy2).delayExecution(1.second))
+      .doOnError { _ => effect += 1 }
+      .lastL
+      .runAsync
+
+    assertEquals(effect, 1)
+    assertEquals(f.value, None)
+
+    s.tick()
+    assertEquals(effect, 1)
+    assertEquals(f.value, None)
+
+    s.tick(1.second)
+    assertEquals(effect, 2)
+    assertEquals(f.value, Some(Failure(dummy2)))
+    assertEquals(s.state.lastReportedError, dummy1)
+  }
+
+  test("error in task after user cancelled") { implicit s =>
+    def delay[A](ex: Throwable): Task[A] =
+      Task.unsafeCreate[A] { (ctx, cb) =>
+        ctx.scheduler.scheduleOnce(1, TimeUnit.SECONDS, new Runnable {
+          def run() = cb.onError(ex)
+        })
+      }
+
+    val dummy = DummyException("dummy")
+    var effect = 0
+
+    val f = Observable.now(10)
+      .doOnNext { _ => effect += 1 }
+      .scanTask(Task.now(0))((_, _) => delay[Int](dummy))
+      .doOnError { _ => effect += 1 }
+      .runAsyncGetLast
+
+    s.tick()
+    assertEquals(effect, 1)
+    assertEquals(f.value, None)
+
+    f.cancel()
+    s.tick()
+
+    assertEquals(effect, 1)
+    assertEquals(f.value, None)
+    assert(s.state.tasks.nonEmpty, "tasks.nonEmpty")
+    assertEquals(s.state.lastReportedError, null)
+
+    s.tick(1.second)
+    assertEquals(effect, 1)
+    assertEquals(f.value, None)
+    assert(s.state.tasks.isEmpty, "tasks.isEmpty")
+    assertEquals(s.state.lastReportedError, dummy)
   }
 }

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ScanTaskSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ScanTaskSuite.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.reactive.internal.operators
+
+import monix.eval.Task
+import monix.reactive.Observable
+import scala.concurrent.duration._
+
+object ScanTaskSuite extends BaseOperatorSuite {
+  def createObservable(sourceCount: Int) = Some {
+    val o = Observable.range(0, sourceCount).scanTask(Task.now(0L)) {
+      (s, x) => if (x % 2 == 0) Task(s + x) else Task.eval(s + x)
+    }
+
+    Sample(o, count(sourceCount), sum(sourceCount), waitFirst, waitNext)
+  }
+
+  def count(sourceCount: Int) =
+    sourceCount
+  def sum(sourceCount: Int) =
+    0.until(sourceCount).scan(0)(_ + _).sum
+
+  def waitFirst = Duration.Zero
+  def waitNext = Duration.Zero
+
+  def observableInError(sourceCount: Int, ex: Throwable) =
+    if (sourceCount == 1) None else Some {
+      val o = createObservableEndingInError(Observable.range(0, sourceCount), ex)
+        .scanTask(Task.now(0L)) {
+          (s, x) => if (x % 2 == 0) Task(s + x) else Task.eval(s + x)
+        }
+
+      Sample(o, count(sourceCount), sum(sourceCount), waitFirst, waitNext)
+    }
+
+  def brokenUserCodeObservable(sourceCount: Int, ex: Throwable) = Some {
+    val o = Observable.range(0, sourceCount)
+      .scanTask(Task.now(0L)) { (s, i) =>
+        if (i == sourceCount-1)
+          throw ex
+        else if (i % 2 == 0)
+          Task(s + i)
+        else
+          Task.eval(s + i)
+      }
+
+    Sample(o, count(sourceCount-1), sum(sourceCount-1), waitFirst, waitNext)
+  }
+
+  override def cancelableObservables(): Seq[Sample] = {
+    val sample1 =  Observable.range(1, 100)
+      .scanTask(Task.now(0L))((s, i) => Task.eval(s + i).delayExecution(1.second))
+    val sample2 = Observable.range(0, 100)
+      .delayOnNext(1.second)
+      .scanTask(Task.now(0L))((s, i) => Task.eval(s + i).delayExecution(1.second))
+
+    Seq(
+      Sample(sample1, 0, 0, 0.seconds, 0.seconds),
+      Sample(sample1, 1, 1, 1.seconds, 0.seconds),
+      Sample(sample2, 0, 0, 0.seconds, 0.seconds)
+    )
+  }
+}

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantScanEval.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantScanEval.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.tail.internal
+
+import cats.effect.Sync
+import cats.syntax.all._
+import monix.execution.misc.NonFatal
+import monix.tail.Iterant
+import monix.tail.Iterant._
+import monix.tail.batches.BatchCursor
+import monix.tail.internal.IterantUtils._
+
+private[tail] object IterantScanEval {
+  /**
+    * Implementation for `Iterant#scanEval`
+    */
+  def apply[F[_], A, S](source: Iterant[F, A], seed: F[S], ff: (S, A) => F[S])
+    (implicit F: Sync[F]): Iterant[F, S] = {
+
+    def protectedF(s: S, a: A, rest: F[Iterant[F, A]], stop: F[Unit]): Iterant[F, S] = {
+      val next = ff(s, a)
+        .map(s => nextS(s, rest.map(loop(s)), stop))
+        .handleErrorWith(signalError[F, S](stop))
+
+      Suspend(next, stop)
+    }
+
+    def evalNextCursor(state: S, ref: NextCursor[F, A], cursor: BatchCursor[A], rest: F[Iterant[F, A]], stop: F[Unit]) = {
+      if (!cursor.hasNext)
+        Suspend[F, S](rest.map(loop(state)), stop)
+      else {
+        val head = cursor.next()
+        val tail = if (cursor.hasNext()) F.pure(ref: Iterant[F, A]) else rest
+        protectedF(state, head, tail, stop)
+      }
+    }
+
+    def loop(state: S)(source: Iterant[F, A]): Iterant[F, S] =
+      try source match {
+        case Next(head, tail, stop) =>
+          protectedF(state, head, tail, stop)
+
+        case ref @ NextCursor(cursor, rest, stop) =>
+          evalNextCursor(state, ref, cursor, rest, stop)
+
+        case NextBatch(gen, rest, stop) =>
+          val cursor = gen.cursor()
+          val ref = NextCursor(cursor, rest, stop)
+          evalNextCursor(state, ref, cursor, rest, stop)
+
+        case Suspend(rest, stop) =>
+          Suspend[F,S](rest.map(loop(state)), stop)
+
+        case Last(item) =>
+          val fa = ff(state, item)
+          Suspend(fa.map(s => lastS[F,S](s)), F.unit)
+
+        case halt @ Halt(_) =>
+          halt.asInstanceOf[Iterant[F, S]]
+      } catch {
+        case NonFatal(ex) => signalError(source, ex)
+      }
+
+    // Suspending execution in order to not trigger
+    // side-effects accidentally
+    val process = F.suspend(
+      seed.attempt.map {
+        case Left(e) =>
+          signalError[F, A, S](source, e)
+        case Right(initial) =>
+          loop(initial)(source)
+      })
+
+    Suspend(process, source.earlyStop)
+  }
+}

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantUtils.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantUtils.scala
@@ -43,4 +43,9 @@ private[tail] object IterantUtils {
         halt
     }
   }
+
+  /** Internal utility for signaling an error. */
+  def signalError[F[_], A](stop: F[Unit])(e: Throwable)
+    (implicit F: Functor[F]): F[Iterant[F, A]] =
+    stop.map(_ => Halt[F, A](Some(e)))
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantScanEvalSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantScanEvalSuite.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.tail
+
+import monix.eval.Coeval
+import monix.execution.exceptions.DummyException
+
+object IterantScanEvalSuite extends BaseTestSuite {
+  test("scanEval evolves state") { implicit s =>
+    sealed trait State[+A] { def count: Int }
+    case object Init extends State[Nothing] { def count = 0 }
+    case class Current[A](current: Option[A], count: Int) extends State[A]
+
+    case class Person(id: Int, name: String)
+
+    def requestPersonDetails(id: Int): Coeval[Option[Person]] =
+      Coeval {
+        if (id % 2 == 0) Some(Person(id, s"Person $id"))
+        else None
+      }
+
+    check2 { (list: List[Int], idx: Int) =>
+      val source = arbitraryListToIterant[Coeval, Int](list, idx, allowErrors = false)
+      val seed = Coeval.now(Init : State[Person])
+
+      val scanned = source.scanEval(seed) { (state, id) =>
+        requestPersonDetails(id).map { person =>
+          state match {
+            case Init =>
+              Current(person, 1)
+            case Current(_, count) =>
+              Current(person, count + 1)
+          }
+        }
+      }
+
+      val fa = scanned
+        .takeWhile(_.count < 20)
+        .collect { case Current(Some(p), _) => p.name }
+        .toListL
+
+      val expected = source.take(20).toListL.map(ls =>
+        ls.take(19)
+          .map(x => requestPersonDetails(x).value)
+          .collect { case Some(p) => p.name }
+      )
+
+      fa <-> expected
+    }
+  }
+
+  test("scanEval protects against errors in initial") { implicit s =>
+    val dummy = DummyException("dummy")
+    var effect = 0
+
+    val fa = Iterant[Coeval].of(1, 2, 3).doOnEarlyStop(Coeval { effect += 1 })
+    val r = fa.scanEval(Coeval.raiseError[Int](dummy))((_, e) => Coeval(e)).attempt.toListL
+
+    assertEquals(effect, 0)
+    assertEquals(r.value, List(Left(dummy)))
+    assertEquals(effect, 1)
+  }
+
+  test("scan protects against exceptions in f") { implicit s =>
+    val dummy = DummyException("dummy")
+    var effect = 0
+
+    val fa = Iterant[Coeval].of(1, 2, 3).doOnEarlyStop(Coeval { effect += 1 })
+    val r = fa.scanEval(Coeval(0))((_, _) => throw dummy).attempt.toListL
+
+    assertEquals(effect, 0)
+    assertEquals(r.value, List(Left(dummy)))
+    assertEquals(effect, 1)
+  }
+
+  test("scan protects against errors in f") { implicit s =>
+    val dummy = DummyException("dummy")
+    var effect = 0
+
+    val fa = Iterant[Coeval].of(1, 2, 3).doOnEarlyStop(Coeval { effect += 1 })
+    val r = fa.scanEval(Coeval(0))((_, _) => Coeval.raiseError(dummy)).attempt.toListL
+
+    assertEquals(effect, 0)
+    assertEquals(r.value, List(Left(dummy)))
+    assertEquals(effect, 1)
+  }
+}

--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -1567,6 +1567,15 @@ object MimaFilters {
     exclude[ReversedMissingMethodProblem]("monix.reactive.observables.ObservableLike.maxByF"),
     exclude[ReversedMissingMethodProblem]("monix.reactive.observables.ObservableLike.maxF"),
     exclude[ReversedMissingMethodProblem]("monix.reactive.observables.ObservableLike.minByF"),
-    exclude[ReversedMissingMethodProblem]("monix.reactive.observables.ObservableLike.minF")
+    exclude[ReversedMissingMethodProblem]("monix.reactive.observables.ObservableLike.minF"),
+    exclude[MissingClassProblem]("monix.reactive.internal.operators.MapTaskObservable$FlatMapState$Active"),
+    exclude[MissingClassProblem]("monix.reactive.internal.operators.MapTaskObservable$FlatMapState$WaitActiveTask$"),
+    exclude[MissingClassProblem]("monix.reactive.internal.operators.MapTaskObservable$FlatMapState"),
+    exclude[MissingClassProblem]("monix.reactive.internal.operators.MapTaskObservable$FlatMapState$WaitOnNext$"),
+    exclude[MissingClassProblem]("monix.reactive.internal.operators.MapTaskObservable$FlatMapState$Active$"),
+    exclude[MissingClassProblem]("monix.reactive.internal.operators.MapTaskObservable$FlatMapState$WaitComplete$"),
+    exclude[MissingClassProblem]("monix.reactive.internal.operators.MapTaskObservable$FlatMapState$WaitComplete"),
+    exclude[MissingClassProblem]("monix.reactive.internal.operators.MapTaskObservable$FlatMapState$Cancelled$"),
+    exclude[MissingClassProblem]("monix.reactive.internal.operators.MapTaskObservable$FlatMapState$")
   )
 }


### PR DESCRIPTION
Adding a new operator to `Iterant[F, A]`:

```scala
import cats.effect.Sync

sealed abstract class Iterant[F[_], A] {
  // ...

  def scanEval[S](seed: F[S])(op: (S, A) => F[S])(implicit F: Sync[F]): Iterant[F, S]
}
```

Adding these operators to `Observable[A]`:

```scala
import cats.effect.Effect

trait Observable[+A] {
  //...

  def scanEval[F[_], S](seed: F[S])(op: (S, A) => F[S])(implicit F: Effect[F]): Self[S]

  def scanTask[S](seed: Task[S])(op: (S, A) => Task[S]): Self[S]
}
```

Adding this builder to `Task[+A]`:

```scala
import cats.effect.Effect

object Task {
  // ...
  def fromEffect[F[_], A](fa: F[A])(implicit F: Effect[F]): Task[A]
}
```

Interestingly the `scanEval` operator for `Iterant` is much easier to implement than for `Observable`. 

The `Observable` implementation is copying what I did previously for `mapTask`, an implementation that uses `Atomic.getAndSet` operations to ensure visibility between multiple threads, to eliminate asynchronous boundaries when not needed and given that we can end up with concurrency between the final `onComplete` of the source and the processing of the last `Task`.

Benchmark results (see `ScanEvalBenchmark` as part of this PR):

```
iterScanEvalDelay   10000  thrpt   20   670.719 ±  7.631  ops/s
iterScanEvalFork    10000  thrpt   20    66.156 ±  7.373  ops/s
iterScanEvalPure    10000  thrpt   20   693.887 ±  7.158  ops/s

obsFlatScanDelay    10000  thrpt   20  1844.675 ± 18.319  ops/s
obsFlatScanFork     10000  thrpt   20    36.009 ±  0.445  ops/s
obsFlatScanPure     10000  thrpt   20  1986.595 ± 11.284  ops/s

obsScanEvalDelay    10000  thrpt   20  1343.907 ± 19.109  ops/s
obsScanEvalFork     10000  thrpt   20    34.727 ±  0.895  ops/s
obsScanEvalPure     10000  thrpt   20  1363.414 ± 32.942  ops/s
```

This compares `Iterant.scanEval` vs `Observable.flatScan` vs `Observable.scanEval`.

Interestingly for `Task` references that `fork`, `Iterant` can be faster, although it can be argued that for such asynchronous boundaries you end up doing I/O, so CPU speed might matter less.

On the other hand for `Task` or `Observable` references that get evaluated immediately (the tests suffixed with `Pure` and `Delay`), the `Observable` implementation ends up being significantly faster, which is quite the feat, given that on each item processed it does one `getAndSet` operation for synchronization and synchronization can be expensive.