### PR TITLE
Make all Task abstractions referentially transparent

### DIFF
--- a/monix-eval/shared/src/main/scala/monix/eval/MVar.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/MVar.scala
@@ -87,18 +87,33 @@ abstract class MVar[A] {
   def read: Task[A]
 }
 
+/** Builders for [[MVar]]
+  *
+  * @define refTransparent [[Task]] returned by this operation
+  *         produces a new [[MVar]] each time it is evaluated.
+  *         To share a state between multiple consumers, pass
+  *         [[MVar]] as a parameter or use [[Task.memoize]]
+  */
 object MVar {
-  /** Builds an [[MVar]] instance with an `initial` value. */
+  /** Builds an [[MVar]] instance with an `initial` value.
+    *
+    * $refTransparent
+    */
   def apply[A](initial: A): Task[MVar[A]] =
     Task.eval(new AsyncMVarImpl[A](AsyncVar(initial)))
 
-  /** Returns an empty [[MVar]] instance. */
+  /** Returns an empty [[MVar]] instance.
+    *
+    * $refTransparent
+    */
   def empty[A]: Task[MVar[A]] =
     Task.eval(new AsyncMVarImpl[A](AsyncVar.empty))
 
   /** Builds an [[MVar]] instance with an `initial`  value and a given
     * [[monix.execution.atomic.PaddingStrategy PaddingStrategy]]
     * (for avoiding the false sharing problem).
+    *
+    * $refTransparent
     */
   def withPadding[A](initial: A, ps: PaddingStrategy): Task[MVar[A]] =
     Task.eval(new AsyncMVarImpl[A](AsyncVar.withPadding(initial, ps)))
@@ -106,6 +121,8 @@ object MVar {
   /** Builds an empty [[MVar]] instance with a given
     * [[monix.execution.atomic.PaddingStrategy PaddingStrategy]]
     * (for avoiding the false sharing problem).
+    *
+    * $refTransparent
     */
   def withPadding[A](ps: PaddingStrategy): Task[MVar[A]] =
     Task.eval(new AsyncMVarImpl[A](AsyncVar.withPadding(ps)))

--- a/monix-eval/shared/src/main/scala/monix/eval/TaskCircuitBreaker.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/TaskCircuitBreaker.scala
@@ -441,6 +441,10 @@ final class TaskCircuitBreaker private (
 object TaskCircuitBreaker {
   /** Builder for a [[TaskCircuitBreaker]] reference.
     *
+    * [[Task]] returned by this operation produces a new
+    * [[TaskCircuitBreaker]] each time it is evaluated. To share a state between
+    * multiple consumers, pass [[TaskCircuitBreaker]] as a parameter or use [[Task.memoize]]
+    *
     * @param maxFailures is the maximum count for failures before
     *        opening the circuit breaker
     * @param resetTimeout is the timeout to wait in the `Open` state
@@ -470,7 +474,7 @@ object TaskCircuitBreaker {
     onClosed: Task[Unit] = Task.unit,
     onHalfOpen: Task[Unit] = Task.unit,
     onOpen: Task[Unit] = Task.unit,
-    padding: PaddingStrategy = NoPadding): TaskCircuitBreaker = {
+    padding: PaddingStrategy = NoPadding): Task[TaskCircuitBreaker] = Task.eval {
 
     val atomic = Atomic.withPadding(Closed(0) : State, padding)
     new TaskCircuitBreaker(

--- a/monix-eval/shared/src/main/scala/monix/eval/TaskLocal.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/TaskLocal.scala
@@ -199,15 +199,24 @@ final class TaskLocal[A] private (default: => A) {
     Task.eval(ref.value = value)
 }
 
+/** Builders for [[TaskLocal]]
+  *
+  * @define refTransparent [[Task]] returned by this operation
+  *         produces a new [[TaskLocal]] each time it is evaluated.
+  *         To share a state between multiple consumers, pass
+  *         [[TaskLocal]] as a parameter or use [[Task.memoize]]
+  */
 object TaskLocal {
   /** Builds a [[TaskLocal]] reference with the given default.
+    *
+    * $refTransparent
     *
     * @param default is a value that gets returned in case the
     *        local was never updated (with [[TaskLocal.write write]])
     *        or in case it was cleared (with [[TaskLocal.clear]])
     */
-  def apply[A](default: A): TaskLocal[A] =
-    new TaskLocal(default)
+  def apply[A](default: A): Task[TaskLocal[A]] =
+    Task.eval(new TaskLocal(default))
 
   /** Builds a [[TaskLocal]] reference with the given `default`,
     * being lazily evaluated, using [[Coeval]] to manage evaluation.
@@ -215,11 +224,13 @@ object TaskLocal {
     * Yes, side effects in the `default` are allowed, [[Coeval]]
     * being a data type that's safe for side effects.
     *
+    * $refTransparent
+    *
     * @param default is a value that gets returned in case the
     *        local was never updated (with [[TaskLocal.write write]])
     *        or in case it was cleared (with [[TaskLocal.clear]]),
     *        lazily evaluated and managed by [[Coeval]]
     */
-  def lazyDefault[A](default: Coeval[A]): TaskLocal[A] =
-    new TaskLocal[A](default.value)
+  def lazyDefault[A](default: Coeval[A]): Task[TaskLocal[A]] =
+    Task.eval(new TaskLocal[A](default.value))
 }

--- a/monix-eval/shared/src/main/scala/monix/eval/TaskSemaphore.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/TaskSemaphore.scala
@@ -128,9 +128,14 @@ final class TaskSemaphore private (maxParallelism: Int) extends Serializable {
 object TaskSemaphore {
   /** Builder for [[TaskSemaphore]].
     *
+    * [[Task]] returned by this operation produces a new
+    * [[TaskSemaphore]] each time it is evaluated. To share
+    * a semaphore between multiple consumers, pass
+    * it as a parameter or use [[Task.memoize]]
+    *
     * @param maxParallelism represents the number of tasks
     *        allowed for parallel execution
     */
-  def apply(maxParallelism: Int): TaskSemaphore =
-    new TaskSemaphore(maxParallelism)
+  def apply(maxParallelism: Int): Task[TaskSemaphore] =
+    Task.eval(new TaskSemaphore(maxParallelism))
 }

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskCircuitBreakerSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskCircuitBreakerSuite.scala
@@ -24,10 +24,10 @@ import scala.util.{Failure, Success}
 
 object TaskCircuitBreakerSuite extends BaseTestSuite {
   test("should work for successful async tasks") { implicit s =>
-    val circuitBreaker = TaskCircuitBreaker(
+    val Right(circuitBreaker) = TaskCircuitBreaker(
       maxFailures = 5,
       resetTimeout = 1.minute
-    )
+    ).runSyncMaybe
 
     var effect = 0
     val task = circuitBreaker.protect(Task {
@@ -40,10 +40,10 @@ object TaskCircuitBreakerSuite extends BaseTestSuite {
   }
 
   test("should work for successful immediate tasks") { implicit s =>
-    val circuitBreaker = TaskCircuitBreaker(
+    val Right(circuitBreaker) = TaskCircuitBreaker(
       maxFailures = 5,
       resetTimeout = 1.minute
-    )
+    ).runSyncMaybe
 
     var effect = 0
     val task = circuitBreaker.protect(Task.eval {
@@ -55,10 +55,10 @@ object TaskCircuitBreakerSuite extends BaseTestSuite {
   }
 
   test("should be stack safe for successful async tasks (flatMap)") { implicit s =>
-    val circuitBreaker = TaskCircuitBreaker(
+    val Right(circuitBreaker) = TaskCircuitBreaker(
       maxFailures = 5,
       resetTimeout = 1.minute
-    )
+    ).runSyncMaybe
 
     def loop(n: Int, acc: Int): Task[Int] = {
       if (n > 0)
@@ -73,10 +73,10 @@ object TaskCircuitBreakerSuite extends BaseTestSuite {
   }
 
   test("should be stack safe for successful async tasks (defer)") { implicit s =>
-    val circuitBreaker = TaskCircuitBreaker(
+    val Right(circuitBreaker) = TaskCircuitBreaker(
       maxFailures = 5,
       resetTimeout = 1.minute
-    )
+    ).runSyncMaybe
 
     def loop(n: Int, acc: Int): Task[Int] =
       Task.defer {
@@ -91,10 +91,10 @@ object TaskCircuitBreakerSuite extends BaseTestSuite {
   }
 
   test("should be stack safe for successful immediate tasks (flatMap)") { implicit s =>
-    val circuitBreaker = TaskCircuitBreaker(
+    val Right(circuitBreaker) = TaskCircuitBreaker(
       maxFailures = 5,
       resetTimeout = 1.minute
-    )
+    ).runSyncMaybe
 
     def loop(n: Int, acc: Int): Task[Int] = {
       if (n > 0)
@@ -109,10 +109,10 @@ object TaskCircuitBreakerSuite extends BaseTestSuite {
   }
 
   test("should be stack safe for successful immediate tasks (defer)") { implicit s =>
-    val circuitBreaker = TaskCircuitBreaker(
+    val Right(circuitBreaker) = TaskCircuitBreaker(
       maxFailures = 5,
       resetTimeout = 1.minute
-    )
+    ).runSyncMaybe
 
     def loop(n: Int, acc: Int): Task[Int] =
       Task.defer {
@@ -133,12 +133,12 @@ object TaskCircuitBreakerSuite extends BaseTestSuite {
     var rejectedCount = 0
 
     val circuitBreaker = {
-      val cb = TaskCircuitBreaker(
+      val Right(cb) = TaskCircuitBreaker(
         maxFailures = 5,
         resetTimeout = 1.minute,
         exponentialBackoffFactor = 2,
         maxResetTimeout = 10.minutes
-      )
+      ).runSyncMaybe
 
       cb.doOnOpen(Task.eval { openedCount += 1})
         .doOnClosed(Task.eval { closedCount += 1 })
@@ -237,7 +237,7 @@ object TaskCircuitBreakerSuite extends BaseTestSuite {
       val circuitBreaker = TaskCircuitBreaker(
         maxFailures = -1,
         resetTimeout = 1.minute
-      )
+      ).runSyncMaybe
     }
 
     intercept[IllegalArgumentException] {
@@ -245,7 +245,7 @@ object TaskCircuitBreakerSuite extends BaseTestSuite {
       val circuitBreaker = TaskCircuitBreaker(
         maxFailures = 2,
         resetTimeout = -1.minute
-      )
+      ).runSyncMaybe
     }
 
     intercept[IllegalArgumentException] {
@@ -254,7 +254,7 @@ object TaskCircuitBreakerSuite extends BaseTestSuite {
         maxFailures = 2,
         resetTimeout = 1.minute,
         exponentialBackoffFactor = 0.5
-      )
+      ).runSyncMaybe
     }
 
     intercept[IllegalArgumentException] {
@@ -264,7 +264,7 @@ object TaskCircuitBreakerSuite extends BaseTestSuite {
         resetTimeout = 1.minute,
         exponentialBackoffFactor = 2,
         maxResetTimeout = Duration.Zero
-      )
+      ).runSyncMaybe
     }
   }
 }

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskLocalSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskLocalSuite.scala
@@ -25,9 +25,9 @@ object TaskLocalSuite extends SimpleTestSuite {
   implicit val opts = Task.defaultOptions.enableLocalContextPropagation
 
   testAsync("Local.apply") {
-    val local = TaskLocal(0)
     val test =
       for {
+        local <- TaskLocal(0)
         v1 <- local.read
         _ <- Task.now(assertEquals(v1, 0))
         _ <- local.write(100)
@@ -45,10 +45,10 @@ object TaskLocalSuite extends SimpleTestSuite {
 
   testAsync("Local.defaultLazy") {
     var i = 0
-    val local = TaskLocal.lazyDefault(Coeval { i += 1; i })
 
     val test =
       for {
+        local <- TaskLocal.lazyDefault(Coeval { i += 1; i })
         v1 <- local.read
         _ <- Task.now(assertEquals(v1, 1))
         _ <- local.write(100)
@@ -66,9 +66,9 @@ object TaskLocalSuite extends SimpleTestSuite {
 
 
   testAsync("TaskLocal!.bind") {
-    val local = TaskLocal(0)
     val test =
       for {
+        local <- TaskLocal(0)
         _ <- local.write(100)
         _ <- Task.shift
         v1 <- local.bind(200)(local.read.map(_ * 2))
@@ -81,9 +81,9 @@ object TaskLocalSuite extends SimpleTestSuite {
   }
 
   testAsync("TaskLocal!.bindL") {
-    val local = TaskLocal(0)
     val test =
       for {
+        local <- TaskLocal(0)
         _ <- local.write(100)
         _ <- Task.shift
         v1 <- local.bindL(Task.eval(200))(local.read.map(_ * 2))
@@ -96,9 +96,9 @@ object TaskLocalSuite extends SimpleTestSuite {
   }
 
   testAsync("TaskLocal!.bindClear") {
-    val local = TaskLocal(200)
     val test =
       for {
+        local <- TaskLocal(200)
         _ <- local.write(100)
         _ <- Task.shift
         v1 <- local.bindClear(local.read.map(_ * 2))

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskSemaphoreSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskSemaphoreSuite.scala
@@ -29,7 +29,7 @@ object TaskSemaphoreSuite extends TestSuite[TestScheduler] {
     assert(env.state.tasks.isEmpty, "should not have tasks left to execute")
 
   test("simple green-light") { implicit s =>
-    val semaphore = TaskSemaphore(maxParallelism = 4)
+    val Right(semaphore) = TaskSemaphore(maxParallelism = 4).runSyncMaybe
     val future = semaphore.greenLight(Task(1)).runAsync
 
     assertEquals(semaphore.activeCount.value, 1)
@@ -41,7 +41,7 @@ object TaskSemaphoreSuite extends TestSuite[TestScheduler] {
   }
 
   test("should release on cancel") { implicit s =>
-    val semaphore = TaskSemaphore(maxParallelism = 4)
+    val Right(semaphore) = TaskSemaphore(maxParallelism = 4).runSyncMaybe
     val p = Promise[Int]()
     var effect = 0
 
@@ -62,7 +62,7 @@ object TaskSemaphoreSuite extends TestSuite[TestScheduler] {
   testAsync("real async test of many tasks") { _ =>
     // Executing tasks on the global scheduler!
     import monix.execution.Scheduler.Implicits.global
-    val semaphore = TaskSemaphore(maxParallelism = 4)
+    val Right(semaphore) = TaskSemaphore(maxParallelism = 4).runSyncMaybe
     val count = if (Platform.isJVM) 100000 else 1000
 
     val tasks = for (i <- 0 until count) yield
@@ -77,7 +77,7 @@ object TaskSemaphoreSuite extends TestSuite[TestScheduler] {
   }
 
   test("await for release of all active and pending permits") { implicit s =>
-    val semaphore = TaskSemaphore(maxParallelism = 2)
+    val Right(semaphore) = TaskSemaphore(maxParallelism = 2).runSyncMaybe
     val p1 = semaphore.acquire.runAsync
     assertEquals(p1.value, Some(Success(())))
     val p2 = semaphore.acquire.runAsync
@@ -114,7 +114,7 @@ object TaskSemaphoreSuite extends TestSuite[TestScheduler] {
   }
 
   test("acquire is cancelable") { implicit s =>
-    val semaphore = TaskSemaphore(maxParallelism = 2)
+    val Right(semaphore) = TaskSemaphore(maxParallelism = 2).runSyncMaybe
 
     val p1 = semaphore.acquire.runAsync
     assert(p1.isCompleted, "p1.isCompleted")


### PR DESCRIPTION
Closes #539.

I found existing circuit breaker & semaphore tests hard to convert since they check async things in sequence, so I used quick and easy `runSyncMaybe`. Let me know if it's not good enough.