### PR TITLE
refactor(eval): get rid of OnFinish type alias b/c of bad naming

### DIFF
--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRunLoop.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRunLoop.scala
@@ -17,7 +17,7 @@
 
 package monix.eval.internal
 
-import monix.eval.Task.{Async, Context, Error, Eval, FlatMap, FrameIndex, MemoizeSuspend, Now, OnFinish, Suspend, fromTry}
+import monix.eval.Task.{Async, Context, Error, Eval, FlatMap, FrameIndex, MemoizeSuspend, Now, Suspend, fromTry}
 import monix.eval.{Callback, Task}
 import monix.execution.atomic.AtomicAny
 import monix.execution.cancelables.StackedCancelable
@@ -145,7 +145,7 @@ private[eval] object TaskRunLoop {
       rcb: RestartCallback,
       bFirst: Bind,
       bRest: CallStack,
-      onFinish: OnFinish[Any],
+      register: (Context, Callback[Any]) => Unit,
       nextFrame: FrameIndex): Unit = {
 
       if (!context.shouldCancel) {
@@ -163,7 +163,7 @@ private[eval] object TaskRunLoop {
         // rcb reference might be null, so initializing
         val restartCallback = if (rcb != null) rcb else new RestartCallback(context, cb)
         restartCallback.prepare(bFirst, bRest)
-        onFinish(context, restartCallback)
+        register(context, restartCallback)
       }
     }
 

--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -154,7 +154,8 @@ object MimaFilters {
     exclude[MissingTypesProblem]("monix.eval.Coeval$Error"),
     exclude[MissingTypesProblem]("monix.eval.Coeval$Now"),
     exclude[ReversedAbstractMethodProblem]("monix.eval.internal.Transformation.apply"),
-    exclude[ReversedMissingMethodProblem]("monix.eval.TaskInstances.catsInstances")
+    exclude[ReversedMissingMethodProblem]("monix.eval.TaskInstances.catsInstances"),
+    exclude[DirectMissingMethodProblem]("monix.eval.Task#Async.onFinish")
   )
 
   /** `monix-react` 3.0.0 */


### PR DESCRIPTION
Small refactoring of `Task`. The `OnFinish` type alias doesn't make much sense and it hides the signature of the callback taken by `unsafeCreate`.