### PR TITLE
Iterant.reduce and headOptionL error handling

### DIFF
--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFoldLeft.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFoldLeft.scala
@@ -51,6 +51,7 @@ private[tail] object IterantFoldLeft {
           stopRef.elem = stop
           rest.flatMap(loop(stopRef, state))
         case Last(item) =>
+          stopRef.elem = null.asInstanceOf[F[Unit]]
           F.pure(op(state,item))
         case Halt(None) =>
           F.pure(state)

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantReduce.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantReduce.scala
@@ -23,69 +23,95 @@ import cats.effect.Sync
 import monix.execution.misc.NonFatal
 import monix.tail.Iterant.{Halt, Last, Next, NextBatch, NextCursor, Suspend}
 
+import scala.runtime.ObjectRef
+
 private[tail] object IterantReduce {
   /** Implementation for `Iterant.reduce`. */
   def apply[F[_], A](self: Iterant[F, A], op: (A, A) => A)
     (implicit F: Sync[F]): F[Option[A]] = {
 
-    def loop(state: A)(self: Iterant[F, A]): F[A] = {
+    def loop(stopRef: ObjectRef[F[Unit]], state: A)(self: Iterant[F, A]): F[A] = {
       try self match {
-        case Next(a, rest, _) =>
+        case Next(a, rest, stop) =>
+          stopRef.elem = stop
           val newState = op(state, a)
-          rest.flatMap(loop(newState))
-        case NextCursor(cursor, rest, _) =>
+          rest.flatMap(loop(stopRef, newState))
+        case NextCursor(cursor, rest, stop) =>
+          stopRef.elem = stop
           val newState = cursor.foldLeft(state)(op)
-          rest.flatMap(loop(newState))
-        case NextBatch(gen, rest, _) =>
+          rest.flatMap(loop(stopRef, newState))
+        case NextBatch(gen, rest, stop) =>
+          stopRef.elem = stop
           val newState = gen.foldLeft(state)(op)
-          rest.flatMap(loop(newState))
-        case Suspend(rest, _) =>
-          rest.flatMap(loop(state))
+          rest.flatMap(loop(stopRef, newState))
+        case Suspend(rest, stop) =>
+          stopRef.elem = stop
+          rest.flatMap(loop(stopRef, state))
         case Last(item) =>
-          F.pure(op(state,item))
+          stopRef.elem = null.asInstanceOf[F[Unit]]
+          F.pure(op(state, item))
         case Halt(None) =>
           F.pure(state)
         case Halt(Some(e)) =>
+          stopRef.elem = null.asInstanceOf[F[Unit]]
           F.raiseError(e)
       } catch {
         case e if NonFatal(e) =>
-          self.earlyStop *> F.raiseError(e)
+          F.raiseError(e)
       }
     }
 
-    def start(self: Iterant[F, A]): F[Option[A]] = {
+    def start(stopRef: ObjectRef[F[Unit]])(self: Iterant[F, A]): F[Option[A]] = {
       try self match {
-        case Next(a, rest, _) =>
-          rest.flatMap(loop(a)).map(Some.apply)
+        case Next(a, rest, stop) =>
+          stopRef.elem = stop
+          rest.flatMap(loop(stopRef, a)).map(Some.apply)
 
-        case NextCursor(cursor, rest, _) =>
+        case NextCursor(cursor, rest, stop) =>
+          stopRef.elem = stop
           if (!cursor.hasNext())
-            rest.flatMap(start)
+            rest.flatMap(start(stopRef))
           else {
             val a = cursor.next()
-            loop(a)(self).map(Some.apply)
+            loop(stopRef, a)(self).map(Some.apply)
           }
 
         case NextBatch(batch, rest, stop) =>
-          start(NextCursor(batch.cursor(), rest, stop))
+          stopRef.elem = stop
+          start(stopRef)(NextCursor(batch.cursor(), rest, stop))
 
-        case Suspend(rest, _) =>
-          rest.flatMap(start)
+        case Suspend(rest, stop) =>
+          stopRef.elem = stop
+          rest.flatMap(start(stopRef))
 
         case Last(a) =>
+          stopRef.elem = null.asInstanceOf[F[Unit]]
           F.pure(Some(a))
 
         case Halt(opt) =>
           opt match {
-            case None => F.pure(None)
-            case Some(e) => F.raiseError(e)
+            case None =>
+              F.pure(None)
+            case Some(e) =>
+              stopRef.elem = null.asInstanceOf[F[Unit]]
+              F.raiseError(e)
           }
       } catch {
         case e if NonFatal(e) =>
-          self.earlyStop *> F.raiseError(e)
+          F.raiseError(e)
       }
     }
 
-    F.suspend(start(self))
+    F.suspend{
+      // Reference to keep track of latest `earlyStop` value
+      val stopRef = ObjectRef.create(null.asInstanceOf[F[Unit]])
+      // Catch-all exceptions, ensuring latest `earlyStop` gets called
+      F.handleErrorWith(start(stopRef)(self)){ ex =>
+        stopRef.elem match {
+          case null => F.raiseError(ex)
+          case stop => stop *> F.raiseError(ex)
+        }
+      }
+    }
   }
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantFoldLeftSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantFoldLeftSuite.scala
@@ -241,4 +241,17 @@ object IterantFoldLeftSuite extends BaseTestSuite {
     assertEquals(effect, 3)
   }
 
+  test("earlyStop doesn't get called for Last node") { implicit s =>
+    var effect = 0
+
+    def stop(i: Int): Coeval[Unit] = Coeval { effect = i}
+    val dummy = DummyException("dummy")
+    val node3 = Iterant[Coeval].lastS(3)
+    val node2 = Iterant[Coeval].nextS(2, Coeval(node3), stop(2))
+    val node1 = Iterant[Coeval].nextS(1, Coeval(node2), stop(1))
+
+    assertEquals(node1.foldLeftL(0)((_, el) => if (el == 3) throw dummy else el).runTry, Failure(dummy))
+    assertEquals(effect, 0)
+  }
+
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantHeadOptionSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantHeadOptionSuite.scala
@@ -23,6 +23,8 @@ import monix.eval.{Coeval, Task}
 import monix.execution.exceptions.DummyException
 import monix.tail.batches.{Batch, BatchCursor}
 
+import scala.util.Failure
+
 object IterantHeadOptionSuite extends BaseTestSuite {
   test("Iterant.headOptionL <-> List.headOption") { _ =>
     check2 { (list: List[Int], idx: Int) =>
@@ -60,10 +62,35 @@ object IterantHeadOptionSuite extends BaseTestSuite {
     val dummy = DummyException("dummy")
     val iter1: Iterant[Task, Int] = Iterant[Task].haltS(Some(dummy))
     val state1 = iter1.headOptionL
-    assertEquals(state1, Task.raiseError[Option[Int]](dummy))
+    val f = state1.runAsync
 
-    val iter2: Iterant[Task, Int] = Iterant[Task].haltS(None)
-    val state2 = iter2.headOptionL
-    assertEquals(state2, Task.pure(None))
+    s.tick()
+    assertEquals(f.value, Some(Failure(dummy)))
+  }
+
+  test("Iterant.headOption earlyStop gets called for failing `rest` on Next node") { implicit s =>
+    var effect = 0
+
+    def stop(i: Int): Coeval[Unit] = Coeval { effect = i}
+    val dummy = DummyException("dummy")
+    val node3 = Iterant[Coeval].suspendS[Int](Coeval.raiseError(dummy), stop(3))
+    val node2 = Iterant[Coeval].suspendS[Int](Coeval(node3), stop(2))
+    val node1 = Iterant[Coeval].suspendS[Int](Coeval(node2), stop(1))
+
+    assertEquals(node1.headOptionL.runTry, Failure(dummy))
+    assertEquals(effect, 3)
+  }
+
+  test("protects against broken batches as first node") { implicit s =>
+    var effect = 0
+    val dummy = DummyException("dummy")
+
+    val fa = Iterant[Coeval].nextBatchS[Int](ThrowExceptionBatch(dummy), Coeval(Iterant[Coeval].empty), Coeval.unit)
+      .doOnEarlyStop(Coeval { effect += 1 })
+      .headOptionL
+
+    assertEquals(effect, 0)
+    assertEquals(fa.runTry, Failure(dummy))
+    assertEquals(effect, 1)
   }
 }


### PR DESCRIPTION
Fixes #577.

That leaves us with:
```scala
final def skipSuspendL(implicit F: Sync[F]): F[Iterant[F, A]]
final def foldRightL[B](b: F[B])(f: (A, F[B], F[Unit]) => F[B])(implicit F: Sync[F]): F[B]
```

We leave `foldRightL` as it is, right?