### PR TITLE
Issue #563 - completeL should handle F[_] errors, mapEval should not

### DIFF
--- a/monix-tail/shared/src/test/scala/monix/tail/IterantCompleteLSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantCompleteLSuite.scala
@@ -41,26 +41,45 @@ object IterantCompleteLSuite extends BaseTestSuite {
   test("BatchCursor.completeL protects against errors") { implicit s =>
     val dummy = DummyException("dummy")
     val cursor = ThrowExceptionCursor[Int](dummy)
+    var earlyStop = false
 
     val fa = Iterant[Coeval].nextCursorS(
       cursor,
       Coeval(Iterant[Coeval].empty[Int]),
-      Coeval.unit
+      Coeval { earlyStop = true }
     )
 
     assertEquals(fa.completeL.runTry, Failure(dummy))
+    assert(earlyStop, "earlyStop")
   }
 
   test("Batch.completeL protects against errors") { implicit s =>
     val dummy = DummyException("dummy")
     val batch = ThrowExceptionBatch[Int](dummy)
+    var earlyStop = false
 
     val fa = Iterant[Coeval].nextBatchS(
       batch,
       Coeval(Iterant[Coeval].empty[Int]),
-      Coeval.unit
+      Coeval { earlyStop = true }
     )
 
     assertEquals(fa.completeL.runTry, Failure(dummy))
+    assert(earlyStop, "earlyStop")
+  }
+
+  test("earlyStop gets called for failing `rest` on Next node") { implicit s =>
+    var effect = 0
+
+    def stop(i: Int): Coeval[Unit] =
+      Coeval { effect = i }
+
+    val dummy = new DummyException("dummy")
+    val node3 = Iterant[Coeval].nextS(3, Coeval.raiseError(dummy), stop(3))
+    val node2 = Iterant[Coeval].nextS(2, Coeval(node3), stop(2))
+    val node1 = Iterant[Coeval].nextS(1, Coeval(node2), stop(1))
+
+    assertEquals(node1.completeL.runTry, Failure(dummy))
+    assertEquals(effect, 3)
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"     % "0.6.21")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"     % "0.6.22")
 addSbtPlugin("com.jsuereth"       % "sbt-pgp"         % "1.1.0")
 addSbtPlugin("com.eed3si9n"       % "sbt-unidoc"      % "0.4.1")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh"         % "0.3.2")


### PR DESCRIPTION
Related to #563 — fixed `completeL` with a reasonable penalty for doing that error handling, due to mutating a plain var.

In case of this loop, it doesn't matter due to the inner workings of the loop being suspended and completely encapsulated. However this isn't an optimization that we can afford to do for operations returning `Iterant`.

Therefore, except for operations meant specifically for error handling, like `onErrorHandlingWith`, the errors raised in the `F[_]` context should get handled by folding operations (ending with the `L` suffix), one of which being `completeL`.