### PR TITLE
Task.cancel as a pure action with .start, .race and .uncancelable

### DIFF
--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -396,6 +396,73 @@ sealed abstract class Task[+A] extends Serializable {
   final def attempt: Task[Either[Throwable, A]] =
     FlatMap(this, AttemptTask.asInstanceOf[A => Task[Either[Throwable, A]]])
 
+  /** Introduces an asynchronous boundary at the current stage in the
+    * asynchronous processing pipeline.
+    *
+    * Consider the following example:
+    *
+    * {{{
+    *   import monix.execution.Scheduler
+    *   val io = Scheduler.io()
+    *
+    *   val source = Task(1).executeOn(io).map(_ + 1)
+    * }}}
+    *
+    * That task is being forced to execute on the `io` scheduler,
+    * including the `map` transformation that follows after
+    * `executeOn`. But what if we want to jump with the execution
+    * run-loop on the default scheduler for the following
+    * transformations?
+    *
+    * Then we can do:
+    *
+    * {{{
+    *   source.asyncBoundary.map(_ + 2)
+    * }}}
+    *
+    * In this sample, whatever gets evaluated by the `source` will
+    * happen on the `io` scheduler, however the `asyncBoundary` call
+    * will make all subsequent operations to happen on the default
+    * scheduler.
+    */
+  final def asyncBoundary: Task[A] =
+    this.flatMap(r => Task.shift.map(_ => r))
+
+  /** Introduces an asynchronous boundary at the current stage in the
+    * asynchronous processing pipeline, making processing to jump on
+    * the given [[monix.execution.Scheduler Scheduler]] (until the
+    * next async boundary).
+    *
+    * Consider the following example:
+    * {{{
+    *   import monix.execution.Scheduler
+    *   val io = Scheduler.io()
+    *
+    *   val source = Task(1).executeOn(io).map(_ + 1)
+    * }}}
+    *
+    * That task is being forced to execute on the `io` scheduler,
+    * including the `map` transformation that follows after
+    * `executeOn`. But what if we want to jump with the execution
+    * run-loop on another scheduler for the following transformations?
+    *
+    * Then we can do:
+    * {{{
+    *   import monix.execution.Scheduler.global
+    *
+    *   source.asyncBoundary(global).map(_ + 2)
+    * }}}
+    *
+    * In this sample, whatever gets evaluated by the `source` will
+    * happen on the `io` scheduler, however the `asyncBoundary` call
+    * will make all subsequent operations to happen on the specified
+    * `global` scheduler.
+    *
+    * @param s is the scheduler triggering the asynchronous boundary
+    */
+  final def asyncBoundary(s: Scheduler): Task[A] =
+    this.flatMap(a => Task.shift(s).map(_ => a))
+
   /** Transforms a [[Task]] into a [[Coeval]] that tries to execute the
     * source synchronously, returning either `Right(value)` in case a
     * value is available immediately, or `Left(future)` in case we
@@ -404,29 +471,17 @@ sealed abstract class Task[+A] extends Serializable {
   final def coeval(implicit s: Scheduler): Coeval[Either[CancelableFuture[A], A]] =
     Coeval.eval(runSyncMaybe(s))
 
-  /** Returns a failed projection of this task.
+  /** Signals cancellation of the source.
     *
-    * The failed projection is a `Task` holding a value of type `Throwable`,
-    * emitting the error yielded by the source, in case the source fails,
-    * otherwise if the source succeeds the result will fail with a
-    * `NoSuchElementException`.
+    * Returns a new task that will complete when the cancellation is
+    * sent (but not when it is observed).
+    *
+    * Compared with
+    * [[monix.execution.CancelableFuture.cancel CancelableFuture.cancel()]]
+    * this action is pure.
     */
-  final def failed: Task[Throwable] =
-    transformWith(_ => Error(new NoSuchElementException("failed")), e => Now(e))
-
-  /** Creates a new Task by applying a function to the successful result
-    * of the source Task, and returns a task equivalent to the result
-    * of the function.
-    */
-  final def flatMap[B](f: A => Task[B]): Task[B] =
-    FlatMap(this, f)
-
-  /** Given a source Task that emits another Task, this function
-    * flattens the result, returning a Task equivalent to the emitted
-    * Task by the source.
-    */
-  final def flatten[B](implicit ev: A <:< Task[B]): Task[B] =
-    flatMap(a => a)
+  final def cancel: Task[Unit] =
+    TaskCancellation.signal(this)
 
   /** Returns a task that waits for the specified `timespan` before
     * executing and mirroring the result of the source.
@@ -694,72 +749,29 @@ sealed abstract class Task[+A] extends Serializable {
   final def executeWithOptions(f: Options => Options): Task[A] =
     TaskExecuteWithOptions(this, f)
 
-  /** Introduces an asynchronous boundary at the current stage in the
-    * asynchronous processing pipeline.
+  /** Returns a failed projection of this task.
     *
-    * Consider the following example:
-    *
-    * {{{
-    *   import monix.execution.Scheduler
-    *   val io = Scheduler.io()
-    *
-    *   val source = Task(1).executeOn(io).map(_ + 1)
-    * }}}
-    *
-    * That task is being forced to execute on the `io` scheduler,
-    * including the `map` transformation that follows after
-    * `executeOn`. But what if we want to jump with the execution
-    * run-loop on the default scheduler for the following
-    * transformations?
-    *
-    * Then we can do:
-    *
-    * {{{
-    *   source.asyncBoundary.map(_ + 2)
-    * }}}
-    *
-    * In this sample, whatever gets evaluated by the `source` will
-    * happen on the `io` scheduler, however the `asyncBoundary` call
-    * will make all subsequent operations to happen on the default
-    * scheduler.
+    * The failed projection is a `Task` holding a value of type `Throwable`,
+    * emitting the error yielded by the source, in case the source fails,
+    * otherwise if the source succeeds the result will fail with a
+    * `NoSuchElementException`.
     */
-  final def asyncBoundary: Task[A] =
-    this.flatMap(r => Task.shift.map(_ => r))
+  final def failed: Task[Throwable] =
+    transformWith(_ => Error(new NoSuchElementException("failed")), e => Now(e))
 
-  /** Introduces an asynchronous boundary at the current stage in the
-    * asynchronous processing pipeline, making processing to jump on
-    * the given [[monix.execution.Scheduler Scheduler]] (until the
-    * next async boundary).
-    *
-    * Consider the following example:
-    * {{{
-    *   import monix.execution.Scheduler
-    *   val io = Scheduler.io()
-    *
-    *   val source = Task(1).executeOn(io).map(_ + 1)
-    * }}}
-    *
-    * That task is being forced to execute on the `io` scheduler,
-    * including the `map` transformation that follows after
-    * `executeOn`. But what if we want to jump with the execution
-    * run-loop on another scheduler for the following transformations?
-    *
-    * Then we can do:
-    * {{{
-    *   import monix.execution.Scheduler.global
-    *
-    *   source.asyncBoundary(global).map(_ + 2)
-    * }}}
-    *
-    * In this sample, whatever gets evaluated by the `source` will
-    * happen on the `io` scheduler, however the `asyncBoundary` call
-    * will make all subsequent operations to happen on the specified
-    * `global` scheduler.
-    *
-    * @param s is the scheduler triggering the asynchronous boundary
+  /** Creates a new Task by applying a function to the successful result
+    * of the source Task, and returns a task equivalent to the result
+    * of the function.
     */
-  final def asyncBoundary(s: Scheduler): Task[A] =
-    this.flatMap(a => Task.shift(s).map(_ => a))
+  final def flatMap[B](f: A => Task[B]): Task[B] =
+    FlatMap(this, f)
+
+  /** Given a source Task that emits another Task, this function
+    * flattens the result, returning a Task equivalent to the emitted
+    * Task by the source.
+    */
+  final def flatten[B](implicit ev: A <:< Task[B]): Task[B] =
+    flatMap(a => a)
 
   /** Returns a new task that upon evaluation will execute the given
     * function for the generated element, transforming the source into
@@ -779,30 +791,6 @@ sealed abstract class Task[+A] extends Serializable {
     */
   final def foreach(f: A => Unit)(implicit s: Scheduler): CancelableFuture[Unit] =
     foreachL(f).runAsync(s)
-
-  /** Returns a new `Task` that applies the mapping function to
-    * the element emitted by the source.
-    *
-    * Can be used for specifying a (lazy) transformation to the result
-    * of the source.
-    *
-    * This equivalence with [[flatMap]] always holds:
-    *
-    * ```scala
-    * fa.map(f) <-> fa.flatMap(x => Task.pure(f(x)))
-    * ```
-    */
-  final def map[B](f: A => B): Task[B] =
-    this match {
-      case Map(source, g, index) =>
-        // Allowed to do a fixed number of map operations fused before
-        // resetting the counter in order to avoid stack overflows;
-        // See `monix.execution.internal.Platform` for details.
-        if (index != fusionMaxStackDepth) Map(source, g.andThen(f), index + 1)
-        else Map(this, f, 0)
-      case _ =>
-        Map(this, f, 0)
-    }
 
   /** Returns a new `Task` in which `f` is scheduled to be run on
     * completion. This would typically be used to release any
@@ -876,41 +864,29 @@ sealed abstract class Task[+A] extends Serializable {
   final def restartUntil(p: (A) => Boolean): Task[A] =
     this.flatMap(a => if (p(a)) now(a) else this.restartUntil(p))
 
-  /** Creates a new task that in case of error will retry executing the
-    * source again and again, until it succeeds.
+  /** Returns a new `Task` that applies the mapping function to
+    * the element emitted by the source.
     *
-    * In case of continuous failure the total number of executions
-    * will be `maxRetries + 1`.
-    */
-  final def onErrorRestart(maxRetries: Long): Task[A] =
-    this.onErrorHandleWith(ex =>
-      if (maxRetries > 0) this.onErrorRestart(maxRetries-1)
-      else raiseError(ex))
-
-  /** Creates a new task that in case of error will retry executing the
-    * source again and again, until it succeeds.
+    * Can be used for specifying a (lazy) transformation to the result
+    * of the source.
     *
-    * In case of continuous failure the total number of executions
-    * will be `maxRetries + 1`.
-    */
-  final def onErrorRestartIf(p: Throwable => Boolean): Task[A] =
-    this.onErrorHandleWith(ex => if (p(ex)) this.onErrorRestartIf(p) else raiseError(ex))
-
-  /** Creates a new task that will handle any matching throwable that
-    * this task might emit.
+    * This equivalence with [[flatMap]] always holds:
     *
-    * See [[onErrorRecover]] for the version that takes a partial function.
+    * ```scala
+    * fa.map(f) <-> fa.flatMap(x => Task.pure(f(x)))
+    * ```
     */
-  final def onErrorHandle[U >: A](f: Throwable => U): Task[U] =
-    onErrorHandleWith(f.andThen(nowConstructor))
-
-  /** Creates a new task that on error will try to map the error
-    * to another value using the provided partial function.
-    *
-    * See [[onErrorHandle]] for the version that takes a total function.
-    */
-  final def onErrorRecover[U >: A](pf: PartialFunction[Throwable, U]): Task[U] =
-    onErrorRecoverWith(pf.andThen(nowConstructor))
+  final def map[B](f: A => B): Task[B] =
+    this match {
+      case Map(source, g, index) =>
+        // Allowed to do a fixed number of map operations fused before
+        // resetting the counter in order to avoid stack overflows;
+        // See `monix.execution.internal.Platform` for details.
+        if (index != fusionMaxStackDepth) Map(source, g.andThen(f), index + 1)
+        else Map(this, f, 0)
+      case _ =>
+        Map(this, f, 0)
+    }
 
   /** Memoizes (caches) the result of the source task and reuses it on
     * subsequent invocations of `runAsync`.
@@ -962,6 +938,42 @@ sealed abstract class Task[+A] extends Serializable {
         new MemoizeSuspend[A](() => other, cacheErrors = false)
     }
 
+  /** Creates a new task that in case of error will retry executing the
+    * source again and again, until it succeeds.
+    *
+    * In case of continuous failure the total number of executions
+    * will be `maxRetries + 1`.
+    */
+  final def onErrorRestart(maxRetries: Long): Task[A] =
+    this.onErrorHandleWith(ex =>
+      if (maxRetries > 0) this.onErrorRestart(maxRetries-1)
+      else raiseError(ex))
+
+  /** Creates a new task that in case of error will retry executing the
+    * source again and again, until it succeeds.
+    *
+    * In case of continuous failure the total number of executions
+    * will be `maxRetries + 1`.
+    */
+  final def onErrorRestartIf(p: Throwable => Boolean): Task[A] =
+    this.onErrorHandleWith(ex => if (p(ex)) this.onErrorRestartIf(p) else raiseError(ex))
+
+  /** Creates a new task that will handle any matching throwable that
+    * this task might emit.
+    *
+    * See [[onErrorRecover]] for the version that takes a partial function.
+    */
+  final def onErrorHandle[U >: A](f: Throwable => U): Task[U] =
+    onErrorHandleWith(f.andThen(nowConstructor))
+
+  /** Creates a new task that on error will try to map the error
+    * to another value using the provided partial function.
+    *
+    * See [[onErrorHandle]] for the version that takes a total function.
+    */
+  final def onErrorRecover[U >: A](pf: PartialFunction[Throwable, U]): Task[U] =
+    onErrorRecoverWith(pf.andThen(nowConstructor))
+
   /** Converts the source `Task` to a `cats.effect.IO` value. */
   final def toIO(implicit s: Scheduler): IO[A] =
     TaskConversions.toIO(this)(s)
@@ -987,14 +999,23 @@ sealed abstract class Task[+A] extends Serializable {
     * source emitting any item.
     */
   final def timeoutTo[B >: A](after: FiniteDuration, backup: Task[B]): Task[B] =
-    Task.chooseFirstOf(this, Task.unit.delayExecution(after)).flatMap {
-      case Left(((a, futureB))) =>
-        futureB.cancel()
+    Task.race(this, Task.unit.delayExecution(after)).flatMap {
+      case Left(a) =>
         Task.now(a)
-      case Right((futureA, _)) =>
-        futureA.cancel()
+      case Right(_) =>
         backup
     }
+
+  /** Returns a string representation of this task meant for
+    * debugging purposes only.
+    */
+  override def toString: String = this match {
+    case Now(a) => s"Task.Now($a)"
+    case Error(e) => s"Task.Error($e)"
+    case _ =>
+      val n = this.getClass.getName.replaceFirst("^monix\\.eval\\.Task[$.]", "")
+      s"Task.$n$$${System.identityHashCode(this)}"
+  }
 
   /** Creates a new `Task` by applying the 'fa' function to the successful result of
     * this future, or the 'fe' function to the potential errors that might happen.
@@ -1020,6 +1041,12 @@ sealed abstract class Task[+A] extends Serializable {
   final def transformWith[R](fa: A => Task[R], fe: Throwable => Task[R]): Task[R] =
     FlatMap(this, StackFrame.fold(fa, fe))
 
+  /** Makes the source `Task` uninterruptible such that a [[cancel]]
+    * signal has no effect until it finishes.
+    */
+  def uncancelable: Task[A] =
+    TaskCancellation.uncancelable(this)
+
   /** Zips the values of `this` and `that` task, and creates a new task
     * that will emit the tuple of their results.
     */
@@ -1031,14 +1058,6 @@ sealed abstract class Task[+A] extends Serializable {
     */
   final def zipMap[B,C](that: Task[B])(f: (A,B) => C): Task[C] =
     Task.mapBoth(this, that)(f)
-
-  override def toString: String = this match {
-    case Now(a) => s"Task.Now($a)"
-    case Error(e) => s"Task.Error($e)"
-    case _ =>
-      val n = this.getClass.getName.replaceFirst("^monix\\.eval\\.Task[$.]", "")
-      s"Task.$n$$${System.identityHashCode(this)}"
-  }
 }
 
 /** Builders for [[Task]].
@@ -1354,21 +1373,79 @@ object Task extends TaskInstancesLevel1 {
   def fromFuture[A](f: Future[A]): Task[A] =
     TaskFromFuture.strict(f)
 
-  /** Creates a `Task` that upon execution will execute both given tasks
-    * (possibly in parallel in case the tasks are asynchronous) and will
-    * return the result of the task that manages to complete first,
-    * along with a cancelable future of the other task.
+  /** Run two `Task` actions concurrently, and return the first to
+    * finish, either in success or error. The loser of the race is
+    * cancelled.
     *
-    * If the first task that completes
+    * The two tasks are executed in parallel, the winner being the
+    * first that signals a result.
+    *
+    * As an example, this would be equivalent with [[Task.timeout]]:
+    * {{{
+    *   import scala.concurrent.duration._
+    *
+    *   val timeoutError = Task
+    *     .raiseError(new TimeoutException)
+    *     .delayExecution(5.seconds)
+    *
+    *   Task.race(myTask, timeoutError)
+    * }}}
+    *
+    * Similarly [[Task.timeoutTo]] is expressed in terms of `race`.
+    *
+    * Also see [[racePair]] for a version that does not cancel
+    * the loser automatically on successful results. And [[raceMany]]
+    * for a version that races a whole list of tasks.
     */
-  def chooseFirstOf[A,B](fa: Task[A], fb: Task[B]): Task[Either[(A, CancelableFuture[B]), (CancelableFuture[A], B)]] =
-    TaskChooseFirstOf(fa, fb)
+  def race[A, B](fa: Task[A], fb: Task[B]): Task[Either[A, B]] =
+    TaskRace(fa, fb)
 
-  /** Creates a `Task` that upon execution will return the result of the
-    * first completed task in the given list and then cancel the rest.
+  /** Runs multiple `Task` actions concurrently, returning the
+    * first to finish, either in success or error. All losers of the
+    * race get cancelled.
+    *
+    * The tasks get executed in parallel, the winner being the first
+    * that signals a result.
+    *
+    * {{{
+    *   val list: List[Task[Int]] = List(t1, t2, t3, ???)
+    *
+    *   val winner: Task[Int] = Task.raceMany(list)
+    * }}}
+    *
+    * See [[race]] or [[racePair]] for racing two tasks, for more
+    * control.
     */
-  def chooseFirstOfList[A](tasks: TraversableOnce[Task[A]]): Task[A] =
-    TaskChooseFirstOfList(tasks)
+  def raceMany[A](tasks: TraversableOnce[Task[A]]): Task[A] =
+    TaskRaceList(tasks)
+
+  /** Run two `Task` actions concurrently, and returns a pair
+    * containing both the winner's successful value and the loser
+    * represented as a still-unfinished task.
+    *
+    * If the first task completes in error, then the result will
+    * complete in error, the other task being cancelled.
+    *
+    * On usage the user has the option of cancelling the losing task,
+    * this being equivalent with plain [[race]]:
+    *
+    * {{{
+    *   val ta: Task[A] = ???
+    *   val tb: Task[B] = ???
+    *
+    *   Task.racePair(ta, tb).flatMap {
+    *     case Left((a, taskB)) =>
+    *       taskB.cancel.map(_ => a)
+    *     case Right((taskA, b)) =>
+    *       taskA.cancel.map(_ => b)
+    *   }
+    * }}}
+    *
+    * See [[race]] for a simpler version that cancels the loser
+    * immediately or [[raceMany]] that races collections of tasks.
+    */
+  def racePair[A,B](fa: Task[A], fb: Task[B]): Task[Either[(A, Task[B]), (Task[A], B)]] =
+    TaskRacePair(fa, fb)
 
   /** Asynchronous boundary described as an effectful `Task` that
     * can be used in `flatMap` chains to "shift" the continuation
@@ -2204,7 +2281,7 @@ object Task extends TaskInstancesLevel1 {
     * and `Task.fork`.
     */
   def unsafeStartAsync[A](source: Task[A], context: Context, cb: Callback[A]): Unit =
-    TaskRunLoop.restartAsync(source, context, cb, null, null)
+    TaskRunLoop.restartAsync(source, context, cb, null, null, null)
 
   /** Unsafe utility - starts the execution of a Task with a guaranteed
     * [[monix.execution.schedulers.TrampolinedRunnable trampolined asynchronous boundary]],
@@ -2219,7 +2296,7 @@ object Task extends TaskInstancesLevel1 {
   def unsafeStartTrampolined[A](source: Task[A], context: Context, cb: Callback[A]): Unit =
     context.scheduler.execute(new TrampolinedRunnable {
       def run(): Unit =
-        TaskRunLoop.startFull(source, context, cb, null, null, context.frameRef())
+        TaskRunLoop.startFull(source, context, cb, null, null, null, context.frameRef())
     })
 
   /** Unsafe utility - starts the execution of a Task, by providing
@@ -2231,7 +2308,7 @@ object Task extends TaskInstancesLevel1 {
     * what you're doing. Prefer [[Task.runAsync(cb* Task.runAsync]].
     */
   def unsafeStartNow[A](source: Task[A], context: Context, cb: Callback[A]): Unit =
-    TaskRunLoop.startFull(source, context, cb, null, null, context.frameRef())
+    TaskRunLoop.startFull(source, context, cb, null, null, null, context.frameRef())
 
   private[this] final val neverRef: Async[Nothing] =
     Async((_,_) => ())

--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -479,6 +479,14 @@ sealed abstract class Task[+A] extends Serializable {
     * Compared with
     * [[monix.execution.CancelableFuture.cancel CancelableFuture.cancel()]]
     * this action is pure.
+    *
+    * Example:
+    * {{{
+    *   Task.racePair(ta, tb).flatMap {
+    *     case Left((a, tb)) => tb.cancel.map(_ => a)
+    *     case Right((ta, b)) => ta.cancel.map(_ => b)
+    *   }
+    * }}}
     */
   final def cancel: Task[Unit] =
     TaskCancellation.signal(this)
@@ -1085,7 +1093,7 @@ sealed abstract class Task[+A] extends Serializable {
   /** Makes the source `Task` uninterruptible such that a [[cancel]]
     * signal has no effect until it finishes.
     */
-  def uncancelable: Task[A] =
+  final def uncancelable: Task[A] =
     TaskCancellation.uncancelable(this)
 
   /** Zips the values of `this` and `that` task, and creates a new task

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskCancellation.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskCancellation.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval
+package internal
+
+import monix.eval.Task.{Async, Context}
+import monix.execution.cancelables.StackedCancelable
+import monix.execution.schedulers.TrampolinedRunnable
+
+private[eval] object TaskCancellation {
+  /**
+    * Implementation for `Task.cancel`.
+    */
+  def signal[A](fa: Task[A]): Task[Unit] =
+    Task.Async { (ctx, cb) =>
+      implicit val sc = ctx.scheduler
+      // Continues the execution of `fa` using an already cancelled
+      // cancelable, which will ensure that all future registrations
+      // will be cancelled immediately and that `isCanceled == false`
+      val ctx2 = ctx.copy(connection = StackedCancelable.alreadyCanceled)
+      // Light async boundary to avoid stack overflows
+      ctx.scheduler.execute(new TrampolinedRunnable {
+        def run(): Unit = {
+          Task.unsafeStartNow(fa, ctx2, Callback.empty)
+          // Signaling that cancellation has been triggered; given
+          // the synchronous execution of `fa`, what this means is that
+          // cancellation succeeded or an asynchronous boundary has
+          // been hit in `fa`
+          cb.onSuccess(())
+        }
+      })
+    }
+
+  /**
+    * Implementation for `Task.uncancelable`.
+    */
+  def uncancelable[A](fa: Task[A]): Task[A] =
+    Async { (ctx, cb) =>
+      implicit val sc = ctx.scheduler
+      val ctx2 = Context(sc, ctx.options)
+      Task.unsafeStartTrampolined(fa, ctx2, Callback.async(cb))
+    }
+}

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskCreate.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskCreate.scala
@@ -18,7 +18,7 @@
 package monix.eval.internal
 
 import monix.eval.{Callback, Task}
-import monix.execution.cancelables.{SingleAssignmentCancelable, StackedCancelable}
+import monix.execution.cancelables.{SingleAssignCancelable, StackedCancelable}
 import monix.execution.misc.NonFatal
 import monix.execution.{Cancelable, Scheduler}
 
@@ -47,7 +47,7 @@ private[eval] object TaskCreate {
     Task.unsafeCreate { (context, cb) =>
       val s = context.scheduler
       val conn = context.connection
-      val cancelable = SingleAssignmentCancelable()
+      val cancelable = SingleAssignCancelable()
       conn push cancelable
 
       // Forcing a real asynchronous boundary,

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDelayExecution.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDelayExecution.scala
@@ -18,7 +18,7 @@
 package monix.eval.internal
 
 import monix.eval.{Callback, Task}
-import monix.execution.cancelables.SingleAssignmentCancelable
+import monix.execution.cancelables.SingleAssignCancelable
 import scala.concurrent.duration.FiniteDuration
 
 private[eval] object TaskDelayExecution {
@@ -29,7 +29,7 @@ private[eval] object TaskDelayExecution {
     Task.unsafeCreate { (context, cb) =>
       implicit val s = context.scheduler
       val conn = context.connection
-      val c = SingleAssignmentCancelable()
+      val c = SingleAssignCancelable()
       conn push c
 
       c := s.scheduleOnce(timespan.length, timespan.unit, new Runnable {

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDelayResult.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDelayResult.scala
@@ -18,7 +18,7 @@
 package monix.eval.internal
 
 import monix.eval.{Callback, Task}
-import monix.execution.cancelables.SingleAssignmentCancelable
+import monix.execution.cancelables.SingleAssignCancelable
 import scala.concurrent.duration.FiniteDuration
 
 private[eval] object TaskDelayResult {
@@ -33,7 +33,7 @@ private[eval] object TaskDelayResult {
       Task.unsafeStartAsync(self, context,
         new Callback[A] {
           def onSuccess(value: A): Unit = {
-            val task = SingleAssignmentCancelable()
+            val task = SingleAssignCancelable()
             conn push task
 
             // Delaying result

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskExecuteWithModel.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskExecuteWithModel.scala
@@ -44,9 +44,8 @@ private[eval] object TaskExecuteWithModel {
           case AlwaysAsyncExecution | SynchronousExecution =>
             em.nextFrameIndex(0)
         }
-        TaskRunLoop.startFull[A](self, context2, cb, null, null, nextIndex)
-      }
-      catch {
+        TaskRunLoop.startFull[A](self, context2, cb, null, null, null, nextIndex)
+      } catch {
         case ex if NonFatal(ex) =>
           if (streamErrors) cb.onError(ex)
           else context.scheduler.reportFailure(ex)

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskFromFuture.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskFromFuture.scala
@@ -76,7 +76,7 @@ private[eval] object TaskFromFuture {
     f.value match {
       case Some(value) =>
         // Short-circuit the processing, as future is already complete
-        cb.apply(value)
+        cb.asyncApply(value)
 
       case None =>
         f.onComplete { result =>
@@ -92,7 +92,7 @@ private[eval] object TaskFromFuture {
     f.value match {
       case Some(value) =>
         // Short-circuit the processing, as future is already complete
-        cb.apply(value)
+        cb.asyncApply(value)
 
       case None =>
         // Given a cancelable future, we should use it

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskFromFuture.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskFromFuture.scala
@@ -17,10 +17,9 @@
 
 package monix.eval.internal
 
-import monix.eval.Task
+import monix.eval.{Callback, Task}
 import monix.execution.misc.NonFatal
-import monix.execution.{Cancelable, Scheduler}
-
+import monix.execution.{Cancelable, CancelableFuture, Scheduler}
 import scala.concurrent.Future
 
 private[eval] object TaskFromFuture {
@@ -29,50 +28,24 @@ private[eval] object TaskFromFuture {
     if (f.isCompleted) {
       // An already computed result is synchronous
       Task.fromTry(f.value.get)
-    }
-    else f match {
+    } else f match {
       // Do we have a CancelableFuture?
-      case c: Cancelable =>
+      case cf: CancelableFuture[A] @unchecked =>
         // Cancelable future, needs canceling
-        Task.unsafeCreate { (context, cb) =>
-          implicit val s = context.scheduler
-          // Already completed future?
-          if (f.isCompleted)
-            cb.asyncApply(f.value.get)
-          else {
-            val conn = context.connection
-            conn.push(c)
-            f.onComplete { result =>
-              // Async boundary should trigger frame reset
-              context.frameRef.reset()
-              conn.pop()
-              cb(result)
-            }
-          }
-        }
+        Task.unsafeCreate(startCancelable(_, _, cf, cf.cancelable))
       case _ =>
         // Simple future, convert directly
-        Task.unsafeCreate { (context, cb) =>
-          implicit val s = context.scheduler
-          if (f.isCompleted)
-            cb.asyncApply(f.value.get)
-          else
-            f.onComplete { result =>
-              // Async boundary should trigger frame reset
-              context.frameRef.reset()
-              cb(result)
-            }
-        }
+        Task.unsafeCreate(startSimple(_, _, f))
     }
   }
 
   def deferAction[A](f: Scheduler => Future[A]): Task[A] =
     Task.unsafeCreate[A] { (context, callback) =>
-      implicit val s = context.scheduler
+      implicit val sc = context.scheduler
       // Prevents violations of the Callback contract
       var streamErrors = true
       try {
-        val future = f(s)
+        val future = f(sc)
         streamErrors = false
 
         future.value match {
@@ -80,32 +53,58 @@ private[eval] object TaskFromFuture {
             // Already completed future, streaming value immediately,
             // but with light async boundary to prevent stack overflows
             callback.asyncApply(value)
-
           case None =>
             future match {
-              case c: Cancelable =>
-                // Given a cancelable future, we should use it
-                val conn = context.connection
-                conn.push(c)
-                future.onComplete { result =>
-                  // Async boundary should trigger frame reset
-                  context.frameRef.reset()
-                  conn.pop()
-                  callback(result)
-                }
+              case cf: CancelableFuture[A] @unchecked =>
+                startCancelable(context, callback, cf, cf.cancelable)
               case _ =>
-                // Normal future reference
-                future.onComplete { result =>
-                  // Async boundary should trigger frame reset
-                  context.frameRef.reset()
-                  callback(result)
-                }
+                startSimple(context, callback, future)
             }
         }
       } catch {
         case ex if NonFatal(ex) =>
           if (streamErrors) callback.asyncOnError(ex)
-          else s.reportFailure(ex)
+          else sc.reportFailure(ex)
       }
     }
+
+  def build[A](f: Future[A], c: Cancelable): Task[A] =
+    Task.unsafeCreate[A](startCancelable(_, _, f, c))
+
+  private def startSimple[A](ctx: Task.Context, cb: Callback[A], f: Future[A]) = {
+    implicit val sc = ctx.scheduler
+    f.value match {
+      case Some(value) =>
+        // Short-circuit the processing, as future is already complete
+        cb.apply(value)
+
+      case None =>
+        f.onComplete { result =>
+          // Async boundary should trigger frame reset
+          ctx.frameRef.reset()
+          cb(result)
+        }
+    }
+  }
+
+  private def startCancelable[A](ctx: Task.Context, cb: Callback[A], f: Future[A], c: Cancelable): Unit = {
+    implicit val sc = ctx.scheduler
+    f.value match {
+      case Some(value) =>
+        // Short-circuit the processing, as future is already complete
+        cb.apply(value)
+
+      case None =>
+        // Given a cancelable future, we should use it
+        val conn = ctx.connection
+        conn.push(c)
+        // Async boundary
+        f.onComplete { result =>
+          // Async boundary should trigger frame reset
+          ctx.frameRef.reset()
+          conn.pop()
+          cb(result)
+        }
+    }
+  }
 }

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRaceList.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRaceList.scala
@@ -22,9 +22,9 @@ import monix.execution.Cancelable
 import monix.execution.atomic.{Atomic, PaddingStrategy}
 import monix.execution.cancelables.StackedCancelable
 
-private[eval] object TaskChooseFirstOfList {
+private[eval] object TaskRaceList {
   /**
-    * Implementation for `Task.chooseFirstOfList`
+    * Implementation for `Task.raceList`
     */
   def apply[A](tasks: TraversableOnce[Task[A]]): Task[A] =
     Task.unsafeCreate { (context, callback) =>

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRacePair.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRacePair.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval.internal
+
+import monix.eval.{Callback, Task}
+import monix.execution.atomic.Atomic
+import monix.execution.cancelables.{CompositeCancelable, StackedCancelable}
+import scala.concurrent.Promise
+
+private[eval] object TaskRacePair {
+  /**
+    * Implementation for `Task.racePair`.
+    */
+  def apply[A, B](fa: Task[A], fb: Task[B]): Task[Either[(A, Task[B]), (Task[A], B)]] =
+    Task.unsafeCreate { (context, cb) =>
+      implicit val s = context.scheduler
+      val conn = context.connection
+
+      val pa = Promise[A]()
+      val pb = Promise[B]()
+
+      val isActive = Atomic(true)
+      val connA = StackedCancelable()
+      val connB = StackedCancelable()
+      conn push CompositeCancelable(connA, connB)
+
+      val contextA = context.copy(connection = connA)
+      val contextB = context.copy(connection = connB)
+
+      // First task: A
+      Task.unsafeStartAsync(fa, contextA, new Callback[A] {
+        def onSuccess(valueA: A): Unit =
+          if (isActive.getAndSet(false)) {
+            val futureB = TaskFromFuture.build(pb.future, connB)
+            conn.pop()
+            cb.asyncOnSuccess(Left((valueA, futureB)))
+          } else {
+            pa.success(valueA)
+          }
+
+        def onError(ex: Throwable): Unit =
+          if (isActive.getAndSet(false)) {
+            conn.pop()
+            connB.cancel()
+            cb.asyncOnError(ex)
+          } else {
+            pa.failure(ex)
+          }
+      })
+
+      // Second task: B
+      Task.unsafeStartAsync(fb, contextB, new Callback[B] {
+        def onSuccess(valueB: B): Unit =
+          if (isActive.getAndSet(false)) {
+            val futureA = TaskFromFuture.build(pa.future, connA)
+            conn.pop()
+            cb.asyncOnSuccess(Right((futureA, valueB)))
+          } else {
+            pb.success(valueB)
+          }
+
+        def onError(ex: Throwable): Unit =
+          if (isActive.getAndSet(false)) {
+            conn.pop()
+            connA.cancel()
+            cb.asyncOnError(ex)
+          } else {
+            pb.failure(ex)
+          }
+      })
+    }
+}

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskStart.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskStart.scala
@@ -39,13 +39,10 @@ private[eval] object TaskStart {
           // It needs its own context, its own cancelable
           val ctx2 = Task.Context(ctx.scheduler, ctx.options)
           val task = TaskFromFuture.build(p.future, ctx2.connection)
-          // Signal the created Task reference; this comes before the
-          // execution because it will make our main run-loop to
-          // eventually back-pressure for its result (when the result
-          // is needed or when the first async boundary is hit)
-          cb.onSuccess(task)
           // Starting actual execution of our newly created task
           Task.unsafeStartNow(fa, ctx2, Callback.fromPromise(p))
+          // Signal the created Task reference
+          cb.onSuccess(task)
         }
       })
     }

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskStart.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskStart.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval
+package internal
+
+import monix.execution.schedulers.TrampolinedRunnable
+
+import scala.concurrent.Promise
+
+private[eval] object TaskStart {
+  /**
+    * Implementation for `Task.start`.
+    */
+  def apply[A](fa: Task[A]): Task[Task[A]] =
+    Task.Async { (ctx, cb) =>
+      implicit val sc = ctx.scheduler
+      // Standard Scala promise gets used for storing or waiting
+      // for the final result
+      val p = Promise[A]()
+      // Signaling the result as a Task
+      val ctx2 = Task.Context(ctx.scheduler, ctx.options)
+      val task = TaskFromFuture.build(p.future, ctx2.connection)
+      // Light async boundary to avoid stack overflows
+      ctx.scheduler.execute(new TrampolinedRunnable {
+        def run(): Unit = {
+          // Signal the created Task reference
+          cb.onSuccess(task)
+          // Starting actual execution
+          Task.unsafeStartNow(fa, ctx2, Callback.fromPromise(p))
+        }
+      })
+    }
+}

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskCancellationSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskCancellationSuite.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval
+
+import scala.concurrent.duration._
+import scala.util.Success
+
+object TaskCancellationSuite extends BaseTestSuite {
+  test("cancellation works for async actions") { implicit ec =>
+    var wasCancelled = false
+    val task = Task.eval(1).delayExecution(1.second)
+      .doOnCancel(Task.eval { wasCancelled = true })
+      .cancel
+
+    task.runAsync
+    assert(wasCancelled, "wasCancelled")
+    assert(ec.state.tasks.isEmpty, "tasks.isEmpty")
+  }
+
+  test("cancellation works for autoCancelableRunLoops") { implicit ec =>
+    implicit val opts = Task.defaultOptions.enableAutoCancelableRunLoops
+
+    var effect = 0
+    val task = Task(1).flatMap(x => Task(2).map(_ + x))
+      .foreachL { x => effect = x }
+      .cancel
+
+    val f = task.runAsyncOpt
+    ec.tick()
+    assertEquals(f.value, Some(Success(())))
+    assertEquals(effect, 0)
+  }
+
+  test("uncancelable works for async actions") { implicit ec =>
+    var effect = 0
+    val task = Task.eval(1).delayExecution(1.second)
+      .foreachL { x => effect += x }
+
+    val f = task.uncancelable.flatMap(_ => task).runAsync
+    ec.tick()
+    assertEquals(effect, 0)
+
+    f.cancel()
+    ec.tick(1.second)
+    assertEquals(effect, 1)
+
+    assert(ec.state.tasks.isEmpty, "tasks.isEmpty")
+    ec.tick(1.second)
+    assertEquals(f.value, None)
+  }
+
+  test("uncancelable works for autoCancelableRunLoops") { implicit ec =>
+    implicit val opts = Task.defaultOptions.enableAutoCancelableRunLoops
+    val task = Task(1)
+    val f = task.flatMap(x => task.map(_ + x)).uncancelable.runAsyncOpt
+
+    f.cancel()
+    ec.tick()
+    assertEquals(f.value, Some(Success(2)))
+  }
+
+  test("uncancelable is stack safe in flatMap loop, take 1") { implicit ec =>
+    def loop(n: Int): Task[Int] =
+      Task.eval(n).flatMap { x =>
+        if (x > 0)
+          Task.eval(x - 1).uncancelable.flatMap(loop)
+        else
+          Task.pure(0)
+      }
+
+    val f = loop(10000).runAsync
+    ec.tick()
+    assertEquals(f.value, Some(Success(0)))
+  }
+
+  test("uncancelable is stack safe in flatMap loop, take 2") { implicit ec =>
+    var task = Task(1)
+    for (_ <- 0 until 10000) task = task.uncancelable
+
+    val f = task.runAsync
+    ec.tick()
+    assertEquals(f.value, Some(Success(1)))
+  }
+}

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskCreateSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskCreateSuite.scala
@@ -19,7 +19,7 @@ package monix.eval
 
 import monix.execution.Cancelable
 import monix.execution.atomic.Atomic
-import monix.execution.cancelables.{CompositeCancelable, MultiAssignmentCancelable}
+import monix.execution.cancelables.{CompositeCancelable, MultiAssignCancelable}
 import monix.execution.exceptions.DummyException
 import monix.execution.internal.Platform
 
@@ -81,7 +81,7 @@ object TaskCreateSuite extends BaseTestSuite {
     def sum(t1: Task[Int], t2: Task[Int]): Task[Int] =
       Task.create { (s, cb) =>
         implicit val scheduler = s
-        val c = MultiAssignmentCancelable()
+        val c = MultiAssignCancelable()
 
         c := t1.runAsync(new Callback[Int] {
           def onSuccess(v1: Int): Unit =

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskStartSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskStartSuite.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval
+
+import cats.laws._
+import cats.laws.discipline._
+
+import concurrent.duration._
+import scala.util.Success
+
+object TaskStartSuite extends BaseTestSuite {
+  test("task.start.flatMap(id) <-> task") { implicit sc =>
+    check1 { (task: Task[Int]) =>
+      task.start.flatMap(x => x) <-> task
+    }
+  }
+
+  test("task.start.flatMap(id) is cancelable") { implicit sc =>
+    val task = Task.eval(1).delayExecution(1.second).start.flatMap(x => x)
+    val f = task.runAsync
+
+    assert(sc.state.tasks.nonEmpty, "tasks.nonEmpty")
+    f.cancel()
+    assert(sc.state.tasks.isEmpty, "tasks.isEmpty")
+
+    sc.tick(1.second)
+    assertEquals(f.value, None)
+  }
+
+  test("task.start is stack safe") { implicit sc =>
+    var task: Task[Any] = Task(1)
+    for (_ <- 0 until 5000) task = task.start
+    for (_ <- 0 until 5000) task = task.flatMap(x => x.asInstanceOf[Task[Any]])
+
+    val f = task.runAsync
+    sc.tick()
+    assertEquals(f.value, Some(Success(1)))
+  }
+}

--- a/monix-execution/js/src/main/scala/monix/execution/cancelables/ChainedCancelable.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/cancelables/ChainedCancelable.scala
@@ -25,7 +25,7 @@ import monix.execution.Cancelable.IsDummy
   * be "chained" to another `ChainedCancelable`, forwarding all
   * operations to it.
   *
-  * For most purposes it works like a [[MultiAssignmentCancelable]]:
+  * For most purposes it works like a [[OrderedCancelable]]:
   *
   * {{{
   *   val s = ChainedCancelable()
@@ -78,8 +78,8 @@ import monix.execution.Cancelable.IsDummy
   * [[monix.execution.CancelableFuture CancelableFuture]].
   *
   * If unsure about what to use, then you probably don't need
-  * [[ChainedCancelable]]. Use [[MultiAssignmentCancelable]] or
-  * [[SingleAssignmentCancelable]] for most purposes.
+  * [[ChainedCancelable]]. Use [[OrderedCancelable]] or
+  * [[SingleAssignCancelable]] for most purposes.
   */
 final class ChainedCancelable private (private var stateRef: AnyRef)
   extends AssignableCancelable {

--- a/monix-execution/jvm/src/main/scala/monix/execution/cancelables/ChainedCancelable.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/cancelables/ChainedCancelable.scala
@@ -27,7 +27,7 @@ import monix.execution.atomic.{AtomicAny, PaddingStrategy}
   * be "chained" to another `ChainedCancelable`, forwarding all
   * operations to it.
   *
-  * For most purposes it works like a [[MultiAssignmentCancelable]]:
+  * For most purposes it works like a [[OrderedCancelable]]:
   *
   * {{{
   *   val s = ChainedCancelable()
@@ -85,8 +85,8 @@ import monix.execution.atomic.{AtomicAny, PaddingStrategy}
   * reasons.
   *
   * If unsure about what to use, then you probably don't need
-  * [[ChainedCancelable]]. Use [[MultiAssignmentCancelable]] or
-  * [[SingleAssignmentCancelable]] for most purposes.
+  * [[ChainedCancelable]]. Use [[OrderedCancelable]] or
+  * [[SingleAssignCancelable]] for most purposes.
   */
 final class ChainedCancelable private (private val state: AtomicAny[AnyRef])
   extends AssignableCancelable {

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/AsyncSchedulerSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/AsyncSchedulerSuite.scala
@@ -20,7 +20,7 @@ package monix.execution.schedulers
 import java.util.concurrent.{CountDownLatch, TimeUnit, TimeoutException}
 import minitest.SimpleTestSuite
 import monix.execution.ExecutionModel.AlwaysAsyncExecution
-import monix.execution.cancelables.SingleAssignmentCancelable
+import monix.execution.cancelables.SingleAssignCancelable
 import monix.execution.{Cancelable, Scheduler}
 import monix.execution.{ExecutionModel => ExecModel}
 import scala.concurrent.duration._
@@ -59,7 +59,7 @@ object AsyncSchedulerSuite extends SimpleTestSuite {
   }
 
   test("schedule with fixed delay") {
-    val sub = SingleAssignmentCancelable()
+    val sub = SingleAssignCancelable()
     val p = Promise[Int]()
     var value = 0
 
@@ -78,7 +78,7 @@ object AsyncSchedulerSuite extends SimpleTestSuite {
   }
 
   test("schedule at fixed rate") {
-    val sub = SingleAssignmentCancelable()
+    val sub = SingleAssignCancelable()
     val p = Promise[Int]()
     var value = 0
 

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/ExecutorSchedulerSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/ExecutorSchedulerSuite.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.{CountDownLatch, TimeUnit, TimeoutException}
 
 import minitest.TestSuite
 import monix.execution.ExecutionModel.{AlwaysAsyncExecution, Default => DefaultExecutionModel}
-import monix.execution.cancelables.SingleAssignmentCancelable
+import monix.execution.cancelables.SingleAssignCancelable
 import monix.execution.exceptions.DummyException
 import monix.execution.{Cancelable, Scheduler, UncaughtExceptionReporter}
 
@@ -79,7 +79,7 @@ abstract class ExecutorSchedulerSuite extends TestSuite[SchedulerService] { self
   }
 
   test("schedule with fixed delay") { scheduler =>
-    val sub = SingleAssignmentCancelable()
+    val sub = SingleAssignCancelable()
     val p = Promise[Int]()
     var value = 0
 
@@ -98,7 +98,7 @@ abstract class ExecutorSchedulerSuite extends TestSuite[SchedulerService] { self
   }
 
   test("schedule at fixed rate") { scheduler =>
-    val sub = SingleAssignmentCancelable()
+    val sub = SingleAssignCancelable()
     val p = Promise[Int]()
     var value = 0
 

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/ScheduledExecutorToSchedulerSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/ScheduledExecutorToSchedulerSuite.scala
@@ -22,7 +22,7 @@ import minitest.TestSuite
 import monix.execution.ExecutionModel.AlwaysAsyncExecution
 import monix.execution.{Scheduler, UncaughtExceptionReporter, ExecutionModel => ExecModel}
 import monix.execution.atomic.Atomic
-import monix.execution.cancelables.SingleAssignmentCancelable
+import monix.execution.cancelables.SingleAssignCancelable
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Promise}
 
@@ -90,7 +90,7 @@ object ScheduledExecutorToSchedulerSuite extends TestSuite[ExecutorScheduler] {
   }
 
   test("schedule with fixed delay") { implicit s =>
-    val sub = SingleAssignmentCancelable()
+    val sub = SingleAssignCancelable()
     val p = Promise[Int]()
     var value = 0
 
@@ -109,7 +109,7 @@ object ScheduledExecutorToSchedulerSuite extends TestSuite[ExecutorScheduler] {
   }
 
   test("schedule at fixed rate") { implicit s =>
-    val sub = SingleAssignmentCancelable()
+    val sub = SingleAssignCancelable()
     val p = Promise[Int]()
     var value = 0
 

--- a/monix-execution/shared/src/main/scala/monix/execution/Cancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/Cancelable.scala
@@ -81,7 +81,7 @@ object Cancelable {
       throw new CompositeException(errors)
   }
 
-  /** Marker for cancellables that are dummies that can be ignored. */
+  /** Marker for cancelables that are dummies that can be ignored. */
   trait IsDummy { self: Cancelable => }
 
   private final class CancelableTask(cb: () => Unit)

--- a/monix-execution/shared/src/main/scala/monix/execution/CancelableFuture.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/CancelableFuture.scala
@@ -20,7 +20,7 @@ package monix.execution
 import cats.{CoflatMap, Eval, Monad, MonadError, StackSafeMonad}
 import monix.execution.Cancelable.IsDummy
 import monix.execution.CancelableFuture.{Async, Never, Pure}
-import monix.execution.cancelables.{ChainedCancelable, SingleAssignmentCancelable}
+import monix.execution.cancelables.{ChainedCancelable, SingleAssignCancelable}
 import monix.execution.schedulers.TrampolinedRunnable
 import monix.execution.schedulers.TrampolineExecutionContext.immediate
 
@@ -34,11 +34,11 @@ import scala.util.control.NonFatal
   * as long as it isn't complete.
   */
 sealed abstract class CancelableFuture[+A] extends Future[A] with Cancelable { self =>
-  /** Returns this future's cancelable reference. */
-  protected def cancelable: Cancelable
+  /** Returns this future's underlying [[Cancelable]] reference. */
+  private[monix] def cancelable: Cancelable
 
   /** Returns the underlying `Future` reference. */
-  protected def underlying: Future[A]
+  private[monix] def underlying: Future[A]
 
   override final def failed: CancelableFuture[Throwable] = {
     implicit val ec = immediate
@@ -272,7 +272,7 @@ object CancelableFuture {
     (implicit ec: ExecutionContext): CancelableFuture[A] = {
 
     val p = Promise[A]()
-    val cRef = SingleAssignmentCancelable()
+    val cRef = SingleAssignCancelable()
 
     // Light async boundary to guard against stack overflows
     ec.execute(new TrampolinedRunnable {

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/AssignableCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/AssignableCancelable.scala
@@ -22,8 +22,8 @@ import monix.execution.Cancelable
   * an internal reference to another cancelable (and thus
   * has to support the assignment operator).
   *
-  * Examples are the [[MultiAssignmentCancelable]] and the
-  * [[SingleAssignmentCancelable]].
+  * Examples are the [[OrderedCancelable]] and the
+  * [[SingleAssignCancelable]].
   *
   * On assignment, if this cancelable is already
   * canceled, then no assignment should happen and the update
@@ -50,21 +50,15 @@ object AssignableCancelable {
   /** Interface for [[AssignableCancelable]] types that can be
     * assigned multiple times.
     */
-  trait Multi extends AssignableCancelable.Bool {
-    /** An ordered update is an update with an order attached and if
-      * the currently stored reference has on order that is greater
-      * than the update, then the update is ignored.
-      */
-    def orderedUpdate(value: Cancelable, order: Long): this.type
-  }
+  trait Multi extends AssignableCancelable.Bool
 
-  /** Builds a [[MultiAssignmentCancelable]] */
+  /** Builds a [[OrderedCancelable]] */
   def multi(initial: Cancelable = Cancelable.empty): AssignableCancelable =
-    MultiAssignmentCancelable(initial)
+    MultiAssignCancelable(initial)
 
-  /** Builds a [[SingleAssignmentCancelable]] */
+  /** Builds a [[SingleAssignCancelable]] */
   def single(): AssignableCancelable =
-    SingleAssignmentCancelable()
+    SingleAssignCancelable()
 
   /** A reusable [[AssignableCancelable]] instance that's already
     * canceled and that's going to cancel given values on assignment.

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/MultiAssignCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/MultiAssignCancelable.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.execution.cancelables
+
+import monix.execution.Cancelable
+import monix.execution.Cancelable.IsDummy
+import monix.execution.atomic.{AtomicAny, PaddingStrategy}
+
+import scala.annotation.tailrec
+
+/** Represents a [[monix.execution.Cancelable Cancelable]] whose
+  * underlying cancelable reference can be swapped for another.
+  *
+  * Example:
+  * {{{
+  *   val s = MultiAssignmentCancelable()
+  *   s := c1 // sets the underlying cancelable to c1
+  *   s := c2 // swaps the underlying cancelable to c2
+  *
+  *   s.cancel() // also cancels c2
+  *
+  *   s := c3 // also cancels c3, because s is already canceled
+  * }}}
+  *
+  * Also see:
+  *
+  *  - [[SerialCancelable]], which is similar, except that it
+  *    cancels the old cancelable upon assigning a new cancelable
+  *  - [[SingleAssignCancelable]] that is effectively a forward
+  *    reference that can be assigned at most once
+  *  - [[OrderedCancelable]] that's very similar with
+  *    `MultiAssignCancelable`, but with the capability of forcing
+  *    ordering on concurrent updates
+  */
+final class MultiAssignCancelable private (initial: Cancelable)
+  extends AssignableCancelable.Multi {
+
+  private[this] val state = {
+    AtomicAny.withPadding(initial, PaddingStrategy.LeftRight128)
+  }
+
+  override def isCanceled: Boolean =
+    state.get match {
+      case null => true
+      case _ => false
+    }
+
+  override def cancel(): Unit = {
+    // Using getAndSet, which on Java 8 should be faster than
+    // a compare-and-set.
+    val oldState: Cancelable = state.getAndSet(null)
+    if (oldState ne null) oldState.cancel()
+  }
+
+  @tailrec def `:=`(value: Cancelable): this.type =
+    state.get match {
+      case null =>
+        value.cancel()
+        this
+      case `value` =>
+        // ignore
+        this
+      case current =>
+        if (!state.compareAndSet(current, value))
+          :=(value) // retry
+        else
+          this
+    }
+
+  /** Clears the underlying reference, setting it to a
+    * [[Cancelable.empty]] (if not cancelled).
+    *
+    * This is equivalent with:
+    * {{{
+    *   ref := Cancelable.empty
+    * }}}
+    *
+    * The purpose of this method is to release any underlying
+    * reference for GC purposes, however if the underlying reference
+    * is a [[monix.execution.Cancelable.IsDummy dummy]] then the
+    * assignment doesn't happen because we don't care about releasing
+    * dummy references.
+    */
+  @tailrec def clear(): Cancelable = {
+    val current: Cancelable = state.get
+    if ((current ne null) && !current.isInstanceOf[IsDummy]) {
+      if (!state.compareAndSet(current, Cancelable.empty))
+        clear() // retry
+      else
+        current
+    } else {
+      Cancelable.empty
+    }
+  }
+}
+
+object MultiAssignCancelable {
+  /** Builder for [[MultiAssignCancelable]]. */
+  def apply(): MultiAssignCancelable =
+    new MultiAssignCancelable(Cancelable.empty)
+
+  /** Builder for [[MultiAssignCancelable]]. */
+  def apply(s: Cancelable): MultiAssignCancelable =
+    new MultiAssignCancelable(s)
+}

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/SerialCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/SerialCancelable.scala
@@ -36,7 +36,7 @@ import scala.annotation.tailrec
   *   s := c3 // also cancels c3, because s is already canceled
   * }}}
   *
-  * Also see [[MultiAssignmentCancelable]], which is similar, but doesn't cancel
+  * Also see [[OrderedCancelable]], which is similar, but doesn't cancel
   * the old cancelable upon assignment.
   */
 final class SerialCancelable private (initial: Cancelable)

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/SingleAssignCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/SingleAssignCancelable.scala
@@ -17,7 +17,7 @@
 
 package monix.execution.cancelables
 
-import monix.execution.cancelables.SingleAssignmentCancelable.State
+import monix.execution.cancelables.SingleAssignCancelable.State
 import monix.execution.atomic.AtomicAny
 import scala.annotation.tailrec
 import monix.execution.Cancelable
@@ -25,7 +25,7 @@ import monix.execution.Cancelable
 /** Represents a [[monix.execution.Cancelable]] that can be assigned only
   * once to another cancelable reference.
   *
-  * Similar to [[monix.execution.cancelables.MultiAssignmentCancelable]],
+  * Similar to [[monix.execution.cancelables.OrderedCancelable]],
   * except that in case of multi-assignment, it throws a
   * `java.lang.IllegalStateException`.
   *
@@ -34,11 +34,11 @@ import monix.execution.Cancelable
   *
   * Useful in case you need a forward reference.
   */
-final class SingleAssignmentCancelable private (extra: Cancelable)
+final class SingleAssignCancelable private (extra: Cancelable)
   extends AssignableCancelable.Bool {
 
   // For binary compatibility
-  private[SingleAssignmentCancelable] def this() = this(null)
+  private[SingleAssignCancelable] def this() = this(null)
 
   import State._
 
@@ -102,13 +102,13 @@ final class SingleAssignmentCancelable private (extra: Cancelable)
   private[this] val state = AtomicAny(Empty : State)
 }
 
-object SingleAssignmentCancelable {
-  /** Builder for [[SingleAssignmentCancelable]]. */
-  def  apply(): SingleAssignmentCancelable =
-    new SingleAssignmentCancelable()
+object SingleAssignCancelable {
+  /** Builder for [[SingleAssignCancelable]]. */
+  def  apply(): SingleAssignCancelable =
+    new SingleAssignCancelable()
 
-  /** Builder for [[SingleAssignmentCancelable]] that takes an extra reference,
-    * to be canceled on [[SingleAssignmentCancelable.cancel cancel()]]
+  /** Builder for [[SingleAssignCancelable]] that takes an extra reference,
+    * to be canceled on [[SingleAssignCancelable.cancel cancel()]]
     * along with whatever underlying reference we have.
     *
     * {{{
@@ -125,8 +125,8 @@ object SingleAssignmentCancelable {
     *   //=> main canceled
     * }}}
     */
-  def plusOne(guest: Cancelable): SingleAssignmentCancelable =
-    new SingleAssignmentCancelable(guest)
+  def plusOne(guest: Cancelable): SingleAssignCancelable =
+    new SingleAssignCancelable(guest)
 
   private[monix] sealed trait State
   private[monix] object State {

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/StackedCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/StackedCancelable.scala
@@ -30,24 +30,7 @@ import scala.annotation.tailrec
   *
   * Used in the implementation of `monix.eval.Task`.
   */
-final class StackedCancelable private (initial: List[Cancelable])
-  extends BooleanCancelable {
-
-  private[this] val state = {
-    val ref = if (initial != null) initial else Nil
-    AtomicAny.withPadding(ref, PaddingStrategy.LeftRight128)
-  }
-
-  override def isCanceled: Boolean =
-    state.get == null
-
-  override def cancel(): Unit = {
-    // Using getAndSet, which on Java 8 should be faster than
-    // a compare-and-set.
-    val oldState = state.getAndSet(null)
-    if (oldState ne null) oldState.foreach(_.cancel())
-  }
-
+sealed abstract class StackedCancelable extends BooleanCancelable {
   /** Pops the head of the stack and pushes a list as an
     * atomic operation.
     *
@@ -60,23 +43,7 @@ final class StackedCancelable private (initial: List[Cancelable])
     * @param list is the list to prepend to the cancelable stack
     * @return the cancelable reference that was popped from the stack
     */
-  @tailrec def popAndPushList(list: List[Cancelable]): Cancelable = {
-    state.get match {
-      case null =>
-        list.foreach(_.cancel())
-        Cancelable.empty
-      case Nil =>
-        if (!state.compareAndSet(Nil, list))
-          popAndPushList(list)
-        else
-          Cancelable.empty
-      case ref @ (head :: tail) =>
-        if (!state.compareAndSet(ref, list ::: tail))
-          popAndPushList(list)
-        else
-          head
-    }
-  }
+  def popAndPushList(list: List[Cancelable]): Cancelable
 
   /** Pops the head of the stack and pushes a list as
     * an atomic operation.
@@ -90,23 +57,7 @@ final class StackedCancelable private (initial: List[Cancelable])
     * @param value is the cancelable reference to push on the stack
     * @return the cancelable reference that was popped from the stack
     */
-  @tailrec def popAndPush(value: Cancelable): Cancelable = {
-    state.get match {
-      case null =>
-        value.cancel()
-        Cancelable.empty
-      case Nil =>
-        if (!state.compareAndSet(Nil, value :: Nil))
-          popAndPush(value)
-        else
-          Cancelable.empty
-      case ref @ (head :: tail) =>
-        if (!state.compareAndSet(ref, value :: tail))
-          popAndPush(value) // retry
-        else
-          head
-    }
-  }
+  def popAndPush(value: Cancelable): Cancelable
 
   /** Pushes a whole list of cancelable references on the stack.
     *
@@ -117,61 +68,154 @@ final class StackedCancelable private (initial: List[Cancelable])
     *
     * @param list is the list to prepend to the cancelable stack
     */
-  @tailrec def pushList(list: List[Cancelable]): Unit = {
-    state.get match {
-      case null =>
-        list.foreach(_.cancel())
-      case stack =>
-        if (!state.compareAndSet(stack, list ::: stack))
-          pushList(list) // retry
-    }
-  }
+  def pushList(list: List[Cancelable]): Unit
 
   /** Pushes a cancelable reference on the stack, to be
     * popped or cancelled later in FIFO order.
     */
-  @tailrec def push(value: Cancelable): Unit = {
-    state.get match {
-      case null =>
-        value.cancel()
-      case stack =>
-        if (!state.compareAndSet(stack, value :: stack))
-          push(value) // retry
-    }
-  }
+  def push(value: Cancelable): Unit
 
   /** Removes a cancelable reference from the stack in FIFO order.
     *
     * @return the cancelable reference that was removed.
     */
-  @tailrec def pop(): Cancelable = {
-    state.get match {
-      case null => Cancelable.empty
-      case Nil => Cancelable.empty
-      case ref @ (head :: tail) =>
-        if (!state.compareAndSet(ref, tail))
-          pop()
-        else
-          head
-    }
-  }
+  def pop(): Cancelable
 }
 
 object StackedCancelable {
   /** Builds an empty [[StackedCancelable]] reference. */
   def apply(): StackedCancelable =
-    new StackedCancelable(null)
+    new Impl(Nil)
 
   /** Builds a [[StackedCancelable]] with an initial
     * cancelable reference in it.
     */
   def apply(initial: Cancelable): StackedCancelable =
-    new StackedCancelable(List(initial))
+    new Impl(List(initial))
 
   /** Builds a [[StackedCancelable]] already initialized with
     * a list of cancelable references, to be popped or canceled
     * later in FIFO order.
     */
   def apply(initial: List[Cancelable]): StackedCancelable =
-    new StackedCancelable(initial)
+    new Impl(initial)
+
+  /** Reusable [[StackedCancelable]] reference that is already
+    * cancelled.
+    */
+  final val alreadyCanceled: StackedCancelable =
+    new AlreadyCanceled
+
+  /** Implementation for [[StackedCancelable]] backed by a
+    * cache-line padded atomic reference for synchronization.
+    */
+  private final class Impl(initial: List[Cancelable])
+    extends StackedCancelable {
+
+    private[this] val state = {
+      val ref = if (initial != null) initial else Nil
+      AtomicAny.withPadding(ref, PaddingStrategy.LeftRight128)
+    }
+
+    override def isCanceled: Boolean =
+      state.get == null
+
+    override def cancel(): Unit = {
+      // Using getAndSet, which on Java 8 should be faster than
+      // a compare-and-set.
+      val oldState = state.getAndSet(null)
+      if (oldState ne null) oldState.foreach(_.cancel())
+    }
+
+    @tailrec def popAndPushList(list: List[Cancelable]): Cancelable = {
+      state.get match {
+        case null =>
+          list.foreach(_.cancel())
+          Cancelable.empty
+        case Nil =>
+          if (!state.compareAndSet(Nil, list))
+            popAndPushList(list)
+          else
+            Cancelable.empty
+        case ref @ (head :: tail) =>
+          if (!state.compareAndSet(ref, list ::: tail))
+            popAndPushList(list)
+          else
+            head
+      }
+    }
+
+    @tailrec def popAndPush(value: Cancelable): Cancelable = {
+      state.get match {
+        case null =>
+          value.cancel()
+          Cancelable.empty
+        case Nil =>
+          if (!state.compareAndSet(Nil, value :: Nil))
+            popAndPush(value)
+          else
+            Cancelable.empty
+        case ref @ (head :: tail) =>
+          if (!state.compareAndSet(ref, value :: tail))
+            popAndPush(value) // retry
+          else
+            head
+      }
+    }
+
+    @tailrec def pushList(list: List[Cancelable]): Unit = {
+      state.get match {
+        case null =>
+          list.foreach(_.cancel())
+        case stack =>
+          if (!state.compareAndSet(stack, list ::: stack))
+            pushList(list) // retry
+      }
+    }
+
+    @tailrec def push(value: Cancelable): Unit = {
+      state.get match {
+        case null =>
+          value.cancel()
+        case stack =>
+          if (!state.compareAndSet(stack, value :: stack))
+            push(value) // retry
+      }
+    }
+
+    @tailrec def pop(): Cancelable = {
+      state.get match {
+        case null => Cancelable.empty
+        case Nil => Cancelable.empty
+        case ref @ (head :: tail) =>
+          if (!state.compareAndSet(ref, tail))
+            pop()
+          else
+            head
+      }
+    }
+  }
+
+  /** [[StackedCancelable]] implementation that is already cancelled. */
+  private final class AlreadyCanceled extends StackedCancelable {
+    override def cancel(): Unit = ()
+    override def isCanceled: Boolean = true
+    override def pop(): Cancelable = Cancelable.empty
+
+    override def push(value: Cancelable): Unit =
+      value.cancel()
+
+    override def popAndPushList(list: List[Cancelable]): Cancelable = {
+      Cancelable.cancelAll(list)
+      Cancelable.empty
+    }
+
+    override def popAndPush(value: Cancelable): Cancelable = {
+      value.cancel()
+      Cancelable.empty
+    }
+
+    override def pushList(list: List[Cancelable]): Unit =
+      Cancelable.cancelAll(list)
+  }
 }

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/package.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/package.scala
@@ -35,4 +35,20 @@ package monix.execution
   *   task.cancel()
   * }}}
   */
-package object cancelables
+package object cancelables {
+  /** DEPRECATED — renamed to [[OrderedCancelable]]. */
+  @deprecated("Renamed to OrderedCancelable", "3.0.0")
+  type MultiAssignmentCancelable = OrderedCancelable
+
+  /** DEPRECATED — renamed to [[OrderedCancelable]]. */
+  @deprecated("Renamed to OrderedCancelable", "3.0.0")
+  val MultiAssignmentCancelable = OrderedCancelable
+
+  /** DEPRECATED — renamed to [[SingleAssignCancelable]]. */
+  @deprecated("Renamed to SingleAssignCancelable", "3.0.0")
+  type SingleAssignmentCancelable = SingleAssignCancelable
+
+  /** DEPRECATED — renamed to [[SingleAssignCancelable]]. */
+  @deprecated("Renamed to SingleAssignCancelable", "3.0.0")
+  val SingleAssignmentCancelable = SingleAssignCancelable
+}

--- a/monix-execution/shared/src/main/scala/monix/execution/rstreams/SingleAssignSubscription.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/rstreams/SingleAssignSubscription.scala
@@ -30,11 +30,11 @@ import scala.annotation.tailrec
   *
   * Useful in case you need a thread-safe forward reference.
   */
-final class SingleAssignmentSubscription private ()
+final class SingleAssignSubscription private ()
   extends Subscription {
 
-  import SingleAssignmentSubscription.State
-  import SingleAssignmentSubscription.State._
+  import SingleAssignSubscription.State
+  import SingleAssignSubscription.State._
 
   private[this] val state = AtomicAny(Empty : State)
 
@@ -114,18 +114,32 @@ final class SingleAssignmentSubscription private ()
   }
 }
 
-object SingleAssignmentSubscription {
-  /** Builder for [[SingleAssignmentSubscription]] */
-  def apply(): SingleAssignmentSubscription =
-    new SingleAssignmentSubscription
+object SingleAssignSubscription {
+  /** Builder for [[SingleAssignSubscription]] */
+  def apply(): SingleAssignSubscription =
+    new SingleAssignSubscription
 
-  private sealed trait State
+  /** Internal state kept in an atomic reference. */
+  private sealed abstract class State
 
   private object State {
+    /** Subscription hasn't been initialized. */
     case object Empty extends State
+
+    /** Subscription hasn't been initialized, but at least
+      * a request was received from subscriber.
+      */
     case class EmptyRequest(nr: Long) extends State
+
+    /** Subscription hasn't been initialized, but the
+      * subscriber has already cancelled.
+      */
     case object EmptyCanceled extends State
+
+    /** Has an active subscription. */
     case class WithSubscription(s: org.reactivestreams.Subscription) extends State
+
+    /** Subscription was cancelled. */
     case object Canceled extends State
   }
 }

--- a/monix-execution/shared/src/main/scala/monix/execution/rstreams/package.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/rstreams/package.scala
@@ -15,25 +15,18 @@
  * limitations under the License.
  */
 
-package monix.reactive.internal.operators
+package monix.execution
 
-import monix.execution.cancelables.SingleAssignCancelable
-import monix.execution.{Cancelable, Scheduler}
-import monix.reactive.Observable
-import monix.reactive.observers.Subscriber
+/** Package exposing utilities for working with the
+  * [[http://www.reactive-streams.org/ Reactive Streams]]
+  * specification.
+  */
+package object rstreams {
+  /** DEPRECATED — renamed to [[SingleAssignSubscription]]. */
+  @deprecated("Renamed to SingleAssignSubscription", "3.0.0")
+  type SingleAssignmentSubscription = SingleAssignSubscription
 
-private[reactive] final
-class SubscribeOnObservable[+A](source: Observable[A], s: Scheduler)
-  extends Observable[A] {
-
-  def unsafeSubscribeFn(out: Subscriber[A]): Cancelable = {
-    val subscription = SingleAssignCancelable()
-
-    s.execute(new Runnable {
-      def run(): Unit =
-        subscription := source.unsafeSubscribeFn(out)
-    })
-
-    subscription
-  }
+  /** DEPRECATED — renamed to [[SingleAssignSubscription]]. */
+  @deprecated("Renamed to SingleAssignSubscription", "3.0.0")
+  val SingleAssignmentSubscription = SingleAssignSubscription
 }

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/ReferenceScheduler.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/ReferenceScheduler.scala
@@ -18,7 +18,7 @@
 package monix.execution.schedulers
 
 import java.util.concurrent.TimeUnit
-import monix.execution.cancelables.MultiAssignmentCancelable
+import monix.execution.cancelables.OrderedCancelable
 import monix.execution.schedulers.ReferenceScheduler.WrappedScheduler
 import monix.execution.{Cancelable, Scheduler}
 // Prevents conflict with the deprecated symbol
@@ -36,7 +36,7 @@ trait ReferenceScheduler extends Scheduler {
     System.currentTimeMillis()
 
   override def scheduleWithFixedDelay(initialDelay: Long, delay: Long, unit: TimeUnit, r: Runnable): Cancelable = {
-    val sub = MultiAssignmentCancelable()
+    val sub = OrderedCancelable()
 
     def loop(initialDelay: Long, delay: Long): Unit = {
       if (!sub.isCanceled)
@@ -53,7 +53,7 @@ trait ReferenceScheduler extends Scheduler {
   }
 
   override def scheduleAtFixedRate(initialDelay: Long, period: Long, unit: TimeUnit, r: Runnable): Cancelable = {
-    val sub = MultiAssignmentCancelable()
+    val sub = OrderedCancelable()
 
     def loop(initialDelayMs: Long, periodMs: Long): Unit =
       if (!sub.isCanceled) {

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/TestScheduler.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/TestScheduler.scala
@@ -19,7 +19,7 @@ package monix.execution.schedulers
 
 import monix.execution.Cancelable
 import monix.execution.atomic.AtomicAny
-import monix.execution.cancelables.SingleAssignmentCancelable
+import monix.execution.cancelables.SingleAssignCancelable
 import monix.execution.misc.NonFatal
 import monix.execution.schedulers.TestScheduler._
 // Prevents conflict with the deprecated symbol
@@ -209,7 +209,7 @@ object TestScheduler {
       require(delay >= Duration.Zero, "The given delay must be positive")
 
       val newID = lastID + 1
-      SingleAssignmentCancelable()
+      SingleAssignCancelable()
 
       val task = Task(newID, r, this.clock + delay)
       val cancelable = new Cancelable {

--- a/monix-execution/shared/src/test/scala/monix/execution/cancelables/AssignableCancelableSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/cancelables/AssignableCancelableSuite.scala
@@ -22,13 +22,13 @@ import minitest.SimpleTestSuite
 object AssignableCancelableSuite extends SimpleTestSuite {
   test("AssignableCancelable.multi() returns a MultiAssignmentCancelable") {
     val c = AssignableCancelable.multi()
-    assert(c.isInstanceOf[MultiAssignmentCancelable],
-      "isInstanceOf[MultiAssignmentCancelable]")
+    assert(c.isInstanceOf[MultiAssignCancelable],
+      "isInstanceOf[MultiAssignCancelable]")
   }
 
   test("AssignableCancelable.single() returns a SingleAssignmentCancelable") {
     val c = AssignableCancelable.single()
-    assert(c.isInstanceOf[SingleAssignmentCancelable],
+    assert(c.isInstanceOf[SingleAssignCancelable],
       "isInstanceOf[SingleAssignmentCancelable]")
   }
 

--- a/monix-execution/shared/src/test/scala/monix/execution/cancelables/MultiAssignCancelableSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/cancelables/MultiAssignCancelableSuite.scala
@@ -18,13 +18,12 @@
 package monix.execution.cancelables
 
 import minitest.SimpleTestSuite
-import monix.execution.Cancelable
 
-object MultiAssignmentCancelableSuite extends SimpleTestSuite {
+object MultiAssignCancelableSuite extends SimpleTestSuite {
   test("cancel()") {
     var effect = 0
     val sub = BooleanCancelable(() => effect += 1)
-    val mSub = MultiAssignmentCancelable(sub)
+    val mSub = MultiAssignCancelable(sub)
 
     assert(effect == 0)
     assert(!sub.isCanceled)
@@ -42,7 +41,7 @@ object MultiAssignmentCancelableSuite extends SimpleTestSuite {
   test("cancel() after second assignment") {
     var effect = 0
     val sub = BooleanCancelable(() => effect += 1)
-    val mSub = MultiAssignmentCancelable(sub)
+    val mSub = MultiAssignCancelable(sub)
     val sub2 = BooleanCancelable(() => effect += 10)
     mSub := sub2
 
@@ -55,7 +54,7 @@ object MultiAssignmentCancelableSuite extends SimpleTestSuite {
   }
 
   test("automatically cancel assigned") {
-    val mSub = MultiAssignmentCancelable()
+    val mSub = MultiAssignCancelable()
     mSub.cancel()
 
     var effect = 0
@@ -69,35 +68,18 @@ object MultiAssignmentCancelableSuite extends SimpleTestSuite {
     assert(sub.isCanceled)
   }
 
-  test("should do orderedUpdate") {
-    val mc = MultiAssignmentCancelable()
-    var effect = 0
+  test("clear()") {
+    val mSub = MultiAssignCancelable()
+    val sub = BooleanCancelable()
 
-    val c1 = Cancelable { () => effect = 1 }
-    mc.orderedUpdate(c1, 1)
-    val c2 = Cancelable { () => effect = 2 }
-    mc.orderedUpdate(c2, 2)
-    val c3 = Cancelable { () => effect = 3 }
-    mc.orderedUpdate(c3, 1)
+    mSub := sub
+    mSub.clear()
 
-    mc.cancel()
-    assertEquals(effect, 2)
-  }
+    mSub.cancel()
+    assert(!sub.isCanceled, "!sub.isCanceled")
 
-  test("orderedUpdate should work on overflow") {
-    val mc = MultiAssignmentCancelable()
-    var effect = 0
-
-    val c1 = Cancelable { () => effect = 1 }
-    mc.orderedUpdate(c1, Long.MaxValue)
-    val c2 = Cancelable { () => effect = 2 }
-    mc.orderedUpdate(c2, Long.MaxValue+1)
-    val c3 = Cancelable { () => effect = 3 }
-    mc.orderedUpdate(c3, Long.MaxValue+2)
-    val c4 = Cancelable { () => effect = 4 }
-    mc.orderedUpdate(c4, Long.MaxValue)
-
-    mc.cancel()
-    assertEquals(effect, 3)
+    mSub.clear()
+    mSub := sub
+    assert(sub.isCanceled, "sub.isCanceled")
   }
 }

--- a/monix-execution/shared/src/test/scala/monix/execution/cancelables/OrderedCancelableSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/cancelables/OrderedCancelableSuite.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.execution.cancelables
+
+import minitest.SimpleTestSuite
+import monix.execution.Cancelable
+
+object OrderedCancelableSuite extends SimpleTestSuite {
+  test("cancel()") {
+    var effect = 0
+    val sub = BooleanCancelable(() => effect += 1)
+    val mSub = OrderedCancelable(sub)
+
+    assert(effect == 0)
+    assert(!sub.isCanceled)
+    assert(!mSub.isCanceled)
+
+    mSub.cancel()
+    assert(sub.isCanceled && mSub.isCanceled)
+    assert(effect == 1)
+
+    mSub.cancel()
+    assert(sub.isCanceled && mSub.isCanceled)
+    assert(effect == 1)
+  }
+
+  test("cancel() after second assignment") {
+    var effect = 0
+    val sub = BooleanCancelable(() => effect += 1)
+    val mSub = OrderedCancelable(sub)
+    val sub2 = BooleanCancelable(() => effect += 10)
+    mSub := sub2
+
+    assert(effect == 0)
+    assert(!sub.isCanceled && !sub2.isCanceled && !mSub.isCanceled)
+
+    mSub.cancel()
+    assert(sub2.isCanceled && mSub.isCanceled && !sub.isCanceled)
+    assert(effect == 10)
+  }
+
+  test("automatically cancel assigned") {
+    val mSub = OrderedCancelable()
+    mSub.cancel()
+
+    var effect = 0
+    val sub = BooleanCancelable(() => effect += 1)
+
+    assert(effect == 0)
+    assert(!sub.isCanceled && mSub.isCanceled)
+
+    mSub := sub
+    assert(effect == 1)
+    assert(sub.isCanceled)
+  }
+
+  test("should do orderedUpdate") {
+    val mc = OrderedCancelable()
+    var effect = 0
+
+    val c1 = Cancelable { () => effect = 1 }
+    mc.orderedUpdate(c1, 1)
+    val c2 = Cancelable { () => effect = 2 }
+    mc.orderedUpdate(c2, 2)
+    val c3 = Cancelable { () => effect = 3 }
+    mc.orderedUpdate(c3, 1)
+
+    mc.cancel()
+    assertEquals(effect, 2)
+  }
+
+  test("orderedUpdate should work on overflow") {
+    val mc = OrderedCancelable()
+    var effect = 0
+
+    val c1 = Cancelable { () => effect = 1 }
+    mc.orderedUpdate(c1, Long.MaxValue)
+    val c2 = Cancelable { () => effect = 2 }
+    mc.orderedUpdate(c2, Long.MaxValue+1)
+    val c3 = Cancelable { () => effect = 3 }
+    mc.orderedUpdate(c3, Long.MaxValue+2)
+    val c4 = Cancelable { () => effect = 4 }
+    mc.orderedUpdate(c4, Long.MaxValue)
+
+    mc.cancel()
+    assertEquals(effect, 3)
+  }
+}

--- a/monix-execution/shared/src/test/scala/monix/execution/cancelables/SingleAssignCancelableSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/cancelables/SingleAssignCancelableSuite.scala
@@ -20,10 +20,10 @@ package monix.execution.cancelables
 import minitest.SimpleTestSuite
 import monix.execution.Cancelable
 
-object SingleAssignmentCancelableSuite extends SimpleTestSuite {
+object SingleAssignCancelableSuite extends SimpleTestSuite {
   test("cancel()") {
     var effect = 0
-    val s = SingleAssignmentCancelable()
+    val s = SingleAssignCancelable()
     val b = BooleanCancelable { () => effect += 1 }
     s := b
 
@@ -41,7 +41,7 @@ object SingleAssignmentCancelableSuite extends SimpleTestSuite {
     val extra = BooleanCancelable { () => effect += 1 }
     val b = BooleanCancelable { () => effect += 2 }
 
-    val s = SingleAssignmentCancelable.plusOne(extra)
+    val s = SingleAssignCancelable.plusOne(extra)
     s := b
 
     s.cancel()
@@ -55,7 +55,7 @@ object SingleAssignmentCancelableSuite extends SimpleTestSuite {
   }
 
   test("cancel on single assignment") {
-    val s = SingleAssignmentCancelable()
+    val s = SingleAssignCancelable()
     s.cancel()
     assert(s.isCanceled)
 
@@ -73,7 +73,7 @@ object SingleAssignmentCancelableSuite extends SimpleTestSuite {
   test("cancel on single assignment (plus one)") {
     var effect = 0
     val extra = BooleanCancelable { () => effect += 1 }
-    val s = SingleAssignmentCancelable.plusOne(extra)
+    val s = SingleAssignCancelable.plusOne(extra)
 
     s.cancel()
     assert(s.isCanceled, "s.isCanceled")
@@ -91,7 +91,7 @@ object SingleAssignmentCancelableSuite extends SimpleTestSuite {
   }
 
   test("throw exception on multi assignment") {
-    val s = SingleAssignmentCancelable()
+    val s = SingleAssignCancelable()
     val b1 = Cancelable()
     s := b1
 
@@ -102,7 +102,7 @@ object SingleAssignmentCancelableSuite extends SimpleTestSuite {
   }
 
   test("throw exception on multi assignment when canceled") {
-    val s = SingleAssignmentCancelable()
+    val s = SingleAssignCancelable()
     s.cancel()
 
     val b1 = Cancelable()

--- a/monix-execution/shared/src/test/scala/monix/execution/cancelables/StackedCancelableSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/cancelables/StackedCancelableSuite.scala
@@ -164,4 +164,58 @@ object StackedCancelableSuite extends SimpleTestSuite {
     assert(sc.isCanceled, "sc.isCanceled")
     assert(c.isCanceled, "c.isCanceled")
   }
+
+  test("alreadyCanceled returns same reference") {
+    val ref1 = StackedCancelable.alreadyCanceled
+    val ref2 = StackedCancelable.alreadyCanceled
+    assertEquals(ref1, ref2)
+  }
+
+  test("alreadyCanceled reference is already cancelled") {
+    val ref = StackedCancelable.alreadyCanceled
+    assert(ref.isCanceled, "ref.isCanceled")
+    ref.cancel()
+    assert(ref.isCanceled, "ref.isCanceled")
+  }
+
+  test("alreadyCanceled.pop") {
+    val ref = StackedCancelable.alreadyCanceled
+    assertEquals(ref.pop(), Cancelable.empty)
+  }
+
+  test("alreadyCanceled.push cancels the given cancelable") {
+    val ref = StackedCancelable.alreadyCanceled
+    val c = BooleanCancelable()
+    ref.push(c)
+
+    assert(c.isCanceled, "c.isCanceled")
+  }
+
+  test("alreadyCanceled.popAndPush cancels the given cancelable") {
+    val ref = StackedCancelable.alreadyCanceled
+    val c = BooleanCancelable()
+
+    assertEquals(ref.popAndPush(c), Cancelable.empty)
+    assert(c.isCanceled, "c.isCanceled")
+  }
+
+  test("alreadyCanceled.pushList cancels the given list") {
+    val ref = StackedCancelable.alreadyCanceled
+    val c1 = BooleanCancelable()
+    val c2 = BooleanCancelable()
+    ref.pushList(List(c1, c2))
+
+    assert(c1.isCanceled, "c1.isCanceled")
+    assert(c2.isCanceled, "c2.isCanceled")
+  }
+
+  test("alreadyCanceled.popAndPushList cancels the given list") {
+    val ref = StackedCancelable.alreadyCanceled
+    val c1 = BooleanCancelable()
+    val c2 = BooleanCancelable()
+
+    assertEquals(ref.popAndPushList(List(c1, c2)), Cancelable.empty)
+    assert(c1.isCanceled, "c1.isCanceled")
+    assert(c2.isCanceled, "c2.isCanceled")
+  }
 }

--- a/monix-execution/shared/src/test/scala/monix/execution/rstreams/SingleAssignSubscriptionSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/rstreams/SingleAssignSubscriptionSuite.scala
@@ -19,9 +19,9 @@ package monix.execution.rstreams
 
 import minitest.SimpleTestSuite
 
-object SingleAssignmentSubscriptionSuite extends SimpleTestSuite {
+object SingleAssignSubscriptionSuite extends SimpleTestSuite {
   test("should call cancel on assignment") {
-    val ref = SingleAssignmentSubscription()
+    val ref = SingleAssignSubscription()
     ref.cancel()
 
     var wasCanceled = false
@@ -34,7 +34,7 @@ object SingleAssignmentSubscriptionSuite extends SimpleTestSuite {
   }
 
   test("should call request on assignment") {
-    val ref = SingleAssignmentSubscription()
+    val ref = SingleAssignSubscription()
     ref.request(100)
     ref.request(200)
 
@@ -48,7 +48,7 @@ object SingleAssignmentSubscriptionSuite extends SimpleTestSuite {
   }
 
   test("cancel should have priority on assignment") {
-    val ref = SingleAssignmentSubscription()
+    val ref = SingleAssignSubscription()
     ref.request(100)
     ref.cancel()
     ref.request(200)
@@ -66,7 +66,7 @@ object SingleAssignmentSubscriptionSuite extends SimpleTestSuite {
   }
 
   test("request and cancel after assignment should work") {
-    val ref = SingleAssignmentSubscription()
+    val ref = SingleAssignSubscription()
     var wasCanceled = false
     var wasRequested = 0L
 

--- a/monix-execution/shared/src/test/scala/monix/execution/schedulers/TracingSchedulerSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/schedulers/TracingSchedulerSuite.scala
@@ -24,7 +24,7 @@ import monix.execution.ExecutionModel.AlwaysAsyncExecution
 import monix.execution.misc.Local
 import monix.execution.FutureUtils.extensions._
 import monix.execution.{Cancelable, Scheduler}
-import monix.execution.cancelables.SingleAssignmentCancelable
+import monix.execution.cancelables.SingleAssignCancelable
 import monix.execution.exceptions.DummyException
 
 import scala.concurrent.{Future, Promise}
@@ -107,7 +107,7 @@ object TracingSchedulerSuite extends SimpleTestSuite {
       var sum = 0
       var count = 0
       val p = Promise[Int]()
-      val sub = SingleAssignmentCancelable()
+      val sub = SingleAssignCancelable()
 
       sub := schedule(traced, 1, 1, TimeUnit.SECONDS, new Runnable {
         def run(): Unit = {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -25,7 +25,7 @@ import monix.eval.Coeval.Eager
 import monix.eval.{Callback, Coeval, Task}
 import monix.execution.Ack.{Continue, Stop}
 import monix.execution._
-import monix.execution.cancelables.{BooleanCancelable, SingleAssignmentCancelable}
+import monix.execution.cancelables.{BooleanCancelable, SingleAssignCancelable}
 import monix.execution.exceptions.UpstreamTimeoutException
 import monix.execution.misc.NonFatal
 import monix.reactive.Observable.Operator
@@ -2623,7 +2623,7 @@ abstract class Observable[+A] extends Serializable { self =>
   final def toReactivePublisher[B >: A](implicit s: Scheduler): RPublisher[B] =
     new RPublisher[B] {
       def subscribe(subscriber: RSubscriber[_ >: B]): Unit = {
-        val subscription = SingleAssignmentCancelable()
+        val subscription = SingleAssignCancelable()
         subscription := unsafeSubscribeFn(SafeSubscriber(
           Subscriber.fromReactiveSubscriber(subscriber, subscription)
         ))

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ConsObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ConsObservable.scala
@@ -18,7 +18,7 @@
 package monix.reactive.internal.builders
 
 import monix.execution.Cancelable
-import monix.execution.cancelables.{MultiAssignmentCancelable, SingleAssignmentCancelable}
+import monix.execution.cancelables.{MultiAssignCancelable, SingleAssignCancelable}
 import monix.reactive.Observable
 import monix.reactive.observables.ChainedObservable
 import monix.reactive.observables.ChainedObservable.{subscribe => chain}
@@ -27,12 +27,12 @@ import monix.reactive.observers.Subscriber
 private[reactive] final class ConsObservable[+A](head: A, tail: Observable[A])
   extends ChainedObservable[A] {
 
-  def unsafeSubscribeFn(conn: MultiAssignmentCancelable, out: Subscriber[A]): Unit = {
+  def unsafeSubscribeFn(conn: MultiAssignCancelable, out: Subscriber[A]): Unit = {
     import out.{scheduler => s}
     out.onNext(head).syncOnContinue(chain(tail, conn, out))(s)
   }
 
-  private def simpleSubscribe(conn: SingleAssignmentCancelable, out: Subscriber[A]): Unit = {
+  private def simpleSubscribe(conn: SingleAssignCancelable, out: Subscriber[A]): Unit = {
     import out.{scheduler => s}
     out.onNext(head).syncOnContinue {
       conn := tail.unsafeSubscribeFn(out)
@@ -41,11 +41,11 @@ private[reactive] final class ConsObservable[+A](head: A, tail: Observable[A])
 
   override def unsafeSubscribeFn(out: Subscriber[A]): Cancelable = {
     if (!tail.isInstanceOf[ChainedObservable[_]]) {
-      val conn = SingleAssignmentCancelable()
+      val conn = SingleAssignCancelable()
       simpleSubscribe(conn, out)
       conn
     } else {
-      val conn = MultiAssignmentCancelable()
+      val conn = MultiAssignCancelable()
       unsafeSubscribeFn(conn, out)
       conn
     }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/DeferObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/DeferObservable.scala
@@ -18,7 +18,7 @@
 package monix.reactive.internal.builders
 
 import monix.execution.Cancelable
-import monix.execution.cancelables.MultiAssignmentCancelable
+import monix.execution.cancelables.MultiAssignCancelable
 import monix.execution.misc.NonFatal
 import monix.reactive.Observable
 import monix.reactive.observables.ChainedObservable
@@ -32,7 +32,7 @@ private[reactive] final class DeferObservable[+A](factory: () => Observable[A])
     val fa = try factory() catch { case e if NonFatal(e) => Observable.raiseError(e) }
     if (fa.isInstanceOf[ChainedObservable[_]]) {
       val ch = fa.asInstanceOf[ChainedObservable[A]]
-      val conn = MultiAssignmentCancelable()
+      val conn = MultiAssignCancelable()
       ch.unsafeSubscribeFn(conn, out)
       conn
     } else {
@@ -40,7 +40,7 @@ private[reactive] final class DeferObservable[+A](factory: () => Observable[A])
     }
   }
 
-  override def unsafeSubscribeFn(conn: MultiAssignmentCancelable, out: Subscriber[A]): Unit = {
+  override def unsafeSubscribeFn(conn: MultiAssignCancelable, out: Subscriber[A]): Unit = {
     val fa = try factory() catch { case e if NonFatal(e) => Observable.raiseError(e) }
     chain(fa, conn, out)
   }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/IntervalFixedDelayObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/IntervalFixedDelayObservable.scala
@@ -17,7 +17,7 @@
 
 package monix.reactive.internal.builders
 
-import monix.execution.cancelables.MultiAssignmentCancelable
+import monix.execution.cancelables.MultiAssignCancelable
 import monix.execution.{Cancelable, Ack}
 import monix.execution.Ack.{Stop, Continue}
 import monix.reactive.Observable
@@ -34,7 +34,7 @@ private[reactive] final class IntervalFixedDelayObservable
     import subscriber.{scheduler => s}
 
     val o = subscriber
-    val task = MultiAssignmentCancelable()
+    val task = MultiAssignCancelable()
 
     val runnable = new Runnable { self =>
       private[this] var counter = 0L

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/IntervalFixedRateObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/IntervalFixedRateObservable.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit
 
 import monix.execution.{Cancelable, Ack}
 import monix.execution.Ack.{Stop, Continue}
-import monix.execution.cancelables.MultiAssignmentCancelable
+import monix.execution.cancelables.MultiAssignCancelable
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 
@@ -36,7 +36,7 @@ private[reactive] final class IntervalFixedRateObservable
   override def unsafeSubscribeFn(subscriber: Subscriber[Long]): Cancelable = {
     import subscriber.{scheduler => s}
     val o = subscriber
-    val task = MultiAssignmentCancelable()
+    val task = MultiAssignCancelable()
 
     val runnable = new Runnable { self =>
       private[this] val periodMillis = period.toMillis

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/PipeThroughSelectorObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/PipeThroughSelectorObservable.scala
@@ -18,7 +18,7 @@
 package monix.reactive.internal.builders
 
 import monix.execution.{Ack, Cancelable}
-import monix.execution.cancelables.SingleAssignmentCancelable
+import monix.execution.cancelables.SingleAssignCancelable
 import monix.execution.misc.NonFatal
 import monix.reactive.observers.Subscriber
 import monix.reactive.{Observable, Pipe}
@@ -32,7 +32,7 @@ private[reactive] final class PipeThroughSelectorObservable[A,B,C]
   def unsafeSubscribeFn(out: Subscriber[C]): Cancelable = {
     import out.scheduler
     var streamErrors = true
-    val upstream = SingleAssignmentCancelable()
+    val upstream = SingleAssignCancelable()
 
     try {
       val connectable = source.multicast(pipe)

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ReactiveObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ReactiveObservable.scala
@@ -18,7 +18,7 @@
 package monix.reactive.internal.builders
 
 import monix.execution.Cancelable
-import monix.execution.rstreams.SingleAssignmentSubscription
+import monix.execution.rstreams.SingleAssignSubscription
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 import org.reactivestreams
@@ -30,7 +30,7 @@ final class ReactiveObservable[A](publisher: RPublisher[A], requestCount: Int)
   extends Observable[A] {
 
   def unsafeSubscribeFn(subscriber: Subscriber[A]): Cancelable = {
-    val subscription = SingleAssignmentSubscription()
+    val subscription = SingleAssignSubscription()
     val sub =
       if (requestCount > 0) subscriber.toReactive(requestCount)
       else subscriber.toReactive

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RepeatedValueObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RepeatedValueObservable.scala
@@ -18,7 +18,7 @@
 package monix.reactive.internal.builders
 
 import java.util.concurrent.TimeUnit
-import monix.execution.cancelables.MultiAssignmentCancelable
+import monix.execution.cancelables.MultiAssignCancelable
 import monix.execution.{Cancelable, Ack}
 import monix.execution.Ack.{Stop, Continue}
 import monix.reactive.Observable
@@ -31,7 +31,7 @@ class RepeatedValueObservable[A](initialDelay: FiniteDuration, period: FiniteDur
   extends Observable[A] {
 
   def unsafeSubscribeFn(subscriber: Subscriber[A]): Cancelable = {
-    val task = MultiAssignmentCancelable()
+    val task = MultiAssignCancelable()
     val r = runnable(subscriber, task)
 
     if (initialDelay.length <= 0)
@@ -44,7 +44,7 @@ class RepeatedValueObservable[A](initialDelay: FiniteDuration, period: FiniteDur
     task
   }
 
-  private[this] def runnable(subscriber: Subscriber[A], task: MultiAssignmentCancelable): Runnable =
+  private[this] def runnable(subscriber: Subscriber[A], task: MultiAssignCancelable): Runnable =
     new Runnable { self =>
       private[this] implicit val s = subscriber.scheduler
       private[this] val periodMs = period.toMillis

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/TailRecMObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/TailRecMObservable.scala
@@ -19,7 +19,7 @@ package monix.reactive.internal.builders
 
 import monix.execution.Ack.{Continue, Stop}
 import monix.execution.atomic.AtomicBoolean
-import monix.execution.cancelables.{SingleAssignmentCancelable, StackedCancelable}
+import monix.execution.cancelables.{SingleAssignCancelable, StackedCancelable}
 import monix.execution.misc.NonFatal
 import monix.execution.schedulers.TrampolineExecutionContext.immediate
 import monix.execution.{Ack, Cancelable}
@@ -149,7 +149,7 @@ private[monix] final class TailRecMObservable[A,B](seed: A, f: A => Observable[E
         }
       }
 
-      val c = SingleAssignmentCancelable()
+      val c = SingleAssignCancelable()
       conn.push(c)
       c := next.unsafeSubscribeFn(loopSubscriber)
     } catch {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/CreateConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/CreateConsumer.scala
@@ -19,7 +19,7 @@ package monix.reactive.internal.consumers
 
 import monix.eval.Callback
 import monix.execution.{Cancelable, Scheduler}
-import monix.execution.cancelables.{AssignableCancelable, SingleAssignmentCancelable}
+import monix.execution.cancelables.{AssignableCancelable, SingleAssignCancelable}
 import monix.reactive.{Consumer, Observer}
 import monix.reactive.observers.Subscriber
 import scala.util.{Failure, Success, Try}
@@ -31,7 +31,7 @@ final class CreateConsumer[-In,+Out]
   extends Consumer[In,Out] {
 
   def createSubscriber(cb: Callback[Out], s: Scheduler): (Subscriber[In], AssignableCancelable) = {
-    val conn = SingleAssignmentCancelable()
+    val conn = SingleAssignCancelable()
 
     Try(f(s, conn, cb)) match {
       case Failure(ex) =>

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/LoadBalanceConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/LoadBalanceConsumer.scala
@@ -21,7 +21,7 @@ import monix.eval.Callback
 import monix.execution.Ack.{Continue, Stop}
 import monix.execution.{Ack, Cancelable, Scheduler}
 import monix.execution.atomic.{Atomic, PaddingStrategy}
-import monix.execution.cancelables.{AssignableCancelable, SingleAssignmentCancelable}
+import monix.execution.cancelables.{AssignableCancelable, SingleAssignCancelable}
 import monix.execution.misc.NonFatal
 import monix.reactive.Consumer
 import monix.reactive.internal.consumers.LoadBalanceConsumer.IndexedSubscriber
@@ -48,7 +48,7 @@ final class LoadBalanceConsumer[-In, R]
   def createSubscriber(onFinish: Callback[List[R]], s: Scheduler): (Subscriber[In], AssignableCancelable) = {
     // Assignable cancelable returned, can be used to cancel everything
     // since it will be assigned the stream subscription
-    val mainCancelable = SingleAssignmentCancelable()
+    val mainCancelable = SingleAssignCancelable()
 
     val balanced = new Subscriber[In] { self =>
       implicit val scheduler = s

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferTimedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferTimedObservable.scala
@@ -19,7 +19,7 @@ package monix.reactive.internal.operators
 
 import java.util.concurrent.TimeUnit
 import monix.execution.Ack.{Continue, Stop}
-import monix.execution.cancelables.{CompositeCancelable, MultiAssignmentCancelable}
+import monix.execution.cancelables.{CompositeCancelable, MultiAssignCancelable}
 import monix.execution.{Ack, Cancelable}
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
@@ -37,7 +37,7 @@ private[reactive] final class BufferTimedObservable[+A](
   require(maxCount >= 0, "maxCount must be positive")
 
   def unsafeSubscribeFn(out: Subscriber[Seq[A]]): Cancelable = {
-    val periodicTask = MultiAssignmentCancelable()
+    val periodicTask = MultiAssignCancelable()
 
     val connection = source.unsafeSubscribeFn(
       new Subscriber[A] with Runnable { self =>

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferWithSelectorObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferWithSelectorObservable.scala
@@ -18,7 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.{Continue, Stop}
-import monix.execution.cancelables.{CompositeCancelable, SingleAssignmentCancelable}
+import monix.execution.cancelables.{CompositeCancelable, SingleAssignCancelable}
 import monix.execution.{Ack, Cancelable}
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
@@ -32,8 +32,8 @@ private[reactive] final class BufferWithSelectorObservable[+A,S](
   extends Observable[Seq[A]] {
 
   def unsafeSubscribeFn(downstream: Subscriber[Seq[A]]): Cancelable = {
-    val upstreamSubscription = SingleAssignmentCancelable()
-    val samplerSubscription = SingleAssignmentCancelable()
+    val upstreamSubscription = SingleAssignCancelable()
+    val samplerSubscription = SingleAssignCancelable()
     val composite = CompositeCancelable(upstreamSubscription, samplerSubscription)
 
     upstreamSubscription := source.unsafeSubscribeFn(

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ConcatObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ConcatObservable.scala
@@ -19,7 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack
 import monix.execution.Ack.Continue
-import monix.execution.cancelables.MultiAssignmentCancelable
+import monix.execution.cancelables.MultiAssignCancelable
 import monix.reactive.Observable
 import monix.reactive.observables.ChainedObservable
 import monix.reactive.observables.ChainedObservable.{subscribe => chain}
@@ -30,7 +30,7 @@ import scala.concurrent.Future
 private[reactive] final class ConcatObservable[A](lh: Observable[A], rh: Observable[A])
   extends ChainedObservable[A] {
 
-  def unsafeSubscribeFn(conn: MultiAssignmentCancelable, out: Subscriber[A]): Unit = {
+  def unsafeSubscribeFn(conn: MultiAssignCancelable, out: Subscriber[A]): Unit = {
     chain(lh, conn, new Subscriber[A] {
       private[this] var ack: Future[Ack] = Continue
       implicit val scheduler = out.scheduler

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DebounceObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DebounceObservable.scala
@@ -19,7 +19,7 @@ package monix.reactive.internal.operators
 
 import java.util.concurrent.TimeUnit
 import monix.execution.Ack.{Continue, Stop}
-import monix.execution.cancelables.{CompositeCancelable, MultiAssignmentCancelable, SingleAssignmentCancelable}
+import monix.execution.cancelables.{CompositeCancelable, MultiAssignCancelable, SingleAssignCancelable}
 import monix.execution.{Ack, Cancelable}
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
@@ -30,8 +30,8 @@ class DebounceObservable[A](source: Observable[A], timeout: FiniteDuration, repe
   extends Observable[A] {
 
   def unsafeSubscribeFn(out: Subscriber[A]): Cancelable = {
-    val task = MultiAssignmentCancelable()
-    val mainTask = SingleAssignmentCancelable()
+    val task = MultiAssignCancelable()
+    val mainTask = SingleAssignCancelable()
     val composite = CompositeCancelable(mainTask, task)
 
     mainTask := source.unsafeSubscribeFn(new Subscriber.Sync[A] with Runnable { self =>

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayBySelectorObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayBySelectorObservable.scala
@@ -18,7 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.{Continue, Stop}
-import monix.execution.cancelables.{CompositeCancelable, MultiAssignmentCancelable}
+import monix.execution.cancelables.{CompositeCancelable, MultiAssignCancelable}
 import monix.execution.misc.NonFatal
 import monix.execution.{Ack, Cancelable}
 import monix.reactive.Observable
@@ -31,7 +31,7 @@ class DelayBySelectorObservable[A,S](source: Observable[A], selector: A => Obser
   extends Observable[A] {
 
   def unsafeSubscribeFn(out: Subscriber[A]): Cancelable = {
-    val task = MultiAssignmentCancelable()
+    val task = MultiAssignCancelable()
     val composite = CompositeCancelable(task)
 
     composite += source.unsafeSubscribeFn(new Subscriber[A] { self =>

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayByTimespanObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayByTimespanObservable.scala
@@ -20,7 +20,7 @@ package monix.reactive.internal.operators
 import java.util.concurrent.TimeUnit
 
 import monix.execution.Ack.{Stop, Continue}
-import monix.execution.cancelables.{CompositeCancelable, MultiAssignmentCancelable}
+import monix.execution.cancelables.{CompositeCancelable, MultiAssignCancelable}
 import monix.execution.{Ack, Cancelable}
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
@@ -33,7 +33,7 @@ class DelayByTimespanObservable[A](source: Observable[A], delay: FiniteDuration)
   extends Observable[A] {
 
   def unsafeSubscribeFn(out: Subscriber[A]): Cancelable = {
-    val task = MultiAssignmentCancelable()
+    val task = MultiAssignCancelable()
     val composite = CompositeCancelable(task)
 
     composite += source.unsafeSubscribeFn(new Subscriber[A] with Runnable { self =>

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelaySubscriptionByTimespanObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelaySubscriptionByTimespanObservable.scala
@@ -18,7 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Cancelable
-import monix.execution.cancelables.MultiAssignmentCancelable
+import monix.execution.cancelables.OrderedCancelable
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 import scala.concurrent.duration.FiniteDuration
@@ -28,7 +28,7 @@ private[reactive] final class DelaySubscriptionByTimespanObservable[A]
   extends Observable[A] { self =>
 
   def unsafeSubscribeFn(out: Subscriber[A]): Cancelable = {
-    val conn = MultiAssignmentCancelable()
+    val conn = OrderedCancelable()
     val main = out.scheduler.scheduleOnce(
       timespan.length, timespan.unit,
       new Runnable {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelaySubscriptionWithTriggerObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelaySubscriptionWithTriggerObservable.scala
@@ -18,7 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.Stop
-import monix.execution.cancelables.MultiAssignmentCancelable
+import monix.execution.cancelables.OrderedCancelable
 import monix.execution.{Ack, Cancelable}
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
@@ -29,7 +29,7 @@ class DelaySubscriptionWithTriggerObservable[A](source: Observable[A], trigger: 
   extends Observable[A] {
 
   def unsafeSubscribeFn(subscriber: Subscriber[A]): Cancelable = {
-    val cancelable = MultiAssignmentCancelable()
+    val cancelable = OrderedCancelable()
 
     val main = trigger.unsafeSubscribeFn(
       new Subscriber[Any] {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DownstreamTimeoutObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DownstreamTimeoutObservable.scala
@@ -19,7 +19,7 @@ package monix.reactive.internal.operators
 
 import java.util.concurrent.TimeUnit
 import monix.execution.Ack.{Stop, Continue}
-import monix.execution.cancelables.{CompositeCancelable, MultiAssignmentCancelable, SingleAssignmentCancelable}
+import monix.execution.cancelables.{CompositeCancelable, MultiAssignCancelable, SingleAssignCancelable}
 import monix.execution.{Ack, Cancelable, Scheduler}
 import monix.execution.exceptions.DownstreamTimeoutException
 import monix.reactive.Observable
@@ -32,8 +32,8 @@ private[reactive] final class DownstreamTimeoutObservable[+A](
   extends Observable[A] {
 
   def unsafeSubscribeFn(downstream: Subscriber[A]): Cancelable = {
-    val timeoutCheck = MultiAssignmentCancelable()
-    val mainTask = SingleAssignmentCancelable()
+    val timeoutCheck = MultiAssignCancelable()
+    val mainTask = SingleAssignCancelable()
     val composite = CompositeCancelable(mainTask, timeoutCheck)
 
     mainTask := source.unsafeSubscribeFn(new Subscriber[A] with Runnable { self =>

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropByTimespanObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropByTimespanObservable.scala
@@ -18,7 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.Continue
-import monix.execution.cancelables.{CompositeCancelable, SingleAssignmentCancelable}
+import monix.execution.cancelables.{CompositeCancelable, SingleAssignCancelable}
 import monix.execution.{Ack, Cancelable}
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
@@ -30,7 +30,7 @@ class DropByTimespanObservable[A](source: Observable[A], timespan: FiniteDuratio
   extends Observable[A] {
 
   def unsafeSubscribeFn(out: Subscriber[A]): Cancelable = {
-    val trigger = SingleAssignmentCancelable()
+    val trigger = SingleAssignCancelable()
     val composite = CompositeCancelable(trigger)
 
     composite += source.unsafeSubscribeFn(

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropUntilObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropUntilObservable.scala
@@ -18,7 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.{Continue, Stop}
-import monix.execution.cancelables.{CompositeCancelable, SingleAssignmentCancelable}
+import monix.execution.cancelables.{CompositeCancelable, SingleAssignCancelable}
 import monix.execution.{Ack, Cancelable}
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
@@ -28,7 +28,7 @@ private[reactive] final class DropUntilObservable[A](source: Observable[A], trig
   extends Observable[A] {
 
   def unsafeSubscribeFn(out: Subscriber[A]): Cancelable = {
-    val task = SingleAssignmentCancelable()
+    val task = SingleAssignCancelable()
     val composite = CompositeCancelable(task)
 
     composite += source.unsafeSubscribeFn(    new Subscriber[A] {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EchoObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EchoObservable.scala
@@ -20,7 +20,7 @@ package monix.reactive.internal.operators
 import java.util.concurrent.TimeUnit
 
 import monix.execution.Ack.{Stop, Continue}
-import monix.execution.cancelables.{CompositeCancelable, MultiAssignmentCancelable, SingleAssignmentCancelable}
+import monix.execution.cancelables.{CompositeCancelable, MultiAssignCancelable, SingleAssignCancelable}
 import monix.execution.{Ack, Cancelable}
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
@@ -35,8 +35,8 @@ class EchoObservable[+A](source: Observable[A], timeout: FiniteDuration, onlyOnc
   private[this] val timeoutMillis = timeout.toMillis
 
   def unsafeSubscribeFn(out: Subscriber[A]): Cancelable = {
-    val task = MultiAssignmentCancelable()
-    val mainTask = SingleAssignmentCancelable()
+    val task = MultiAssignCancelable()
+    val mainTask = SingleAssignCancelable()
     val composite = CompositeCancelable(mainTask, task)
 
     mainTask := source.unsafeSubscribeFn(new Subscriber[A] with Runnable { self =>

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ExecuteOnObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ExecuteOnObservable.scala
@@ -17,7 +17,7 @@
 
 package monix.reactive.internal.operators
 
-import monix.execution.cancelables.{AssignableCancelable, SingleAssignmentCancelable}
+import monix.execution.cancelables.{AssignableCancelable, SingleAssignCancelable}
 import monix.execution.schedulers.TrampolinedRunnable
 import monix.execution.{Ack, Cancelable, Scheduler}
 import monix.reactive.Observable
@@ -29,7 +29,7 @@ class ExecuteOnObservable[+A](source: Observable[A], s: Scheduler, forceAsync: B
   extends Observable[A] {
 
   def unsafeSubscribeFn(out: Subscriber[A]): Cancelable = {
-    val conn = SingleAssignmentCancelable()
+    val conn = SingleAssignCancelable()
     if (forceAsync) s.execute(new Thunk(conn, out))
     else s.execute(new TrampolinedThunk(conn, out))
     conn

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FlatScanObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FlatScanObservable.scala
@@ -18,7 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.{Continue, Stop}
-import monix.execution.cancelables.{CompositeCancelable, MultiAssignmentCancelable}
+import monix.execution.cancelables.{CompositeCancelable, MultiAssignCancelable}
 import monix.execution.misc.NonFatal
 import monix.execution.{Ack, Cancelable}
 import monix.execution.exceptions.CompositeException
@@ -46,7 +46,7 @@ class FlatScanObservable[A,R](
   }
 
   def subscribeWithState(out: Subscriber[R], initial: R): Cancelable = {
-    val conn = MultiAssignmentCancelable()
+    val conn = MultiAssignCancelable()
     val composite = CompositeCancelable(conn)
 
     composite += source.unsafeSubscribeFn(new Subscriber[A] { self =>

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapParallelUnorderedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapParallelUnorderedObservable.scala
@@ -19,7 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.eval.{Callback, Task}
 import monix.execution.Ack.{Continue, Stop}
-import monix.execution.cancelables.{CompositeCancelable, SingleAssignmentCancelable}
+import monix.execution.cancelables.{CompositeCancelable, SingleAssignCancelable}
 import monix.execution.misc.{AsyncSemaphore, NonFatal}
 import monix.execution.{Ack, Cancelable}
 import monix.reactive.{Observable, OverflowStrategy}
@@ -94,7 +94,7 @@ private[reactive] final class MapParallelUnorderedObservable[A,B](
       try {
         // We need a forward reference, because of the
         // interaction with the `composite` below
-        val subscription = SingleAssignmentCancelable()
+        val subscription = SingleAssignCancelable()
         composite += subscription
 
         val task = {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MergeMapObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MergeMapObservable.scala
@@ -78,7 +78,7 @@ private[reactive] final class MergeMapObservable[A,B](
           streamError = false
           val refID = refCount.acquire()
 
-          val childTask = SingleAssignmentCancelable()
+          val childTask = SingleAssignCancelable()
           composite += childTask
 
           childTask := fb.unsafeSubscribeFn(new Subscriber[B] {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/OnErrorRecoverWithObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/OnErrorRecoverWithObservable.scala
@@ -18,7 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.Continue
-import monix.execution.cancelables.MultiAssignmentCancelable
+import monix.execution.cancelables.OrderedCancelable
 import monix.execution.misc.NonFatal
 import monix.execution.{Ack, Cancelable}
 import monix.reactive.Observable
@@ -31,7 +31,7 @@ class OnErrorRecoverWithObservable[A](source: Observable[A], f: Throwable => Obs
   extends Observable[A] {
 
   def unsafeSubscribeFn(out: Subscriber[A]): Cancelable = {
-    val cancelable = MultiAssignmentCancelable()
+    val cancelable = OrderedCancelable()
 
     val main = source.unsafeSubscribeFn(new Subscriber[A] {
       implicit val scheduler = out.scheduler

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/OnErrorRetryCountedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/OnErrorRetryCountedObservable.scala
@@ -18,7 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.Continue
-import monix.execution.cancelables.MultiAssignmentCancelable
+import monix.execution.cancelables.OrderedCancelable
 import monix.execution.{Scheduler, Ack, Cancelable}
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
@@ -29,7 +29,7 @@ private[reactive] final
 class OnErrorRetryCountedObservable[+A](source: Observable[A], maxRetries: Long)
   extends Observable[A] {
 
-  private def loop(subscriber: Subscriber[A], task: MultiAssignmentCancelable, retryIdx: Long): Unit = {
+  private def loop(subscriber: Subscriber[A], task: OrderedCancelable, retryIdx: Long): Unit = {
     val cancelable = source.unsafeSubscribeFn(new Subscriber[A] {
       implicit val scheduler: Scheduler = subscriber.scheduler
       private[this] var isDone = false
@@ -72,7 +72,7 @@ class OnErrorRetryCountedObservable[+A](source: Observable[A], maxRetries: Long)
   }
 
   def unsafeSubscribeFn(subscriber: Subscriber[A]): Cancelable = {
-    val task = MultiAssignmentCancelable()
+    val task = OrderedCancelable()
     loop(subscriber, task, retryIdx = 0)
     task
   }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/OnErrorRetryIfObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/OnErrorRetryIfObservable.scala
@@ -19,7 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack.Continue
 import monix.execution.{Ack, Cancelable, Scheduler}
-import monix.execution.cancelables.MultiAssignmentCancelable
+import monix.execution.cancelables.OrderedCancelable
 import monix.execution.misc.NonFatal
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
@@ -31,7 +31,7 @@ private[reactive] final
 class OnErrorRetryIfObservable[+A](source: Observable[A], p: Throwable => Boolean)
   extends Observable[A] {
 
-  private def loop(subscriber: Subscriber[A], task: MultiAssignmentCancelable, retryIdx: Long): Unit = {
+  private def loop(subscriber: Subscriber[A], task: OrderedCancelable, retryIdx: Long): Unit = {
     val cancelable = source.unsafeSubscribeFn(new Subscriber[A] {
       implicit val scheduler: Scheduler = subscriber.scheduler
       private[this] var isDone = false
@@ -87,7 +87,7 @@ class OnErrorRetryIfObservable[+A](source: Observable[A], p: Throwable => Boolea
   }
 
   def unsafeSubscribeFn(subscriber: Subscriber[A]): Cancelable = {
-    val task = MultiAssignmentCancelable()
+    val task = OrderedCancelable()
     loop(subscriber, task, retryIdx = 0)
     task
   }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/PipeThroughObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/PipeThroughObservable.scala
@@ -17,7 +17,7 @@
 
 package monix.reactive.internal.operators
 
-import monix.execution.cancelables.SingleAssignmentCancelable
+import monix.execution.cancelables.SingleAssignCancelable
 import monix.execution.{Ack, Cancelable}
 import monix.reactive.observers.Subscriber
 import monix.reactive.{Observable, Pipe}
@@ -30,7 +30,7 @@ private[reactive] final class PipeThroughObservable[A,B]
   def unsafeSubscribeFn(out: Subscriber[B]): Cancelable = {
     import out.scheduler
     val (input,output) = pipe.unicast
-    val upstream = SingleAssignmentCancelable()
+    val upstream = SingleAssignCancelable()
 
     val downstream = output.unsafeSubscribeFn(new Subscriber[B] {
       implicit val scheduler = out.scheduler

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/RepeatSourceObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/RepeatSourceObservable.scala
@@ -18,7 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.Continue
-import monix.execution.cancelables.{CompositeCancelable, MultiAssignmentCancelable}
+import monix.execution.cancelables.{CompositeCancelable, OrderedCancelable}
 import monix.execution.{Ack, Cancelable}
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
@@ -32,7 +32,7 @@ private[reactive] final class RepeatSourceObservable[A](source: Observable[A])
   // recursive function - subscribes the observer again when
   // onComplete happens
   def loop(subject: Subject[A, A], out: Subscriber[A],
-    task: MultiAssignmentCancelable, index: Long): Unit = {
+    task: OrderedCancelable, index: Long): Unit = {
 
     val cancelable = subject.unsafeSubscribeFn(new Subscriber[A] {
       implicit val scheduler = out.scheduler
@@ -75,7 +75,7 @@ private[reactive] final class RepeatSourceObservable[A](source: Observable[A])
 
   def unsafeSubscribeFn(out: Subscriber[A]): Cancelable = {
     val subject = ReplaySubject[A]()
-    val repeatTask = MultiAssignmentCancelable()
+    val repeatTask = OrderedCancelable()
     loop(subject, out, repeatTask, index=0)
 
     val mainTask = source.unsafeSubscribeFn(Subscriber(subject, out.scheduler))

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ScanTaskObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ScanTaskObservable.scala
@@ -21,7 +21,7 @@ import monix.eval.{Callback, Task}
 import monix.execution.Ack.Stop
 import monix.execution.atomic.Atomic
 import monix.execution.atomic.PaddingStrategy.LeftRight128
-import monix.execution.cancelables.MultiAssignmentCancelable
+import monix.execution.cancelables.OrderedCancelable
 import monix.execution.misc.NonFatal
 import monix.execution.{Ack, Cancelable}
 import monix.reactive.Observable
@@ -41,7 +41,7 @@ private[reactive] final class ScanTaskObservable[A, S]
   extends Observable[S] {
 
   def unsafeSubscribeFn(out: Subscriber[S]): Cancelable = {
-    val conn = MultiAssignmentCancelable()
+    val conn = OrderedCancelable()
 
     val cb = new Callback[S] {
       def onSuccess(initial: S): Unit = {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/SwitchIfEmptyObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/SwitchIfEmptyObservable.scala
@@ -17,7 +17,7 @@
 
 package monix.reactive.internal.operators
 
-import monix.execution.cancelables.MultiAssignmentCancelable
+import monix.execution.cancelables.OrderedCancelable
 import monix.execution.{Ack, Cancelable}
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
@@ -28,7 +28,7 @@ class SwitchIfEmptyObservable[+A](source: Observable[A], backup: Observable[A])
   extends Observable[A] {
 
   override def unsafeSubscribeFn(out: Subscriber[A]): Cancelable = {
-    val cancelable = MultiAssignmentCancelable()
+    val cancelable = OrderedCancelable()
 
     val mainSub = source.unsafeSubscribeFn(new Subscriber[A] {
       implicit val scheduler = out.scheduler

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/SwitchMapObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/SwitchMapObservable.scala
@@ -18,7 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.{Continue, Stop}
-import monix.execution.cancelables.{CompositeCancelable, SerialCancelable, SingleAssignmentCancelable}
+import monix.execution.cancelables.{CompositeCancelable, SerialCancelable, SingleAssignCancelable}
 import monix.execution.misc.NonFatal
 import monix.execution.{Ack, Cancelable}
 import monix.reactive.observers.Subscriber
@@ -32,7 +32,7 @@ private[reactive] final class SwitchMapObservable[A,B](
 
   def unsafeSubscribeFn(out: Subscriber[B]): Cancelable = {
     val activeChild = SerialCancelable()
-    val mainTask = SingleAssignmentCancelable()
+    val mainTask = SingleAssignCancelable()
     val composite = CompositeCancelable(activeChild, mainTask)
 
     mainTask := source.unsafeSubscribeFn(new Subscriber.Sync[A] { self =>

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeUntilObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeUntilObservable.scala
@@ -18,7 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.Stop
-import monix.execution.cancelables.{CompositeCancelable, SingleAssignmentCancelable}
+import monix.execution.cancelables.{CompositeCancelable, SingleAssignCancelable}
 import monix.execution.{Ack, Cancelable}
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
@@ -30,7 +30,7 @@ private[reactive] final class TakeUntilObservable[+A](
   extends Observable[A] {
 
   def unsafeSubscribeFn(out: Subscriber[A]): Cancelable = {
-    val mainConn = SingleAssignmentCancelable()
+    val mainConn = SingleAssignCancelable()
     var isComplete = false
 
     val selectorConn = trigger.unsafeSubscribeFn(

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ThrottleLastObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ThrottleLastObservable.scala
@@ -18,7 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.{Continue, Stop}
-import monix.execution.cancelables.{CompositeCancelable, SingleAssignmentCancelable}
+import monix.execution.cancelables.{CompositeCancelable, SingleAssignCancelable}
 import monix.execution.{Ack, Cancelable}
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
@@ -30,8 +30,8 @@ private[reactive] final class ThrottleLastObservable[+A, S](
   extends Observable[A] {
 
   def unsafeSubscribeFn(downstream: Subscriber[A]): Cancelable = {
-    val upstreamSubscription = SingleAssignmentCancelable()
-    val samplerSubscription = SingleAssignmentCancelable()
+    val upstreamSubscription = SingleAssignCancelable()
+    val samplerSubscription = SingleAssignCancelable()
     val composite = CompositeCancelable(upstreamSubscription, samplerSubscription)
 
     upstreamSubscription := source.unsafeSubscribeFn(

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/UpstreamTimeoutObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/UpstreamTimeoutObservable.scala
@@ -19,7 +19,7 @@ package monix.reactive.internal.operators
 
 import java.util.concurrent.TimeUnit
 import monix.execution.Ack.{Continue, Stop}
-import monix.execution.cancelables.{CompositeCancelable, MultiAssignmentCancelable, SingleAssignmentCancelable}
+import monix.execution.cancelables.{CompositeCancelable, MultiAssignCancelable, SingleAssignCancelable}
 import monix.execution.exceptions.UpstreamTimeoutException
 import monix.execution.{Ack, Cancelable, Scheduler}
 import monix.reactive.Observable
@@ -32,8 +32,8 @@ private[reactive] final class UpstreamTimeoutObservable[+A](
   extends Observable[A] {
 
   def unsafeSubscribeFn(downstream: Subscriber[A]): Cancelable = {
-    val timeoutCheck = MultiAssignmentCancelable()
-    val mainTask = SingleAssignmentCancelable()
+    val timeoutCheck = MultiAssignCancelable()
+    val mainTask = SingleAssignCancelable()
     val composite = CompositeCancelable(mainTask, timeoutCheck)
 
     mainTask := source.unsafeSubscribeFn(new Subscriber[A] with Runnable { self =>

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/rstreams/SubscriberAsReactiveSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/rstreams/SubscriberAsReactiveSubscriber.scala
@@ -19,7 +19,7 @@ package monix.reactive.internal.rstreams
 
 import monix.execution.Ack
 import monix.execution.Ack.{Continue, Stop}
-import monix.execution.rstreams.SingleAssignmentSubscription
+import monix.execution.rstreams.SingleAssignSubscription
 import monix.execution.schedulers.TrampolineExecutionContext.immediate
 import monix.reactive.OverflowStrategy.Unbounded
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
@@ -109,7 +109,7 @@ private[reactive] final class AsyncSubscriberAsReactiveSubscriber[A]
 
   require(requestCount > 0, "requestCount must be strictly positive, according to the Reactive Streams contract")
 
-  private[this] val subscription = SingleAssignmentSubscription()
+  private[this] val subscription = SingleAssignSubscription()
   private[this] val downstream: Subscriber[A] =
     new Subscriber[A] {
       implicit val scheduler = target.scheduler

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observables/ChainedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observables/ChainedObservable.scala
@@ -18,7 +18,7 @@
 package monix.reactive.observables
 
 import monix.execution.Cancelable
-import monix.execution.cancelables.MultiAssignmentCancelable
+import monix.execution.cancelables.MultiAssignCancelable
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 
@@ -48,10 +48,10 @@ abstract class ChainedObservable[+A] extends Observable[A] {
     * @param subscriber is the subscriber that will receive all events
     *        from the source
     */
-  def unsafeSubscribeFn(conn: MultiAssignmentCancelable, subscriber: Subscriber[A]): Unit
+  def unsafeSubscribeFn(conn: MultiAssignCancelable, subscriber: Subscriber[A]): Unit
 
   override def unsafeSubscribeFn(subscriber: Subscriber[A]): Cancelable = {
-    val conn = MultiAssignmentCancelable()
+    val conn = MultiAssignCancelable()
     unsafeSubscribeFn(conn, subscriber)
     conn
   }
@@ -62,7 +62,7 @@ object ChainedObservable {
     * subscribing to it by injecting the provided `conn` if it is,
     * otherwise it subscribes
     */
-  def subscribe[A](source: Observable[A], conn: MultiAssignmentCancelable, out: Subscriber[A]): Unit =
+  def subscribe[A](source: Observable[A], conn: MultiAssignCancelable, out: Subscriber[A]): Unit =
     source match {
       case _: ChainedObservable[_] =>
         out.scheduler.executeTrampolined { () =>

--- a/monix-reactive/shared/src/main/scala/monix/reactive/subjects/ConcurrentSubject.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/subjects/ConcurrentSubject.scala
@@ -17,7 +17,7 @@
 
 package monix.reactive.subjects
 
-import monix.execution.cancelables.SingleAssignmentCancelable
+import monix.execution.cancelables.SingleAssignCancelable
 import monix.execution.{Ack, Cancelable, Scheduler}
 import monix.reactive.OverflowStrategy.{Synchronous, Unbounded}
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
@@ -239,7 +239,7 @@ object ConcurrentSubject {
         Subscriber(source, s).toReactive(bufferSize)
 
       def subscribe(subscriber: RSubscriber[_ >: O]): Unit = {
-        val sub = SingleAssignmentCancelable()
+        val sub = SingleAssignCancelable()
         sub := source.unsafeSubscribeFn(Subscriber.fromReactiveSubscriber(subscriber, sub))
       }
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/subjects/Subject.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/subjects/Subject.scala
@@ -18,7 +18,7 @@
 package monix.reactive.subjects
 
 import monix.execution.Scheduler
-import monix.execution.cancelables.SingleAssignmentCancelable
+import monix.execution.cancelables.SingleAssignCancelable
 import monix.reactive.observers.Subscriber
 import monix.reactive.{Observable, Observer}
 import org.reactivestreams.{Subscription, Processor => RProcessor, Subscriber => RSubscriber}
@@ -67,7 +67,7 @@ object Subject {
         Subscriber(source, s).toReactive(bufferSize)
 
       def subscribe(subscriber: RSubscriber[_ >: O]): Unit = {
-        val sub = SingleAssignmentCancelable()
+        val sub = SingleAssignCancelable()
         sub := source.unsafeSubscribeFn(Subscriber.fromReactiveSubscriber(subscriber, sub))
       }
 

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/rstreams/ObservableIsPublisherSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/rstreams/ObservableIsPublisherSuite.scala
@@ -19,7 +19,7 @@ package monix.reactive.internal.rstreams
 
 import minitest.TestSuite
 import monix.execution.Ack.Continue
-import monix.execution.rstreams.SingleAssignmentSubscription
+import monix.execution.rstreams.SingleAssignSubscription
 import monix.execution.schedulers.TestScheduler
 import monix.reactive.Observable
 import monix.reactive.subjects.PublishSubject
@@ -72,7 +72,7 @@ object ObservableIsPublisherSuite extends TestSuite[TestScheduler] {
   test("should work with stop-and-wait back-pressure, test 2") { implicit s =>
     val out = PublishSubject[Long]()
 
-    val subscription = SingleAssignmentSubscription()
+    val subscription = SingleAssignSubscription()
     var wasCompleted = false
     var received = 0L
     var streamed = 0L

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantToReactivePublisherSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantToReactivePublisherSuite.scala
@@ -24,7 +24,7 @@ import monix.eval.Task
 import monix.execution.ExecutionModel.AlwaysAsyncExecution
 import monix.execution.exceptions.DummyException
 import monix.execution.internal.Platform
-import monix.execution.rstreams.SingleAssignmentSubscription
+import monix.execution.rstreams.SingleAssignSubscription
 import monix.tail.batches.Batch
 import org.reactivestreams.{Subscriber, Subscription}
 import scala.util.{Failure, Success}
@@ -94,7 +94,7 @@ object IterantToReactivePublisherSuite extends BaseTestSuite {
     var wasCompleted = false
     var received = 0
 
-    val subscription = SingleAssignmentSubscription()
+    val subscription = SingleAssignSubscription()
 
     Iterant[Task].range(0, count)
       .doOnEarlyStop(Task { wasStopped += 1 })
@@ -189,7 +189,7 @@ object IterantToReactivePublisherSuite extends BaseTestSuite {
     var wasCompleted: Option[Throwable] = null
     var received = 0
 
-    val subscription = SingleAssignmentSubscription()
+    val subscription = SingleAssignSubscription()
 
     Iterant[Task].range(0, count)
       .doOnEarlyStop(Task { wasStopped += 1 })
@@ -324,7 +324,7 @@ object IterantToReactivePublisherSuite extends BaseTestSuite {
   def sum[F[_]](stream: Iterant[F, Int], request: Long)(implicit F: Effect[F]): Task[Long] =
     Task.create { (scheduler, cb) =>
       implicit val ec = scheduler
-      val subscription = SingleAssignmentSubscription()
+      val subscription = SingleAssignSubscription()
 
       stream.toReactivePublisher.subscribe(
         new Subscriber[Int] {


### PR DESCRIPTION
New additions to `Task`, making its API purer and more powerful out of the box:

```scala
sealed abstract class Task[+A]
  // ...
  def cancel: Task[Unit]

  def start: Task[Task[A]]

  def uncancelable: Task[A]
}

object Task {
  // ...
  def race[A, B](fa: Task[A], fb: Task[B]): Task[Either[A, B]] = ???

  def raceMany[A](tasks: TraversableOnce[Task[A]]): Task[A] = ???

  def racePair[A,B](fa: Task[A], fb: Task[B]): Task[Either[(A, Task[B]), (Task[A], B)]] = ???
} 
```

NOTE — no changes to the run-loop or internal encoding have been made, these are simply operations that were added on top of the existing implementation, but needed nevertheless for a good out of the box experience.

In the future changes to the internal encoding might happen. For example at this point there's no special state that describes cancellation, the result of `.cancel` being a `Task.Async` that makes use of the existing cancellation protocol. But in the future we might add a special state for it, depending on feedback.

## Pure cancellation

It is now possible to do this:

```scala
val ta: Task[A] = ???
val tb: Task[B] = ???

Task.racePair(ta, tb).flatMap {
  case Left((a, taskB)) =>
    taskB.cancel.map(_ => a)
  case Right((taskA, b)) =>
    taskA.cancel.map(_ => b)
}
```
 
You might recognize this operation as the old `Task.chooseFirstOf`, however the old signature was returning `CancelableFuture` as the reference for the future result of the losing task, whereas this one returns a pure `Task` (linked to an underlying `Promise`, but that's an implementation detail). And because now `Task` has a pure `.cancel` operation that describes cancellation, you can cancel these tasks in `racePair` without side effects being involved.

```scala
val task = Task.eval(println("Hello!"))
  .delayExecution(1.second)
  .doOnCancel(Task.eval(println("Cancelled!")))

task.cancel.runAsync
//=> Cancelled!
```

## .start

Inspired by [FS2](https://github.com/functional-streams-for-scala/fs2), we can now trigger `start` as a pure operation, allowing operations like this:

```scala
def par2[A, B](ta: Task[A], tb: Task[B]): Task[(A, B)] =
  for {
    fa <- ta.start
    fb <- tb.start
     a <- fa
     b <- fb
  } yield (a, b)
```

Note this is not exactly equivalent with `parMap2` due to insufficient behavior when an error happens. To make this behave like `parMap2` is harder, so usage of `parMap2` (and `parMap3`, etc) is still recommended, this being just a pedagogical example for what `start` might be useful for.

Also compared with the equivalent from FS2, Monix's `start` does not introduce an automatic `fork` (i.e. it does not shift the processing on another thread, although shifting might happen due to batched processing), being consistent with other operations in Monix.

## .uncancelable

Sometimes we need to ensure that tasks are not cancelable, in order to ensure that some actions are executed no matter what and now you can use the new `uncancelable` operator to mark tasks that cannot be canceled:

```scala
Task(println("Hello!")).delayExecution(5.seconds)
  .doOnFinish(_ => println("Executed!"))
  .uncancelable
```

Normally the above task is cancelable and there's plenty of time to trigger cancellation (due to the `delayExecution`), so if we want to ensure that this task executes as an atomic unit (all or nothing), we can call `.uncancelable` on it.

## race, racePair, raceMany

The old `.chooseFirstOf` was too powerful. Most of the time you just want to pick the winner and cancel the loser. Plus `race` as a name is much more standard, having been used both in Haskell and JavaScript's standard libraries at least.

`race` is the new version that automatically cancels the loser.

`racePair` is the new version that behaves like the old `chooseFirstOf`, but is pure, giving you a `Task` for the loser, since tasks can now be cancelled directly as a pure action.

`raceMany` is just the old `chooseFirstOfList`, to be consistent with the other two.

## Other Changes

Refactoring to `monix.execution.cancelables`:

- rename `MultiAssignmentCancelable` to `OrderedCancelable`
- introduce new `MultiAssignCancelable` with a simpler implementation
- rename `SingleAssignmentCancelable` to `SingleAssignCancelable`
- add deprecated symbols in `cancelable` package object
  
  
  