### PR TITLE
Observable.mapParallelUnordered needs configurable overflow strategy

### DIFF
--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -1582,7 +1582,7 @@ abstract class Observable[+A] extends Serializable { self =>
     * @see [[mapTask]] for serial execution
     */
   final def mapParallelUnordered[B](parallelism: Int)(f: A => Task[B])
-                                   (implicit os: OverflowStrategy[B] = OverflowStrategy.Default): Observable[B] =
+    (implicit os: OverflowStrategy[B] = OverflowStrategy.Default): Observable[B] =
     new MapParallelUnorderedObservable[A, B](self, parallelism, f, os)
 
   /** Converts the source Observable that emits `A` into an Observable

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -1581,8 +1581,9 @@ abstract class Observable[+A] extends Serializable { self =>
     *
     * @see [[mapTask]] for serial execution
     */
-  final def mapParallelUnordered[B](parallelism: Int)(f: A => Task[B]): Observable[B] =
-    new MapParallelUnorderedObservable[A, B](self, parallelism, f)
+  final def mapParallelUnordered[B](parallelism: Int)(f: A => Task[B])
+                                   (implicit os: OverflowStrategy[B] = OverflowStrategy.Default): Observable[B] =
+    new MapParallelUnorderedObservable[A, B](self, parallelism, f, os)
 
   /** Converts the source Observable that emits `A` into an Observable
     * that emits `Notification[A]`.

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapParallelUnorderedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapParallelUnorderedSuite.scala
@@ -21,7 +21,7 @@ import monix.eval.Task
 import monix.execution.Ack.Continue
 import monix.execution.internal.Platform
 import monix.execution.exceptions.DummyException
-import monix.reactive.{Observable, Observer}
+import monix.reactive.{Observable, Observer, OverflowStrategy}
 
 import scala.concurrent.Promise
 import scala.concurrent.duration._
@@ -305,6 +305,39 @@ object MapParallelUnorderedSuite extends BaseOperatorSuite {
     p.success(Continue); s.tick()
     assertEquals(initiated, totalCount)
     assertEquals(received, totalCount)
+    assert(isComplete, "isComplete")
+  }
+
+  test("should respect custom overflow strategy") { implicit s =>
+    var initiated = 0
+    var received = 0
+    var isComplete = false
+    val p = Promise[Continue.type]()
+    val totalCount = Platform.recommendedBatchSize * 4
+
+    Observable.range(0, totalCount)
+      .doOnNext(_ => initiated += 1)
+      .mapParallelUnordered(parallelism=4)(x => Task(x))(OverflowStrategy.DropNew(Platform.recommendedBatchSize))
+      .unsafeSubscribeFn(new Observer[Long] {
+        def onNext(elem: Long) = {
+          received += 1
+          p.future
+        }
+
+        def onError(ex: Throwable): Unit =
+          throw ex
+        def onComplete(): Unit =
+          isComplete = true
+      })
+
+    s.tick()
+    assertEquals(initiated, totalCount)
+    assertEquals(received, 1)
+    assert(!isComplete, "!isComplete")
+
+    p.success(Continue); s.tick()
+    assertEquals(initiated, totalCount)
+    assertEquals(received, Platform.recommendedBatchSize + 2) // The rest were dropped from the buffer
     assert(isComplete, "isComplete")
   }
 


### PR DESCRIPTION
Fixes #440.