### PR TITLE
Re-add reactivestreams.org tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,13 +4,17 @@ import sbt.Keys.version
 import scala.xml.Elem
 import scala.xml.transform.{RewriteRule, RuleTransformer}
 
-addCommandAlias("ci-jvm-all", ";clean ;coreJVM/test:compile ;coreJVM/test ;mimaReportBinaryIssues ;unidoc")
+addCommandAlias("ci-jvm-all", ";clean ;coreJVM/test:compile ;reactiveTests/test:compile ;coreJVM/test ;reactiveTests/test ;mimaReportBinaryIssues ;unidoc")
 addCommandAlias("ci-jvm",     ";clean ;coreJVM/test:compile ;coreJVM/test")
 addCommandAlias("ci-js",      ";clean ;coreJS/test:compile  ;coreJS/test")
 addCommandAlias("release",    ";project monix ;+publishSigned ;sonatypeReleaseAll")
 
 val catsVersion = "1.0.0-MF"
 val catsEffectVersion = "0.4"
+val jcToolsVersion = "2.0.2"
+val reactiveStreamsVersion = "1.0.1"
+val scalaTestVersion = "3.0.3"
+val minitestVersion = "1.1.1"
 
 // The Monix version with which we must keep binary compatibility.
 // https://github.com/typesafehub/migration-manager/wiki/Sbt-plugin
@@ -142,8 +146,8 @@ lazy val sharedSettings = warnUnusedImport ++ Seq(
   credentials += Credentials(
     "Sonatype Nexus Repository Manager",
     "oss.sonatype.org",
-    sys.env.get("SONATYPE_USER").getOrElse(""),
-    sys.env.get("SONATYPE_PASS").getOrElse("")
+    sys.env.getOrElse("SONATYPE_USER", ""),
+    sys.env.getOrElse("SONATYPE_PASS", "")
   ),
 
   publishMavenStyle := true,
@@ -243,7 +247,7 @@ lazy val unidocSettings = Seq(
 lazy val testSettings = Seq(
   testFrameworks := Seq(new TestFramework("minitest.runner.Framework")),
   libraryDependencies ++= Seq(
-    "io.monix" %%% "minitest-laws" % "1.1.1" % Test,
+    "io.monix" %%% "minitest-laws" % minitestVersion % Test,
     "org.typelevel" %%% "cats-laws" % catsVersion % Test,
     "org.typelevel" %%% "cats-effect-laws" % catsEffectVersion % Test
   )
@@ -268,7 +272,7 @@ def profile: Project ⇒ Project = pr => cmdlineProfile match {
 lazy val monix = project.in(file("."))
   .enablePlugins(ScalaUnidocPlugin)
   .configure(profile)
-  .aggregate(coreJVM, coreJS)
+  .aggregate(coreJVM, coreJS, reactiveTests)
   .settings(sharedSettings)
   .settings(doNotPublishArtifact)
   .settings(unidocSettings)
@@ -302,7 +306,7 @@ lazy val executionJVM = project.in(file("monix-execution/jvm"))
   .settings(testSettings)
   .settings(requiredMacroDeps)
   .settings(executionCommon)
-  .settings(libraryDependencies += "org.reactivestreams" % "reactive-streams" % "1.0.0")
+  .settings(libraryDependencies += "org.reactivestreams" % "reactive-streams" % reactiveStreamsVersion)
   .settings(mimaSettings("monix-execution"))
 
 lazy val executionJS = project.in(file("monix-execution/js"))
@@ -364,17 +368,28 @@ lazy val reactiveCommon =
 
 lazy val reactiveJVM = project.in(file("monix-reactive/jvm"))
   .configure(profile)
-  .dependsOn(executionJVM, evalJVM % "compile->compile; test->test", tailJVM)
+  .dependsOn(executionJVM, evalJVM % "compile->compile; test->test")
   .settings(reactiveCommon)
-  .settings(libraryDependencies += "org.jctools" % "jctools-core" % "2.0.2")
+  .settings(libraryDependencies += "org.jctools" % "jctools-core" % jcToolsVersion)
   .settings(mimaSettings("monix-reactive"))
 
 lazy val reactiveJS = project.in(file("monix-reactive/js"))
   .enablePlugins(ScalaJSPlugin)
   .configure(profile)
-  .dependsOn(executionJS, evalJS % "compile->compile; test->test", tailJS)
+  .dependsOn(executionJS, evalJS % "compile->compile; test->test")
   .settings(reactiveCommon)
   .settings(scalaJSSettings)
+
+lazy val reactiveTests = project.in(file("reactiveTests"))
+  .configure(profile)
+  .dependsOn(coreJVM)
+  .settings(sharedSettings)
+  .settings(doNotPublishArtifact)
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.reactivestreams" % "reactive-streams-tck" % reactiveStreamsVersion % Test,
+      "org.scalatest" %% "scalatest" % scalaTestVersion % Test
+    ))
 
 lazy val benchmarksPrev = project.in(file("benchmarks/vprev"))
   .configure(profile)

--- a/build.sbt
+++ b/build.sbt
@@ -272,7 +272,7 @@ def profile: Project ⇒ Project = pr => cmdlineProfile match {
 lazy val monix = project.in(file("."))
   .enablePlugins(ScalaUnidocPlugin)
   .configure(profile)
-  .aggregate(coreJVM, coreJS, reactiveTests)
+  .aggregate(coreJVM, coreJS)
   .settings(sharedSettings)
   .settings(doNotPublishArtifact)
   .settings(unidocSettings)

--- a/reactiveTests/src/test/scala/monix/reactiveTests/ObservableAsPublisherTest.scala
+++ b/reactiveTests/src/test/scala/monix/reactiveTests/ObservableAsPublisherTest.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.reactiveTests
+
+import monix.execution.Scheduler.Implicits.global
+import monix.reactive.Observable
+import org.reactivestreams.Publisher
+import org.reactivestreams.tck.PublisherVerification
+import org.scalatest.testng.TestNGSuiteLike
+import scala.util.Random
+
+class ObservableAsPublisherTest extends PublisherVerification[Long](env())
+  with TestNGSuiteLike {
+
+  def eval[A](x: A): Observable[A] = {
+    val n = Random.nextInt()
+    if (math.abs(n % 10) == 0)
+      Observable.fork(Observable.now(x))
+    else
+      Observable.now(x)
+  }
+
+  def createPublisher(elements: Long): Publisher[Long] = {
+    if (elements == Long.MaxValue)
+      Observable.repeat(1L).flatMap(eval)
+        .toReactivePublisher
+    else
+      Observable.range(0, elements).flatMap(eval)
+        .toReactivePublisher
+  }
+
+  def createFailedPublisher(): Publisher[Long] = {
+    Observable.raiseError(new RuntimeException("dummy"))
+      .asInstanceOf[Observable[Long]]
+      .toReactivePublisher
+  }
+}

--- a/reactiveTests/src/test/scala/monix/reactiveTests/SubscriberWhiteBoxAsyncTest.scala
+++ b/reactiveTests/src/test/scala/monix/reactiveTests/SubscriberWhiteBoxAsyncTest.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.reactiveTests
+
+import monix.execution.Ack
+import monix.execution.Scheduler.Implicits.global
+import monix.execution.Ack.Continue
+import monix.reactive.Observer
+import monix.reactiveTests.SubscriberWhiteBoxAsyncTest.Value
+import org.reactivestreams.tck.SubscriberWhiteboxVerification.WhiteboxSubscriberProbe
+import org.reactivestreams.tck.SubscriberWhiteboxVerification
+import org.reactivestreams.{Subscriber, Subscription}
+import org.scalatest.testng.TestNGSuiteLike
+
+import scala.concurrent.Future
+import scala.util.Random
+
+class SubscriberWhiteBoxAsyncTest extends SubscriberWhiteboxVerification[Value](env())
+  with TestNGSuiteLike {
+
+  def createSubscriber(probe: WhiteboxSubscriberProbe[Value]): Subscriber[Value] = {
+    val underlying = Observer.toReactiveSubscriber(new Observer[Value] {
+      def onNext(elem: Value): Future[Ack] = {
+        probe.registerOnNext(elem)
+        if (Random.nextInt() % 4 == 0)
+          Future(Continue)
+        else
+          Continue
+      }
+
+      def onError(ex: Throwable): Unit = {
+        probe.registerOnError(ex)
+      }
+
+      def onComplete(): Unit = {
+        probe.registerOnComplete()
+      }
+    })
+
+    new Subscriber[Value] {
+      def onError(t: Throwable): Unit =
+        underlying.onError(t)
+
+      def onSubscribe(s: Subscription): Unit = {
+        underlying.onSubscribe(s)
+        probe.registerOnSubscribe(new SubscriberWhiteboxVerification.SubscriberPuppet {
+          def triggerRequest(elements: Long): Unit = s.request(elements)
+          def signalCancel(): Unit = s.cancel()
+        })
+      }
+
+      def onComplete(): Unit =
+        underlying.onComplete()
+
+      def onNext(t: Value): Unit =
+        underlying.onNext(t)
+    }
+  }
+
+  def createElement(element: Int): Value = {
+    Value(element)
+  }
+}
+
+object SubscriberWhiteBoxAsyncTest {
+  case class Value(nr: Int)
+}

--- a/reactiveTests/src/test/scala/monix/reactiveTests/SubscriberWhiteBoxSyncTest.scala
+++ b/reactiveTests/src/test/scala/monix/reactiveTests/SubscriberWhiteBoxSyncTest.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.reactiveTests
+
+import monix.execution.Scheduler.Implicits.global
+import monix.reactive.Observer
+import monix.execution.Ack.Continue
+import monix.reactiveTests.SubscriberWhiteBoxSyncTest.Value
+import org.reactivestreams.tck.SubscriberWhiteboxVerification.WhiteboxSubscriberProbe
+import org.reactivestreams.tck.SubscriberWhiteboxVerification
+import org.reactivestreams.{Subscriber, Subscription}
+import org.scalatest.testng.TestNGSuiteLike
+
+class SubscriberWhiteBoxSyncTest
+  extends SubscriberWhiteboxVerification[Value](env())
+  with TestNGSuiteLike {
+
+  def createSubscriber(probe: WhiteboxSubscriberProbe[Value]): Subscriber[Value] = {
+    val underlying = Observer.toReactiveSubscriber(new Observer.Sync[Value] {
+      def onNext(elem: Value) = {
+        probe.registerOnNext(elem)
+        Continue
+      }
+
+      def onError(ex: Throwable): Unit = {
+        probe.registerOnError(ex)
+      }
+
+      def onComplete(): Unit = {
+        probe.registerOnComplete()
+      }
+    })
+
+    new Subscriber[Value] {
+      def onError(t: Throwable): Unit =
+        underlying.onError(t)
+
+      def onSubscribe(s: Subscription): Unit = {
+        underlying.onSubscribe(s)
+        probe.registerOnSubscribe(new SubscriberWhiteboxVerification.SubscriberPuppet {
+          def triggerRequest(elements: Long): Unit = s.request(elements)
+          def signalCancel(): Unit = s.cancel()
+        })
+      }
+
+      def onComplete(): Unit =
+        underlying.onComplete()
+
+      def onNext(t: Value): Unit =
+        underlying.onNext(t)
+    }
+  }
+
+  def createElement(element: Int): Value = {
+    Value(element)
+  }
+}
+
+object SubscriberWhiteBoxSyncTest {
+  case class Value(nr: Int)
+}

--- a/reactiveTests/src/test/scala/monix/reactiveTests/package.scala
+++ b/reactiveTests/src/test/scala/monix/reactiveTests/package.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2014-2017 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix
+
+import org.reactivestreams.tck.TestEnvironment
+
+package object reactiveTests {
+  /** Builds the default `TestEnvironment` instance. */
+  def env(): TestEnvironment =
+    new TestEnvironment(
+      TestEnvironment.envDefaultTimeoutMillis(),
+      TestEnvironment.envDefaultNoSignalsTimeoutMillis()
+    )
+}


### PR DESCRIPTION
The [reactive-streams](http://www.reactive-streams.org/) specification provides a TCK that can be used to test for compatibility.

Unfortunately these tests are slow to execute and have always been a problem, due to timeouts triggered. But this is life, we can't let go of them.