### PR TITLE
Upgrade to cats 1.0.0 rc2 and cats-effect 0.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,8 +9,8 @@ addCommandAlias("ci-jvm",     ";clean ;coreJVM/test:compile ;coreJVM/test")
 addCommandAlias("ci-js",      ";clean ;coreJS/test:compile  ;coreJS/test")
 addCommandAlias("release",    ";project monix ;+publishSigned ;sonatypeReleaseAll")
 
-val catsVersion = "1.0.0-RC1"
-val catsEffectVersion = "0.5"
+val catsVersion = "1.0.0-RC2"
+val catsEffectVersion = "0.6"
 val jcToolsVersion = "2.1.1"
 val reactiveStreamsVersion = "1.0.1"
 val scalaTestVersion = "3.0.4"

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantCompleteL.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantCompleteL.scala
@@ -51,7 +51,7 @@ private[tail] object IterantCompleteL {
           F.raiseError(ex)
       } catch {
         case NonFatal(ex) =>
-          source.earlyStop.followedBy(F.raiseError(ex))
+          source.earlyStop *> F.raiseError(ex)
       }
     }
 

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFoldLeft.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFoldLeft.scala
@@ -52,7 +52,7 @@ private[tail] object IterantFoldLeft {
           F.raiseError(ex)
       } catch {
         case NonFatal(ex) =>
-          source.earlyStop.followedBy(F.raiseError(ex))
+          source.earlyStop *> F.raiseError(ex)
       }
     }
 
@@ -64,7 +64,7 @@ private[tail] object IterantFoldLeft {
         loop(source, init)
       } catch {
         case NonFatal(e) if catchErrors =>
-          source.earlyStop.followedBy(F.raiseError(e))
+          source.earlyStop *> F.raiseError(e)
       }
     }
   }

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFoldWhileLeft.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFoldWhileLeft.scala
@@ -80,7 +80,7 @@ private[tail] object IterantFoldWhileLeft {
       }
       catch {
         case NonFatal(e) =>
-          self.earlyStop.followedBy(F.raiseError(e))
+          self.earlyStop *> F.raiseError(e)
       }
     }
 
@@ -138,7 +138,7 @@ private[tail] object IterantFoldWhileLeft {
       }
       catch {
         case NonFatal(e) =>
-          self.earlyStop.followedBy(F.raiseError(e))
+          self.earlyStop *> F.raiseError(e)
       }
     }
 

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantReduce.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantReduce.scala
@@ -49,7 +49,7 @@ private[tail] object IterantReduce {
           F.raiseError(e)
       } catch {
         case NonFatal(e) =>
-          self.earlyStop.followedBy(F.raiseError(e))
+          self.earlyStop *> F.raiseError(e)
       }
     }
 
@@ -82,7 +82,7 @@ private[tail] object IterantReduce {
           }
       } catch {
         case NonFatal(e) =>
-          self.earlyStop.followedBy(F.raiseError(e))
+          self.earlyStop *> F.raiseError(e)
       }
     }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-sbt.version=1.1.0-RC4
+sbt.version=0.13.16

--- a/project/build.properties
+++ b/project/build.properties
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-sbt.version=1.0.3
+sbt.version=1.1.0-RC4


### PR DESCRIPTION
Addressing issue #484. Ought to be quite straightforward.

Replaced one single deprecated operation `Apply.followedBy` with its equivalent, syntactically symbolic, cousin, `*>`.