### PR TITLE
Add Iterant.intersperse operation

### DIFF
--- a/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
@@ -978,6 +978,25 @@ sealed abstract class Iterant[F[_], A] extends Product with Serializable {
   final def foldRightL[B](b: F[B])(f: (A, F[B], F[Unit]) => F[B])(implicit F: Sync[F]): F[B] =
     IterantFoldRightL(self, b, f)(F)
 
+  /** Creates a new stream from the source that will emit a specific `separator`
+    * between every pair of elements.
+    *
+    * @param separator the separator
+    */
+  final def intersperse(separator: A)(implicit F: Sync[F]): Iterant[F, A] =
+    IterantIntersperse(self, separator)
+
+  /** Creates a new stream from the source that will emit the `start` element
+    * followed by the upstream elements paired with the `separator`
+    * and lastly the `end` element.
+    *
+    * @param start the first element emitted
+    * @param separator the separator
+    * @param end the last element emitted
+    */
+  final def intersperse(start: A, separator: A, end: A)(implicit F: Sync[F]): Iterant[F, A] =
+    start +: IterantIntersperse(self, separator) :+ end
+
   /** Given mapping functions from `F` to `G`, lifts the source into
     * an iterant that is going to use the resulting `G` for evaluation.
     *

--- a/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
@@ -981,6 +981,11 @@ sealed abstract class Iterant[F[_], A] extends Product with Serializable {
   /** Creates a new stream from the source that will emit a specific `separator`
     * between every pair of elements.
     *
+    * {{{
+    *   // Yields 1, 0, 2, 0, 3
+    *   Iterant[Coeval].of(1, 2, 3).intersperse(0)
+    * }}}
+    *
     * @param separator the separator
     */
   final def intersperse(separator: A)(implicit F: Sync[F]): Iterant[F, A] =
@@ -989,6 +994,11 @@ sealed abstract class Iterant[F[_], A] extends Product with Serializable {
   /** Creates a new stream from the source that will emit the `start` element
     * followed by the upstream elements paired with the `separator`
     * and lastly the `end` element.
+    *
+    * {{{
+    *   // Yields '<', 'a', '-', 'b', '>'
+    *   Iterant[Coeval].of('a', 'b').intersperse('<', '-', '>')
+    * }}}
     *
     * @param start the first element emitted
     * @param separator the separator

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantIntersperse.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantIntersperse.scala
@@ -108,7 +108,8 @@ private[tail] object IterantIntersperse {
     source match {
       case NextCursor(_, _, _) | NextBatch(_, _, _) =>
         Suspend(F.delay(loop(prepend = false)(source)), source.earlyStop)
-      case _ => loop(prepend = false)(source)
+      case _ =>
+        loop(prepend = false)(source)
     }
   }
 }

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantIntersperse.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantIntersperse.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.tail.internal
+
+import scala.collection.mutable.ArrayBuffer
+
+import cats.effect.Sync
+import cats.syntax.functor._
+import monix.execution.misc.NonFatal
+import monix.tail.Iterant
+import monix.tail.Iterant._
+import monix.tail.batches.BatchCursor
+
+
+private[tail] object IterantIntersperse {
+  def apply[F[_], A](source: Iterant[F, A], separator: A)(implicit F: Sync[F]): Iterant[F, A] = {
+    def processNonEmptyCursor(ref: NextCursor[F, A]): Iterant[F, A] = {
+      val NextCursor(cursor, rest, stop) = ref
+      val batchSize = cursor.recommendedBatchSize
+
+      if (batchSize <= 1) {
+        val item = cursor.next()
+        Next(item, F.pure(ref).map(loop(prepend = true)), stop)
+      } else {
+        var appends = 0
+        val maxAppends = batchSize / 2
+        val buffer = ArrayBuffer.empty[A]
+        var continue = true
+        while (continue && appends < maxAppends) {
+          buffer += cursor.next()
+          appends += 1
+          if (cursor.hasNext()) {
+            // only append separator if element is guaranteed to be not the last one
+            buffer += separator
+          } else {
+            continue = false
+          }
+        }
+        val batchCursor = BatchCursor.fromAnyArray[A](buffer.toArray[Any])
+        if (cursor.hasNext()) {
+          // ref now contains mutated cursor, continue with it
+          NextCursor(batchCursor, F.delay(loop(prepend = false)(ref)), stop)
+        } else {
+          NextCursor(batchCursor, rest.map(loop(prepend = true)), stop)
+        }
+      }
+    }
+
+    def loop(prepend: Boolean)(source: Iterant[F, A]): Iterant[F, A] = {
+      try source match {
+        case halt @ Halt(_) => halt
+
+        case Suspend(rest, stop) =>
+          Suspend(rest.map(loop(prepend)), stop)
+
+        case NextCursor(cursor, rest, stop) if !cursor.hasNext() =>
+          Suspend(rest.map(loop(prepend)), stop)
+
+        case NextBatch(batch, rest, stop) =>
+          val cursor = batch.cursor()
+          if (cursor.hasNext()) {
+            val processed =
+              processNonEmptyCursor(NextCursor(cursor, rest, stop))
+            if (prepend) {
+              Next(separator, F.pure(processed), stop)
+            } else {
+              processed
+            }
+          } else {
+            Suspend(rest.map(loop(prepend)), stop)
+          }
+
+        case _ if prepend => Next(
+          separator,
+          F.pure(source).map(loop(prepend = false)),
+          source.earlyStop
+        )
+
+        case ref @ NextCursor(_, _, _) =>
+          processNonEmptyCursor(ref)
+
+        case Next(item, rest, stop) =>
+          Next(item, rest.map(loop(prepend = true)), stop)
+
+        case last @ Last(_) => last
+      } catch {
+        case ex if NonFatal(ex) =>
+          val stop = source.earlyStop
+          Suspend(stop.map(_ => Halt(Some(ex))), stop)
+      }
+    }
+
+    source match {
+      case NextCursor(_, _, _) | NextBatch(_, _, _) =>
+        Suspend(F.delay(loop(prepend = false)(source)), source.earlyStop)
+      case _ => loop(prepend = false)(source)
+    }
+  }
+}

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantIntersperseSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantIntersperseSuite.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package monix.tail
 
 import cats.laws._

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantIntersperseSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantIntersperseSuite.scala
@@ -1,0 +1,75 @@
+package monix.tail
+
+import cats.laws._
+import cats.laws.discipline._
+import monix.eval.{Coeval, Task}
+import monix.execution.exceptions.DummyException
+
+object IterantIntersperseSuite extends BaseTestSuite {
+  def intersperseList[A](separator: A)(xs: List[A]): List[A] = {
+    xs.flatMap(e => e :: separator :: Nil).dropRight(1)
+  }
+
+  test("Iterant.intersperse(x) inserts the separator between elem pairs") { implicit s =>
+    check2 { (stream: Iterant[Task, Int], elem: Int) =>
+      stream.intersperse(elem).toListL <-> stream.toListL.map(intersperseList(elem))
+    }
+  }
+
+  test("Iterant.intersperse(x) preserves the source earlyStop") { implicit s =>
+    import IterantOfCoeval._
+    var effect = 0
+    val stop = Coeval(effect += 1)
+    val source = suspendS(
+      Coeval(of(1, 2, 3)),
+      stop
+    )
+    val interspersed = source.intersperse(0)
+    interspersed.earlyStop.value
+    assertEquals(effect, 1)
+  }
+
+  test("Iterant.intersperse(x) protects against broken batches") { implicit s =>
+    import IterantOfCoeval._
+
+    val dummy = DummyException("dummy")
+    val stream = of(1, 2, 3) ++ nextBatchS(
+      ThrowExceptionBatch(dummy),
+      Coeval(empty[Int]),
+      Coeval.unit
+    )
+
+    assertEquals(
+      stream.intersperse(0).toListL.runAttempt,
+      Left(dummy)
+    )
+  }
+
+  test("Iterant.intersperse(x) protects against broken cursors") { implicit s =>
+    import IterantOfCoeval._
+
+    val dummy = DummyException("dummy")
+    val stream = of(1, 2, 3) ++ nextCursorS(
+      ThrowExceptionCursor(dummy),
+      Coeval(empty[Int]),
+      Coeval.unit
+    )
+
+    assertEquals(
+      stream.intersperse(0).toListL.runAttempt,
+      Left(dummy)
+    )
+  }
+
+  test("Iterant.intersperse(a, b, c) inserts the separator between elem pairs and adds prefix/suffix") { implicit s =>
+    check3 { (stream: Iterant[Coeval, Int], prefix: Int, suffix: Int) =>
+      val separator = prefix ^ suffix
+      val source = stream.intersperse(prefix, separator, suffix)
+      val target = stream.toListL
+        .map(intersperseList(separator))
+        .map(prefix +: _ :+ suffix)
+
+      source.toListL <-> target
+    }
+  }
+}


### PR DESCRIPTION
Closes #501 

Hope you're not annoyed by my pull requests yet 😅 

Not too many tests for this one. I found that ScalaCheck-powered tests check pretty much every stream structure, and since `intersperse` signature requires pure values, there's not many erroneous cases possible.