### PR TITLE
Add Iterant#sumL method

### DIFF
--- a/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
@@ -1717,6 +1717,15 @@ sealed abstract class Iterant[F[_], A] extends Product with Serializable {
   final def skipSuspendL(implicit F: Sync[F]): F[Iterant[F, A]] =
     IterantSkipSuspend(self)
 
+  /** Given evidence that type `A` has a `scala.math.Numeric` implementation,
+    * sums the stream of elements.
+    *
+    * An alternative to [[foldL]] which does not require any imports and works
+    * in cases `cats.Monoid` is not defined for values (e.g. `A = Char`)
+    */
+  final def sumL(implicit F: Sync[F], A: Numeric[A]): F[A] =
+    foldLeftL(A.zero)(A.plus)
+
   /** Aggregates all elements in a `List` and preserves order.
     *
     * Example: {{{

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantFoldLeftSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantFoldLeftSuite.scala
@@ -221,6 +221,12 @@ object IterantFoldLeftSuite extends BaseTestSuite {
     }
   }
 
+  test("Iterant[Coeval, Int].sumL is consistent with foldLeftL") { implicit s =>
+    check1 { (stream: Iterant[Coeval, Int]) =>
+      stream.sumL <-> stream.foldLeftL(0)(_ + _)
+    }
+  }
+
   test("Iterant.countL consistent with List.length") { implicit s =>
     check2 { (list: List[Int], idx: Int) =>
       val i = arbitraryListToIterant[Coeval, Int](list, idx, allowErrors = false)


### PR DESCRIPTION
Closes #570

This was easy. Although the only type that has `Numeric`, but not `Monoid` out of the box is `Char`.