### PR TITLE
Add Iterant.bufferSliding + bufferTumbling + batched

### DIFF
--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferSlidingOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferSlidingOperator.scala
@@ -35,7 +35,7 @@ private[reactive] final class BufferSlidingOperator[A](count: Int, skip: Int)
       implicit val scheduler = out.scheduler
 
       private[this] var isDone = false
-      private[this] var ack: Future[Ack] = null
+      private[this] var ack: Future[Ack] = _
 
       private[this] val toDrop = if (count > skip) 0 else skip - count
       private[this] val toRepeat = if (skip > count) 0 else count - skip

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantBuffer.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantBuffer.scala
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.tail
+package internal
+
+import cats.effect.Sync
+import cats.syntax.all._
+import monix.execution.misc.NonFatal
+import monix.tail.Iterant.{Halt, Last, Next, NextBatch, NextCursor, Suspend}
+import monix.tail.batches.Batch
+import monix.tail.internal.IterantUtils.signalError
+
+private[tail] object IterantBuffer {
+  /** Implementation for `Iterant.bufferSliding`. */
+  def sliding[F[_], A](self: Iterant[F, A], count: Int, skip: Int)
+    (implicit F: Sync[F]): Iterant[F, Seq[A]] = {
+
+    build[F, A, Seq[A]](self, count, skip,
+      (seq, rest, stop) => Next(seq, rest, stop),
+      seq => Last(seq))
+  }
+
+  /** Implementation for `Iterant.batched`. */
+  def batched[F[_], A](self: Iterant[F, A], count: Int)
+    (implicit F: Sync[F]): Iterant[F, A] = {
+
+    build[F, A, A](self, count, count,
+      (seq, rest, stop) => NextBatch(Batch.fromAnyArray(seq), rest, stop),
+      seq => NextBatch(Batch.fromAnyArray(seq), F.pure(Halt(None)), F.unit))
+  }
+
+  private def build[F[_], A, B](
+    self: Iterant[F, A],
+    count: Int,
+    skip: Int,
+    f: (Array[A], F[Iterant[F, B]], F[Unit]) => Iterant[F, B],
+    last: Array[A] => Iterant[F, B])
+    (implicit F: Sync[F]): Iterant[F, B] = {
+
+    val buffer = new Buffer[A](count, skip)
+
+    def process(fa: Iterant[F, A]): F[Iterant[F, B]] = {
+      val NextCursor(cursor, rest, stop) = fa
+
+      while (cursor.hasNext()) {
+        val seq = buffer.push(cursor.next())
+        if (seq != null) {
+          val next = if (cursor.hasNext()) F.pure(fa) else rest
+          return F.pure(f(seq, next.flatMap(loop), stop))
+        }
+      }
+
+      rest.flatMap(loop)
+    }
+
+    def loop(self: Iterant[F, A]): F[Iterant[F, B]] = {
+      try self match {
+        case Next(a, rest, stop) =>
+          val seq = buffer.push(a)
+          if (seq != null)
+            F.pure(f(seq, rest.flatMap(loop), stop))
+          else
+            rest.flatMap(loop)
+
+        case self@NextCursor(_, _, _) =>
+          process(self)
+
+        case NextBatch(batch, rest, stop) =>
+          process(NextCursor(batch.cursor(), rest, stop))
+
+        case Suspend(rest, _) =>
+          rest.flatMap(loop)
+
+        case Last(a) =>
+          var seq = buffer.push(a)
+          if (seq == null) seq = buffer.rest()
+          F.pure {
+            if (seq != null && seq.length > 0)
+              last(seq)
+            else
+              Halt(None)
+          }
+
+        case ref @ Halt(_) =>
+          val self = ref.asInstanceOf[Iterant[F, B]]
+          val seq = buffer.rest()
+          F.pure {
+            if (seq != null && seq.length > 0)
+              f(seq, F.pure(self), F.unit)
+            else
+              self
+          }
+      }
+      catch {
+        case NonFatal(e) =>
+          F.pure(signalError(self, e))
+      }
+    }
+
+    Suspend(F.suspend(loop(self)), self.earlyStop)
+  }
+
+  private final class Buffer[A](count: Int, skip: Int) {
+    private[this] val toDrop = if (count > skip) 0 else skip - count
+    private[this] val toRepeat = if (skip > count) 0 else count - skip
+
+    private[this] var isBufferNew = true
+    private[this] var buffer = new Array[AnyRef](count)
+    private[this] var dropped = 0
+    private[this] var length = 0
+
+    def push(elem: A): Array[A] = {
+      if (dropped > 0) {
+        dropped -= 1
+        null
+      } else {
+        buffer(length) = elem.asInstanceOf[AnyRef]
+        length += 1
+
+        if (length < count) null else {
+          val oldBuffer = buffer
+          buffer = new Array(count)
+
+          if (toRepeat > 0) {
+            System.arraycopy(oldBuffer, count-toRepeat, buffer, 0, toRepeat)
+            length = toRepeat
+          } else {
+            dropped = toDrop
+            length = 0
+          }
+
+          // signaling downstream
+          if (isBufferNew) isBufferNew = false
+          oldBuffer.asInstanceOf[Array[A]]
+        }
+      }
+    }
+
+    def rest(): Array[A] = {
+      val threshold = if (isBufferNew) 0 else toRepeat
+      if (length > threshold)
+        buffer.take(length).asInstanceOf[Array[A]]
+      else
+        null
+    }
+  }
+}

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantBufferSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantBufferSuite.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.tail
+
+import monix.eval.Coeval
+import monix.execution.exceptions.DummyException
+import scala.util.Failure
+
+object IterantBufferSuite extends BaseTestSuite {
+  test("bufferTumbling(c) is consistent with List.sliding(c, c)") { implicit s =>
+    check3 { (list: List[Int], idx: Int, num: Int) =>
+      val count = math.abs(num % 4) + 2
+      val stream = arbitraryListToIterant[Coeval, Int](list, idx, allowErrors = false)
+
+      stream.bufferTumbling(count).map(_.toList).toListL <->
+        Coeval(list.sliding(count, count).toList)
+    }
+  }
+
+  test("bufferSliding(c, s) is consistent with List.sliding(c, s)") { implicit s =>
+    check4 { (list: List[Int], idx: Int, c: Int, s: Int) =>
+      val count = math.abs(c % 4) + 2
+      val skip = math.abs(s % 4) + 2
+      val stream = arbitraryListToIterant[Coeval, Int](list, idx, allowErrors = false)
+
+      stream.bufferSliding(count, skip).map(_.toList).toListL <->
+        Coeval(list.sliding(count, skip).toList)
+    }
+  }
+
+  test("source.batched <-> source") { implicit s =>
+    check2 { (stream: Iterant[Coeval, Int], c: Int) =>
+      val count = math.abs(c % 4) + 2
+      stream.batched(count) <-> stream
+    }
+  }
+
+  test("protect against broken batches") { implicit s =>
+    val dummy = DummyException("dummy")
+    var effect = 0
+
+    val stream = Iterant[Coeval].nextBatchS[Int](ThrowExceptionBatch(dummy), Coeval(Iterant[Coeval].empty), Coeval.unit)
+      .doOnEarlyStop(Coeval { effect += 1 })
+      .bufferTumbling(10)
+
+    assertEquals(effect, 0)
+    assertEquals(stream.toListL.runTry, Failure(dummy))
+    assertEquals(effect, 1)
+  }
+
+  test("protect against broken cursors") { implicit s =>
+    val dummy = DummyException("dummy")
+    var effect = 0
+
+    val stream = Iterant[Coeval].nextCursorS[Int](ThrowExceptionCursor(dummy), Coeval(Iterant[Coeval].empty), Coeval.unit)
+      .doOnEarlyStop(Coeval { effect += 1 })
+      .bufferTumbling(10)
+
+    assertEquals(effect, 0)
+    assertEquals(stream.toListL.runTry, Failure(dummy))
+    assertEquals(effect, 1)
+  }
+}


### PR DESCRIPTION
New `Iterant` operators:

```scala
sealed abstract class Iterant[F[_], A] {

  def batched(count: Int)(implicit F: Sync[F]): Iterant[F, A]

  def bufferTumbling(count: Int)(implicit F: Sync[F]): Iterant[F, Seq[A]]
 
  def bufferSliding(count: Int, skip: Int)(implicit F: Sync[F]): Iterant[F, Seq[A]] =
}
```

These all share the same implementation, more or less:

1. `bufferSliding` is the exact equivalent of the `sliding` operation on Scala's collection or of `Observable.bufferSliding`
2. `bufferTumbling(count)` is a handy alias for `bufferSliding(count, count)`
3. `batched(count)` is equivalent with `bufferTumbling(count)`, however what it does is to emit `NextBatch` nodes, thus hiding the actual batches being emitted in the underlying implementation - this operator is useful for optimizing the representation of the source

Example for `bufferSliding` given in the docs:

```scala
val source = Iterant[Coeval].of(1, 2, 3, 4, 5, 6, 7)

// Yields Seq(1, 2, 3), Seq(4, 5, 6), Seq(7)
source.bufferSliding(3, 3)

// Yields Seq(1, 2, 3), Seq(5, 6, 7)
source.bufferSliding(3, 4)

// Yields Seq(1, 2, 3), Seq(3, 4, 5), Seq(5, 6, 7)
source.bufferSliding(3, 2)
```