### PR TITLE
Add onErrorRestartLoop for Task and Coeval

### DIFF
--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -1013,7 +1013,7 @@ sealed abstract class Task[+A] extends Serializable {
     *   task.onErrorRestartLoop(Backoff(10, 1.second)) { (err, state, retry) =>
     *     val Backoff(maxRetries, delay) = state
     *     if (maxRetries > 0)
-    *       retry(Backoff(maxRetries - 1, delay * 2)).delayExecution(1.second)
+    *       retry(Backoff(maxRetries - 1, delay * 2)).delayExecution(delay)
     *     else
     *       // No retries left, rethrow the error
     *       Task.raiseError(err)

--- a/monix-execution/shared/src/main/scala/monix/execution/ExecutionModel.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/ExecutionModel.scala
@@ -81,8 +81,8 @@ object ExecutionModel {
       * [[SynchronousExecution]] type is set to the maximum power
       * of 2 expressible with a `Int`, which is 2^30^ (or 1,073,741,824).
       */
-    val recommendedBatchSize = math.roundToPowerOf2(Int.MaxValue)
-    val batchedExecutionModulus = recommendedBatchSize-1
+    val recommendedBatchSize: Int = math.roundToPowerOf2(Int.MaxValue)
+    val batchedExecutionModulus: Int = recommendedBatchSize-1
 
     /** Returns the next frame index in the run-loop.
       *
@@ -100,8 +100,8 @@ object ExecutionModel {
     /** The [[ExecutionModel.recommendedBatchSize]] for the
       * [[SynchronousExecution]] type is set to one.
       */
-    val recommendedBatchSize = 1
-    val batchedExecutionModulus = 0
+    val recommendedBatchSize: Int = 1
+    val batchedExecutionModulus: Int = 0
 
     /** Returns the next frame index in the run-loop.
       *
@@ -128,8 +128,8 @@ object ExecutionModel {
     private val batchSize: Int)
     extends ExecutionModel {
 
-    val recommendedBatchSize = math.nextPowerOf2(batchSize)
-    val batchedExecutionModulus = recommendedBatchSize-1
+    val recommendedBatchSize: Int = math.nextPowerOf2(batchSize)
+    val batchedExecutionModulus: Int = recommendedBatchSize - 1
 
     def nextFrameIndex(current: Int): Int =
       (current + 1) & batchedExecutionModulus


### PR DESCRIPTION
Add new `Task` and `Coeval` operator for dealing with errors:

```scala
def onErrorRestartLoop[S, B >: A](initial: S)(f: (Throwable, S, S => Task[B]) => Task[B]): Task[B]
```

This makes it easier to describe a custom retry loop. Example 1 (from ScalaDoc):

```scala
import scala.concurrent.duration._

task.onErrorRestartLoop(10) { (err, maxRetries, retry) =>
  if (maxRetries > 0)
    // Next retry please; but do a 1 second delay
    retry(maxRetries - 1).delayExecution(1.second)
  else
    // No retries left, rethrow the error
    Task.raiseError(err)
}
```

A more complex example for doing exponential backoff (from ScalaDoc):

```scala
import scala.concurrent.duration._

// Keeps the current state, indicating the restart delay and the
// maximum number of retries left
final case class Backoff(maxRetries: Int, delay: FiniteDuration)

// Restarts for a maximum of 10 times, with an initial delay of 1 second,
// a delay that keeps being multiplied by 2
task.onErrorRestartLoop(Backoff(10, 1.second)) { (err, state, retry) =>
  val Backoff(maxRetries, delay) = state
  if (maxRetries > 0)
    retry(Backoff(maxRetries - 1, delay * 2)).delayExecution(delay)
  else
    // No retries left, rethrow the error
    Task.raiseError(err)
}
```

Closes #472 too.
  