### PR TITLE
WIP: Add Observable.mapParallelOrdered

### DIFF
--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -1561,6 +1561,35 @@ abstract class Observable[+A] extends Serializable { self =>
   /** Given a mapping function that maps events to [[monix.eval.Task tasks]],
     * applies it in parallel on the source, but with a specified
     * `parallelism`, which indicates the maximum number of tasks that
+    * can be executed in parallel returning them preserving original order.
+    *
+    * Similar in spirit with
+    * [[monix.reactive.Consumer.loadBalance[A,R](parallelism* Consumer.loadBalance]],
+    * but expressed as an operator that executes [[monix.eval.Task Task]]
+    * instances in parallel.
+    *
+    * Note that when the specified `parallelism` is 1, it has the same
+    * behavior as [[mapTask]].
+    *
+    * @param parallelism is the maximum number of tasks that can be executed
+    *        in parallel, over which the source starts being
+    *        back-pressured
+    *
+    * @param f is the mapping function that produces tasks to execute
+    *        in parallel, which will eventually produce events for the
+    *        resulting observable stream
+    *
+    * @see [[mapParallelUnordered]] for a variant that does not preserve order
+    *     which may lead to faster execution times
+    * @see [[mapTask]] for serial execution
+    */
+  final def mapParallelOrdered[B](parallelism: Int)(f: A => Task[B])
+    (implicit os: OverflowStrategy[B] = OverflowStrategy.Default): Observable[B] =
+    new MapParallelOrderedObservable[A, B](self, parallelism, f, os)
+
+  /** Given a mapping function that maps events to [[monix.eval.Task tasks]],
+    * applies it in parallel on the source, but with a specified
+    * `parallelism`, which indicates the maximum number of tasks that
     * can be executed in parallel.
     *
     * Similar in spirit with
@@ -1579,6 +1608,7 @@ abstract class Observable[+A] extends Serializable { self =>
     *        in parallel, which will eventually produce events for the
     *        resulting observable stream
     *
+    * @see [[mapParallelOrdered]] for a variant that does preserve order
     * @see [[mapTask]] for serial execution
     */
   final def mapParallelUnordered[B](parallelism: Int)(f: A => Task[B])

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapParallelOrderedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapParallelOrderedObservable.scala
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.reactive.internal.operators
+
+import monix.eval.Task
+import monix.execution.Ack.{Continue, Stop}
+import monix.execution.cancelables.{CompositeCancelable, SingleAssignCancelable}
+import monix.execution.misc.{AsyncSemaphore, NonFatal}
+import monix.execution.{Ack, Cancelable, CancelableFuture}
+import monix.reactive.observers.{BufferedSubscriber, Subscriber}
+import monix.reactive.{Observable, OverflowStrategy}
+
+import scala.collection.mutable
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+private[reactive] final class MapParallelOrderedObservable[A, B](
+  source: Observable[A],
+  parallelism: Int,
+  f: A => Task[B],
+  overflowStrategy: OverflowStrategy[B]) extends Observable[B] {
+
+  override def unsafeSubscribeFn(out: Subscriber[B]): Cancelable = {
+    if (parallelism <= 0) {
+      out.onError(new IllegalArgumentException("parallelism > 0"))
+      Cancelable.empty
+    }
+    else if (parallelism == 1) {
+      // optimization for one worker
+      new MapTaskObservable[A, B](source, f).unsafeSubscribeFn(out)
+    }
+    else {
+      val composite = CompositeCancelable()
+      val subscription = new MapAsyncParallelSubscription(out, composite)
+      composite += source.unsafeSubscribeFn(subscription)
+      subscription
+    }
+  }
+
+  private final class MapAsyncParallelSubscription(
+    out: Subscriber[B], composite: CompositeCancelable)
+    extends Subscriber[A] with Cancelable { self =>
+
+    implicit val scheduler = out.scheduler
+    // Ensures we don't execute more then a maximum number of tasks in parallel
+    private[this] val semaphore = AsyncSemaphore(parallelism)
+    // Reusable instance for releasing permits on cancel, but
+    // it's debatable whether this is needed, since on cancel
+    // everything gets canceled at once
+    private[this] val releaseTask = Task.eval(semaphore.release())
+    // Buffer with the supplied  overflow strategy.
+    private[this] val buffer = BufferedSubscriber[B](out, overflowStrategy)
+
+    // Flag indicating whether a final event was called, after which
+    // nothing else can happen. It's a very light protection, as
+    // access to it is concurrent and not synchronized
+    private[this] var isDone = false
+    // Turns to `Stop` when a stop acknowledgement is observed
+    // coming from the `buffer` - this indicates that the downstream
+    // no longer wants any events, so we must cancel
+    private[this] var lastAck: Ack = Continue
+    // Buffer for signaling new elements to downstream preserving original order
+    private[this] val queue = mutable.Queue[CancelableFuture[B]]()
+
+    private def sendHeadIfPossible(): Unit = {
+      while (queue.nonEmpty && queue.head.isCompleted && !isDone) {
+        val head = queue.head
+        head.value match {
+          case Some(Success(value)) =>
+            buffer.onNext(value).syncOnComplete {
+              case Success(Stop) =>
+                lastAck = Stop
+                composite.cancel()
+                queue.dequeue()
+              case Success(Continue) =>
+                queue.dequeue()
+                composite -= head.cancelable
+              case Failure(ex) =>
+                lastAck = Stop
+                composite -= head.cancelable
+                self.onError(ex)
+            }
+
+          case Some(Failure(error)) =>
+            lastAck = Stop
+            composite -= head.cancelable
+            self.onError(error)
+
+          case None => // shouldnt get here
+        }
+      }
+    }
+
+    private def process(elem: A) = {
+      // For protecting against user code, without violating the
+      // observer's contract, by marking the boundary after which
+      // we can no longer stream errors downstream
+      var streamErrors = true
+      try {
+        // We need a forward reference, because of the
+        // interaction with the `composite` below
+        val subscription = SingleAssignCancelable()
+        composite += subscription
+
+        val task = f(elem).doOnCancel(releaseTask)
+        // No longer allowed to stream errors downstream
+        streamErrors = false
+        // Start execution
+        val future = task.runAsync
+        future.onComplete {
+          case Success(_) =>
+            // Computation is complete so we can accept new ones
+            semaphore.release()
+            // We can only send current head element to downstream subscriber
+            sendHeadIfPossible()
+          case Failure(error) =>
+            lastAck = Stop
+            composite -= subscription
+            self.onError(error)
+        }
+        queue.enqueue(future)
+        subscription := future.cancelable
+      } catch {
+        case ex if NonFatal(ex) =>
+          if (streamErrors) self.onError(ex)
+          else scheduler.reportFailure(ex)
+      }
+    }
+
+    def onNext(elem: A): Future[Ack] = {
+      // Light protection, since access isn't synchronized
+      if (lastAck == Stop || isDone) Stop else {
+        // This will wait asynchronously, if there are no permits left
+        val permit = semaphore.acquire()
+        composite += permit
+
+        val ack: Future[Ack] = permit.value match {
+          case None => permit.flatMap { _ =>
+            composite -= permit
+            process(elem)
+            Continue
+          }
+          case Some(_) =>
+            composite -= permit
+            process(elem)
+            Continue
+        }
+
+        ack.onComplete {
+          case Failure(ex) =>
+            // Take out the garbage
+            composite -= permit
+            self.onError(ex)
+          case _ =>
+        }
+
+        // As noted already, the back-pressure happening here
+        // is solely on `semaphore.acquire()`, see above
+        ack.syncTryFlatten
+      }
+    }
+
+    def onError(ex: Throwable): Unit = {
+      if (!isDone) {
+        isDone = true
+        lastAck = Stop
+        // clear elements from queue
+        queue.dequeueAll(_ => true)
+        // Outsourcing the handling and safety of onError
+        // to our concurrent buffer implementation
+        buffer.onError(ex)
+      }
+    }
+
+    def onComplete(): Unit = {
+      // We need to wait for all semaphore permits to be
+      // released, otherwise we can lose events and that's
+      // not acceptable for onComplete!
+      semaphore.awaitAllReleased().foreach { _ =>
+        if (!isDone) {
+          isDone = true
+          lastAck = Stop
+          // Outsourcing the handling and safety of onComplete
+          // to our concurrent buffer implementation
+          buffer.onComplete()
+        }
+      }
+    }
+
+    def cancel(): Unit = {
+      // We are canceling permits as well, so this is necessary to prevent
+      // `onComplete` / `onError` signals from main subscriber
+      isDone = true
+      composite.cancel()
+    }
+  }
+
+}

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapParallelOrderedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapParallelOrderedSuite.scala
@@ -1,0 +1,393 @@
+/*
+ * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.reactive.internal.operators
+
+import cats.laws._
+import cats.laws.discipline._
+import monix.eval.Task
+import monix.execution.Ack.Continue
+import monix.execution.exceptions.DummyException
+import monix.execution.internal.Platform
+import monix.reactive.{Observable, Observer, OverflowStrategy}
+
+import scala.concurrent.Promise
+import scala.concurrent.duration._
+import scala.util.{Failure, Random}
+
+object MapParallelOrderedSuite extends BaseOperatorSuite {
+
+  def createObservable(sourceCount: Int) = {
+    Some {
+      val o = Observable.range(0, sourceCount).mapParallelOrdered(parallelism = 4)(x => Task(x))
+      Sample(o, count(sourceCount), sum(sourceCount), waitFirst, waitNext)
+    }
+  }
+
+  def sum(sourceCount: Int) =
+    sourceCount * (sourceCount - 1) / 2
+
+  def count(sourceCount: Int) =
+    sourceCount
+
+  def waitFirst = Duration.Zero
+
+  def waitNext = Duration.Zero
+
+  def observableInError(sourceCount: Int, ex: Throwable) = None
+
+  def brokenUserCodeObservable(sourceCount: Int, ex: Throwable) = None
+
+  override def cancelableObservables(): Seq[Sample] = {
+    Seq.empty
+    val sample1 = Observable.range(1, 100)
+      .mapParallelOrdered(parallelism = 4)(x => Task.now(x).delayExecution(1.second))
+    val sample2 = Observable.range(0, 100).delayOnNext(1.second)
+      .mapParallelOrdered(parallelism = 4)(x => Task.now(x).delayExecution(1.second))
+
+    Seq(
+      Sample(sample1, 0, 0, 0.seconds, 0.seconds),
+      Sample(sample1, 4, 10, 1.seconds, 0.seconds),
+      Sample(sample2, 0, 0, 0.seconds, 0.seconds),
+      Sample(sample2, 0, 0, 1.seconds, 0.seconds)
+    )
+  }
+
+  test("should preserve ordering") { implicit s =>
+    val list = List(5, 4, 3, 2, 1)
+    var counterList = List[Int]()
+
+    Observable.fromIterable(list)
+      .mapParallelOrdered(parallelism = 4)(x => Task.now(x).delayExecution(x.second))
+      .foreach(counterList ::= _)
+
+    assertEquals(counterList, List[Int]())
+    s.tick(4.second)
+    assertEquals(counterList, List[Int]())
+    s.tick(1.second)
+    assertEquals(counterList, List[Int](1, 2, 3, 4, 5))
+  }
+
+  test("should execute in parallel") { implicit s =>
+    val list = List(1, 2)
+    var counter = 0
+
+    Observable.fromIterable(list)
+      .mapParallelOrdered(parallelism = 4)(x => Task {
+        counter += 1
+        x
+      }.delayExecution(1.second))
+      .toListL
+      .runAsync
+
+    assertEquals(counter, 0)
+    s.tick(1.second)
+    assertEquals(counter, 2)
+  }
+
+  test("should work for synchronous observers") { implicit s =>
+    val randomCount = Random.nextInt(300) + 100
+
+    for (sourceCount <- List(0, 1, 2, 3, 4, 5, randomCount)) {
+      var received = 0
+      var total = 0L
+
+      val obs = Observable.range(0, sourceCount).mapParallelOrdered(parallelism = 4)(x => Task.now(x))
+      obs.unsafeSubscribeFn(new Observer[Long] {
+        private[this] var sum = 0L
+
+        def onNext(elem: Long) = {
+          received += 1
+          sum += elem
+          Continue
+        }
+
+        def onError(ex: Throwable): Unit =
+          throw new IllegalStateException()
+
+        def onComplete(): Unit =
+          total = sum
+      })
+
+      s.tick()
+      assertEquals(received, count(sourceCount))
+      assertEquals(total, sum(sourceCount))
+    }
+  }
+
+  test("should work for asynchronous observers") { implicit s =>
+    val randomCount = Random.nextInt(300) + 100
+
+    for (sourceCount <- List(0, 1, 2, 3, 4, 5, randomCount)) {
+      var received = 0
+      var total = 0L
+
+      val obs = Observable.range(0, sourceCount).mapParallelOrdered(parallelism = 4)(x => Task(x))
+      obs.unsafeSubscribeFn(new Observer[Long] {
+        private[this] var sum = 0L
+
+        def onNext(elem: Long) = {
+          received += 1
+          sum += elem
+          Continue
+        }
+
+        def onError(ex: Throwable): Unit =
+          throw new IllegalStateException()
+
+        def onComplete(): Unit =
+          total = sum
+      })
+
+      s.tick()
+      assertEquals(received, count(sourceCount))
+      assertEquals(total, sum(sourceCount))
+    }
+  }
+
+  test("mapParallelOrdered equivalence with map") { implicit s =>
+    check2 { (list: List[Int], isAsync: Boolean) =>
+      val received = Observable.fromIterable(list)
+        .mapParallelOrdered(parallelism = 4)(x => if (isAsync) Task(x + 10) else Task.eval(x + 10))
+        .toListL
+        .map(_.sorted)
+
+      val expected = Observable.fromIterable(list).map(_ + 10).toListL.map(_.sorted)
+      received <-> expected
+    }
+  }
+
+  test("mapParallelOrdered(parallelism = 1) equivalence with mapTask") { implicit s =>
+    check2 { (list: List[Int], isAsync: Boolean) =>
+      val received = Observable.fromIterable(list)
+        .mapParallelOrdered(parallelism = 1)(x => if (isAsync) Task(x + 10) else Task.eval(x + 10))
+        .toListL
+
+      val expected = Observable.fromIterable(list)
+        .mapTask(x => if (isAsync) Task(x + 10) else Task.eval(x + 10))
+        .toListL
+
+      received <-> expected
+    }
+  }
+
+  test("should interrupt the streaming on error, test #1") { implicit s =>
+    val dummy = DummyException("dummy")
+    var isComplete = false
+    var wasThrown: Throwable = null
+    var received = 0L
+
+    val task1 = Task(1L)
+    val task2 = Task.raiseError[Long](dummy)
+    val task3 = Task.never[Long]
+    val tasks = List.fill(8)(task1) ::: List(task2) ::: List.fill(10)(task3)
+
+    Observable.fromIterable(tasks).mapParallelOrdered(parallelism = 4)(x => x)
+      .unsafeSubscribeFn(new Observer[Long] {
+        def onNext(elem: Long) = {
+          assert(!isComplete, "!isComplete")
+          received += elem
+          Continue
+        }
+
+        def onError(ex: Throwable) = {
+          assert(!isComplete, "!isComplete")
+          isComplete = true
+          wasThrown = ex
+        }
+
+        def onComplete() = {
+          isComplete = true
+          throw new IllegalStateException("onComplete")
+        }
+      })
+
+    s.tick()
+    assertEquals(wasThrown, dummy)
+  }
+
+  test("should interrupt the streaming on error, test #2") { implicit s =>
+    val dummy = DummyException("dummy")
+    var isComplete = false
+    var wasThrown: Throwable = null
+    var received = 0L
+
+    val task1 = Task(1L)
+    val tasks = List.fill(8)(task1)
+
+    Observable.fromIterable(tasks).endWithError(dummy).mapParallelOrdered(parallelism = 4)(x => x)
+      .unsafeSubscribeFn(new Observer[Long] {
+        def onNext(elem: Long) = {
+          assert(!isComplete, "!isComplete")
+          received += elem
+          Continue
+        }
+
+        def onError(ex: Throwable) = {
+          assert(!isComplete, "!isComplete")
+          isComplete = true
+          wasThrown = ex
+        }
+
+        def onComplete() = {
+          isComplete = true
+          throw new IllegalStateException("onComplete")
+        }
+      })
+
+    s.tick()
+    assertEquals(wasThrown, dummy)
+  }
+
+  test("should protect against user error") { implicit s =>
+    val dummy = DummyException("dummy")
+    var isComplete = false
+    var wasThrown: Throwable = null
+    var received = 0L
+
+    Observable.range(0, 100)
+      .mapParallelOrdered(parallelism = 4)(x => if (x >= 50) throw dummy else Task(x))
+      .unsafeSubscribeFn(new Observer[Long] {
+        def onNext(elem: Long) = {
+          assert(!isComplete, "!isComplete")
+          received += elem
+          Continue
+        }
+
+        def onError(ex: Throwable) = {
+          assert(!isComplete, "!isComplete")
+          isComplete = true
+          wasThrown = ex
+        }
+
+        def onComplete() = {
+          isComplete = true
+          throw new IllegalStateException("onComplete")
+        }
+      })
+
+    s.tick()
+    assertEquals(wasThrown, dummy)
+  }
+
+  test("should back-pressure on semaphore") { implicit s =>
+    var initiated = 0
+    var received = 0
+    var isComplete = false
+    val p = Promise[Int]()
+
+    val tasks = List.fill(8)(Task.fromFuture(p.future))
+    Observable(tasks: _*).doOnNext(_ => initiated += 1)
+      .mapParallelOrdered(parallelism = 4)(x => x)
+      .unsafeSubscribeFn(new Observer[Int] {
+        def onNext(elem: Int) = {
+          received += 1
+          Continue
+        }
+
+        def onError(ex: Throwable): Unit =
+          throw ex
+
+        def onComplete(): Unit =
+          isComplete = true
+      })
+
+    s.tick()
+    assertEquals(initiated, 5)
+    assertEquals(received, 0)
+    assert(!isComplete, "!isComplete")
+
+    p.success(1)
+    s.tick()
+    assertEquals(initiated, 8)
+    assertEquals(received, 8)
+    assert(isComplete, "isComplete")
+  }
+
+  test("should respect custom overflow strategy") { implicit s =>
+    var initiated = 0
+    var received = 0
+    var isComplete = false
+    val p = Promise[Continue.type]()
+    val totalCount = Platform.recommendedBatchSize * 4
+
+    Observable.range(0, totalCount)
+      .doOnNext(_ => initiated += 1)
+      .mapParallelOrdered(parallelism = 4)(x => Task(x))(OverflowStrategy.DropNew(Platform.recommendedBatchSize))
+      .unsafeSubscribeFn(new Observer[Long] {
+        def onNext(elem: Long) = {
+          received += 1
+          p.future
+        }
+
+        def onError(ex: Throwable): Unit =
+          throw ex
+
+        def onComplete(): Unit =
+          isComplete = true
+      })
+
+    s.tick()
+    assertEquals(initiated, totalCount)
+    assertEquals(received, 1)
+    assert(!isComplete, "!isComplete")
+
+    p.success(Continue)
+    s.tick()
+    assertEquals(initiated, totalCount)
+    assertEquals(received, Platform.recommendedBatchSize + 2) // The rest were dropped from the buffer
+    assert(isComplete, "isComplete")
+  }
+
+  test("should be cancelable after the main stream has ended") { implicit s =>
+    val f = Observable.now(1)
+      .mapParallelOrdered(parallelism = 4)(x => Task(x + 1).delayExecution(1.second))
+      .sumL
+      .runAsync
+
+    s.tick()
+    assertEquals(f.value, None)
+    assert(s.state.tasks.nonEmpty, "tasks.nonEmpty")
+
+    f.cancel()
+    s.tick()
+    assertEquals(f.value, None)
+    assert(s.state.tasks.isEmpty, "tasks.isEmpty")
+  }
+
+  test("exceptions can be triggered synchronously by throw") { implicit s =>
+    val dummy = DummyException("dummy")
+    val source = Observable.now(1L).mapParallelOrdered(parallelism = 4)(_ => throw dummy)
+
+    val f = source.runAsyncGetLast
+    s.tick()
+
+    assertEquals(f.value, Some(Failure(dummy)))
+    assertEquals(s.state.lastReportedError, null)
+  }
+
+  test("exceptions can be triggered synchronously through raiseError") { implicit s =>
+    val dummy = DummyException("dummy")
+    val source = Observable.now(1).mapParallelOrdered(parallelism = 4)(_ => Task.raiseError(dummy))
+
+    val f = source.runAsyncGetLast
+    s.tick()
+
+    assertEquals(f.value, Some(Failure(dummy)))
+    assertEquals(s.state.lastReportedError, null)
+  }
+}


### PR DESCRIPTION
Closes #329 

This is my first attempt.
Tests are the same as for ```Observable#mapParallelUnordered``` minus backpressuring on buffer and I've added test for parallel processing and preserving order. 

It passes all of the test cases so that looks good but it is pretty likely I've got lost in proper cancelation, cleaning resources etc despite basing implementation on ```Observable#mapParallelUnordered```. :)

Things to consider:

- After my experience with default ```mutable.Queue``` in #509 I think we might need to use something else to get easiest boost in performance. Probably dedicated solution. Right now it is probably best to have anything working but I think this operator will be used a lot so we will have to tune its performance sooner or later.
- Sempahore is released as soon as computation is complete - not after getting ack from downstream. This is because there might be situation when we have ```parallelism = 1000``` and 999 tasks are idle but the first element is still doing some work, "wasting" time. I think it can lead to higher memory consumption but better throughput but that's the tradeoff to make. It should probably be limited with some kind of ```BlockingQueue``` so it doesn't consume memory forever if oldest task never finish.

I need to come back to this code after I clear my head but in the meantime I'm opening PR so you could see how is my progress. :)