### PR TITLE
Fix issue where `fromAsyncStateAction` is not safe for user code

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -30,3 +30,6 @@ https://github.com/alonsodomin
 
 Leandro Bolivar
 https://github.com/leandrob13
+
+Ryo Fukumuro
+https://github.com/rfkm

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/AsyncStateActionObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/AsyncStateActionObservable.scala
@@ -46,12 +46,18 @@ class AsyncStateActionObservable[S,A](seed: => S, f: S => Task[(A,S)]) extends O
   }
 
   def loop(subscriber: Subscriber[A], state: S): Task[Unit] =
-    try f(state).flatMap { case (a, newState) =>
-      Task.fromFuture(subscriber.onNext(a)).flatMap {
-        case Continue => loop(subscriber, newState)
-        case Stop => Task.unit
+    try f(state).transformWith(
+      { case (a, newState) =>
+        Task.fromFuture(subscriber.onNext(a)).flatMap {
+          case Continue => loop(subscriber, newState)
+          case Stop => Task.unit
+        }
+      },
+      { ex =>
+        subscriber.onError(ex)
+        Task.unit
       }
-    } catch {
+    ) catch {
       case NonFatal(ex) =>
         Task.raiseError(ex)
     }

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/AsyncStateActionObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/AsyncStateActionObservableSuite.scala
@@ -22,9 +22,12 @@ import monix.eval.Task
 import monix.execution.Ack.Continue
 import monix.execution.internal.Platform
 import monix.execution.ExecutionModel.AlwaysAsyncExecution
+import monix.execution.exceptions.DummyException
 import monix.execution.schedulers.TestScheduler
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
+
+import scala.util.Failure
 
 object AsyncStateActionObservableSuite extends TestSuite[TestScheduler] {
   def setup() = TestScheduler()
@@ -88,6 +91,15 @@ object AsyncStateActionObservableSuite extends TestSuite[TestScheduler] {
     assert(!wasCompleted)
   }
 
+  test("should protect against user code errors") { implicit s =>
+    val ex = DummyException("dummy")
+    val f = Observable.fromAsyncStateAction(intError(ex))(s.currentTimeMillis())
+      .runAsyncGetFirst
+
+    s.tick()
+    assertEquals(f.value, Some(Failure(ex)))
+  }
+
   test("should respect the ExecutionModel") { scheduler =>
     implicit val s = scheduler.withExecutionModel(AlwaysAsyncExecution)
 
@@ -109,6 +121,7 @@ object AsyncStateActionObservableSuite extends TestSuite[TestScheduler] {
 
   def intAsync(seed: Long) = Task(int(seed))
   def intNow(seed: Long) = Task.now(int(seed))
+  def intError(ex: Throwable)(seed: Long) = Task.raiseError[(Int, Long)](ex)
 
   def int(seed: Long): (Int, Long) = {
     // `&` is bitwise AND. We use the current seed to generate a new seed.


### PR DESCRIPTION
An observable created by `fromAsyncStateAction` never completes even if a state function returns a failed task since it doesn't propagate its error to downstream.

This might be related to:  https://github.com/monix/monix/issues/380