### PR TITLE
Improve strictness of Eq of Iterants / fix doOnFinish on Last

### DIFF
--- a/monix-eval/shared/src/test/scala/monix/eval/BaseLawsSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/BaseLawsSuite.scala
@@ -17,6 +17,8 @@
 
 package monix.eval
 
+import scala.util.Try
+
 import cats.Eq
 import cats.effect.IO
 import monix.execution.Cancelable
@@ -124,11 +126,7 @@ trait ArbitraryInstancesBase extends monix.execution.ArbitraryInstances {
   implicit def equalityCoeval[A](implicit A: Eq[A]): Eq[Coeval[A]] =
     new Eq[Coeval[A]] {
       def eqv(lh: Coeval[A], rh: Coeval[A]): Boolean = {
-        val valueA = lh.runTry
-        val valueB = rh.runTry
-
-        (valueA.isFailure && valueB.isFailure) ||
-          A.eqv(valueA.get, valueB.get)
+        Eq[Try[A]].eqv(lh.runTry, rh.runTry)
       }
     }
 

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantStop.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantStop.scala
@@ -60,9 +60,8 @@ private[tail] object IterantStop {
         NextBatch(items, rest.map(doOnFinish[F, A](_, f)), stop.flatMap(_ => f(None)))
       case Suspend(rest, stop) =>
         Suspend(rest.map(doOnFinish[F, A](_, f)), stop.flatMap(_ => f(None)))
-      case last @ Last(_) =>
-        val ref = f(None)
-        Suspend[F,A](F.map(ref)(_ => last), ref)
+      case Last(item) =>
+        Next(item, F.delay(doOnFinish(Halt(None), f)), F.suspend(f(None)))
       case halt @ Halt(ex) =>
         val ref = f(ex)
         Suspend[F,A](F.map(ref)(_ => halt), ref)

--- a/monix-tail/shared/src/test/scala/monix/tail/ArbitraryInstances.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/ArbitraryInstances.scala
@@ -18,6 +18,7 @@
 package monix.tail
 
 import cats.Eq
+import cats.syntax.eq._
 import cats.effect.{IO, Sync}
 import monix.eval.{Coeval, Task}
 import monix.execution.exceptions.DummyException
@@ -88,33 +89,26 @@ trait ArbitraryInstances extends monix.eval.ArbitraryInstances {
         arbitraryListToIterant[IO, A](source.reverse, math.abs(i))
     }
 
-  implicit def isEqIterantCoeval[A](implicit A: Eq[List[A]]): Eq[Iterant[Coeval, A]] =
+  implicit def isEqIterantCoeval[A](implicit A: Eq[A]): Eq[Iterant[Coeval, A]] =
     new Eq[Iterant[Coeval, A]] {
       def eqv(lh: Iterant[Coeval,  A], rh: Iterant[Coeval,  A]): Boolean = {
-        val valueA = lh.toListL.runTry
-        val valueB = rh.toListL.runTry
-
-        (valueA.isFailure && valueB.isFailure) || {
-          val la = valueA.get
-          val lb = valueB.get
-          A.eqv(la, lb)
-        }
+        lh.attempt.toListL === rh.attempt.toListL
       }
     }
 
-  implicit def isEqIterantTask[A](implicit A: Eq[List[A]]): Eq[Iterant[Task, A]] =
+  implicit def isEqIterantTask[A](implicit A: Eq[A]): Eq[Iterant[Task, A]] =
     new Eq[Iterant[Task, A]] {
       def eqv(lh: Iterant[Task,  A], rh: Iterant[Task,  A]): Boolean = {
         implicit val s = TestScheduler()
-        equalityTask[List[A]].eqv(lh.toListL, rh.toListL)
+        lh.attempt.toListL === rh.attempt.toListL
       }
     }
 
-  implicit def isEqIterantIO[A](implicit A: Eq[List[A]]): Eq[Iterant[IO, A]] =
+  implicit def isEqIterantIO[A](implicit A: Eq[A]): Eq[Iterant[IO, A]] =
     new Eq[Iterant[IO, A]] {
       def eqv(lh: Iterant[IO,  A], rh: Iterant[IO,  A]): Boolean = {
         implicit val s = TestScheduler()
-        equalityIO[List[A]].eqv(lh.toListL, rh.toListL)
+        lh.attempt.toListL === rh.attempt.toListL
       }
     }
 

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantDoOnFinishSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantDoOnFinishSuite.scala
@@ -152,7 +152,7 @@ object IterantDoOnFinishSuite extends BaseTestSuite {
     check1 { (stream: Iterant[Coeval, Int]) =>
       val dummy = DummyException("dummy")
       val received = stream.doOnFinish(_ => throw dummy)
-      received <-> Iterant[Coeval].raiseError(dummy)
+      received <-> stream.onErrorIgnore ++ Iterant[Coeval].raiseError[Int](dummy)
     }
   }
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantDropLastSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantDropLastSuite.scala
@@ -40,7 +40,7 @@ object IterantDropLastSuite extends BaseTestSuite {
       val suffix = Iterant[Task].nextBatchS[Int](new ThrowExceptionBatch(dummy), Task.now(Iterant[Task].empty), Task.unit)
       val stream = iter.onErrorIgnore ++ suffix
       val received = stream.dropLast(10)
-      received <-> Iterant[Task].haltS[Int](Some(dummy))
+      received <-> iter.onErrorIgnore.dropLast(10) ++ Iterant[Task].haltS[Int](Some(dummy))
     }
   }
 
@@ -50,7 +50,7 @@ object IterantDropLastSuite extends BaseTestSuite {
       val suffix = Iterant[Task].nextCursorS[Int](new ThrowExceptionCursor(dummy), Task.now(Iterant[Task].empty), Task.unit)
       val stream = iter.onErrorIgnore ++ suffix
       val received = stream.dropLast(10)
-      received <-> Iterant[Task].haltS[Int](Some(dummy))
+      received <-> iter.onErrorIgnore.dropLast(10) ++ Iterant[Task].haltS[Int](Some(dummy))
     }
   }
 

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantDumpSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantDumpSuite.scala
@@ -21,7 +21,6 @@ import java.io.{OutputStream, PrintStream}
 
 import cats.laws._
 import cats.laws.discipline._
-
 import monix.eval.{Coeval, Task}
 import monix.execution.atomic.AtomicInt
 import monix.execution.exceptions.DummyException
@@ -145,20 +144,22 @@ object IterantDumpSuite extends BaseTestSuite {
   test("Iterant.dump protects against broken batches") { implicit s =>
     check1 { (iter: Iterant[Task, Int]) =>
       val dummy = DummyException("dummy")
+      val prefix = iter.onErrorIgnore
       val suffix = Iterant[Task].nextBatchS[Int](new ThrowExceptionBatch(dummy), Task.now(Iterant[Task].empty), Task.unit)
-      val stream = iter.onErrorIgnore ++ suffix
+      val stream = prefix ++ suffix
 
-      stream.dump("O", dummyOut(AtomicInt(0))) <-> Iterant[Task].haltS[Int](Some(dummy))
+      stream.dump("O", dummyOut(AtomicInt(0))) <-> prefix ++ Iterant[Task].haltS[Int](Some(dummy))
     }
   }
 
   test("Iterant.dump protects against broken cursors") { implicit s =>
     check1 { (iter: Iterant[Task, Int]) =>
       val dummy = DummyException("dummy")
+      val prefix = iter.onErrorIgnore
       val suffix = Iterant[Task].nextCursorS[Int](new ThrowExceptionCursor(dummy), Task.now(Iterant[Task].empty), Task.unit)
-      val stream = iter.onErrorIgnore ++ suffix
+      val stream = prefix ++ suffix
 
-      stream.dump("O", dummyOut(AtomicInt(0))) <-> Iterant[Task].haltS[Int](Some(dummy))
+      stream.dump("O", dummyOut(AtomicInt(0))) <-> prefix ++ Iterant[Task].haltS[Int](Some(dummy))
     }
   }
 

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantFlatMapSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantFlatMapSuite.scala
@@ -164,7 +164,7 @@ object IterantFlatMapSuite extends BaseTestSuite {
       val cursor = new ThrowExceptionCursor(dummy)
       val error = Iterant[Task].nextCursorS(cursor, Task.now(Iterant[Task].empty[Int]), Task.unit)
       val stream = (prefix.onErrorIgnore ++ error).flatMap(x => Iterant[Task].now(x))
-      stream <-> Iterant[Task].haltS[Int](Some(dummy))
+      stream <-> prefix.onErrorIgnore ++ Iterant[Task].haltS[Int](Some(dummy))
     }
   }
 
@@ -174,7 +174,7 @@ object IterantFlatMapSuite extends BaseTestSuite {
       val generator = new ThrowExceptionBatch(dummy)
       val error = Iterant[Task].nextBatchS(generator, Task.now(Iterant[Task].empty[Int]), Task.unit)
       val stream = (prefix.onErrorIgnore ++ error).flatMap(x => Iterant[Task].now(x))
-      stream <-> Iterant[Task].haltS[Int](Some(dummy))
+      stream <-> prefix.onErrorIgnore ++ Iterant[Task].haltS[Int](Some(dummy))
     }
   }
 
@@ -300,7 +300,7 @@ object IterantFlatMapSuite extends BaseTestSuite {
       val cursor = new ThrowExceptionCursor(dummy)
       val error = Iterant[Coeval].nextCursorS(cursor, Coeval.now(Iterant[Coeval].empty[Int]), Coeval.unit)
       val stream = (prefix.onErrorIgnore ++ error).flatMap(x => Iterant[Coeval].now(x))
-      stream <-> Iterant[Coeval].haltS[Int](Some(dummy))
+      stream <-> prefix.onErrorIgnore ++ Iterant[Coeval].haltS[Int](Some(dummy))
     }
   }
 
@@ -310,7 +310,7 @@ object IterantFlatMapSuite extends BaseTestSuite {
       val cursor = new ThrowExceptionBatch(dummy)
       val error = Iterant[Coeval].nextBatchS(cursor, Coeval.now(Iterant[Coeval].empty[Int]), Coeval.unit)
       val stream = (prefix ++ error).flatMap(x => Iterant[Coeval].now(x))
-      stream <-> Iterant[Coeval].haltS[Int](Some(dummy))
+      stream <-> prefix ++ Iterant[Coeval].haltS[Int](Some(dummy))
     }
   }
 

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantMapEvalSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantMapEvalSuite.scala
@@ -140,7 +140,7 @@ object IterantMapEvalSuite extends BaseTestSuite {
       val cursor = new ThrowExceptionCursor(dummy)
       val error = Iterant[Task].nextCursorS(cursor, Task.now(Iterant[Task].empty[Int]), Task.unit)
       val stream = (prefix.onErrorIgnore ++ error).mapEval(x => Task.now(x))
-      stream <-> Iterant[Task].haltS[Int](Some(dummy))
+      stream <-> prefix.onErrorIgnore ++ Iterant[Task].haltS[Int](Some(dummy))
     }
   }
 
@@ -150,7 +150,7 @@ object IterantMapEvalSuite extends BaseTestSuite {
       val cursor = new ThrowExceptionBatch(dummy)
       val error = Iterant[Task].nextBatchS(cursor, Task.now(Iterant[Task].empty[Int]), Task.unit)
       val stream = (prefix.onErrorIgnore ++ error).mapEval(x => Task.now(x))
-      stream <-> Iterant[Task].haltS[Int](Some(dummy))
+      stream <-> prefix.onErrorIgnore ++ Iterant[Task].haltS[Int](Some(dummy))
     }
   }
 
@@ -244,7 +244,7 @@ object IterantMapEvalSuite extends BaseTestSuite {
       val cursor: BatchCursor[Int] = new ThrowExceptionCursor(dummy)
       val error = Iterant[Coeval].nextCursorS(cursor, Coeval.now(Iterant[Coeval].empty[Int]), Coeval.unit)
       val stream = (prefix ++ error).mapEval(x => Coeval.now(x))
-      stream <-> Iterant[Coeval].haltS[Int](Some(dummy))
+      stream <-> prefix ++ Iterant[Coeval].haltS[Int](Some(dummy))
     }
   }
 
@@ -254,7 +254,7 @@ object IterantMapEvalSuite extends BaseTestSuite {
       val cursor: Batch[Int] = new ThrowExceptionBatch(dummy)
       val error = Iterant[Coeval].nextBatchS(cursor, Coeval.now(Iterant[Coeval].empty[Int]), Coeval.unit)
       val stream = (prefix ++ error).mapEval(x => Coeval.now(x))
-      stream <-> Iterant[Coeval].haltS[Int](Some(dummy))
+      stream <-> prefix ++ Iterant[Coeval].haltS[Int](Some(dummy))
     }
   }
 

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantMapSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantMapSuite.scala
@@ -85,7 +85,7 @@ object IterantMapSuite extends BaseTestSuite {
       val cursor = new ThrowExceptionCursor(dummy)
       val error = Iterant[Task].nextCursorS(cursor, Task.now(Iterant[Task].empty[Int]), Task.unit)
       val stream = (prefix.onErrorIgnore ++ error).map(x => x)
-      stream <-> Iterant[Task].haltS[Int](Some(dummy))
+      stream <-> prefix.onErrorIgnore ++ Iterant[Task].haltS[Int](Some(dummy))
     }
   }
 
@@ -95,7 +95,7 @@ object IterantMapSuite extends BaseTestSuite {
       val cursor = new ThrowExceptionBatch(dummy)
       val error = Iterant[Task].nextBatchS(cursor, Task.now(Iterant[Task].empty[Int]), Task.unit)
       val stream = (prefix.onErrorIgnore ++ error).map(x => x)
-      stream <-> Iterant[Task].haltS[Int](Some(dummy))
+      stream <-> prefix.onErrorIgnore ++ Iterant[Task].haltS[Int](Some(dummy))
     }
   }
 
@@ -150,7 +150,7 @@ object IterantMapSuite extends BaseTestSuite {
       val cursor: BatchCursor[Int] = new ThrowExceptionCursor(dummy)
       val error = Iterant[Coeval].nextCursorS(cursor, Coeval.now(Iterant[Coeval].empty[Int]), Coeval.unit)
       val stream = (prefix ++ error).map(x => x)
-      stream <-> Iterant[Coeval].haltS[Int](Some(dummy))
+      stream <-> prefix ++ Iterant[Coeval].haltS[Int](Some(dummy))
     }
   }
 
@@ -160,7 +160,7 @@ object IterantMapSuite extends BaseTestSuite {
       val cursor: Batch[Int] = new ThrowExceptionBatch(dummy)
       val error = Iterant[Coeval].nextBatchS(cursor, Coeval.now(Iterant[Coeval].empty[Int]), Coeval.unit)
       val stream = (prefix ++ error).map(x => x)
-      stream <-> Iterant[Coeval].haltS[Int](Some(dummy))
+      stream <-> prefix ++ Iterant[Coeval].haltS[Int](Some(dummy))
     }
   }
 

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantOnErrorSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantOnErrorSuite.scala
@@ -83,7 +83,7 @@ object IterantOnErrorSuite extends BaseTestSuite {
       val cursor = new ThrowExceptionCursor(dummy)
       val error = Iterant[Task].nextCursorS(cursor, Task.now(Iterant[Task].empty[Int]), Task.unit)
       val stream = (prefix.onErrorIgnore ++ error).onErrorHandleWith(ex => Iterant[Task].haltS[Int](Some(ex)))
-      stream <-> Iterant[Task].haltS[Int](Some(dummy))
+      stream <-> prefix.onErrorIgnore ++ Iterant[Task].haltS[Int](Some(dummy))
     }
   }
 

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantRepeatSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantRepeatSuite.scala
@@ -47,7 +47,7 @@ object IterantRepeatSuite extends BaseTestSuite {
       val suffix = Iterant[Task].nextBatchS[Int](new ThrowExceptionBatch(dummy), Task.now(Iterant[Task].empty), Task.unit)
       val stream = iter.onErrorIgnore ++ suffix
       val received = stream.repeat
-      received <-> Iterant[Task].haltS[Int](Some(dummy))
+      received <-> iter.onErrorIgnore ++ Iterant[Task].haltS[Int](Some(dummy))
     }
   }
 
@@ -57,7 +57,7 @@ object IterantRepeatSuite extends BaseTestSuite {
       val suffix = Iterant[Task].nextCursorS[Int](new ThrowExceptionCursor(dummy), Task.now(Iterant[Task].empty), Task.unit)
       val stream = iter.onErrorIgnore ++ suffix
       val received = stream.repeat
-      received <-> Iterant[Task].haltS[Int](Some(dummy))
+      received <-> iter.onErrorIgnore ++ Iterant[Task].haltS[Int](Some(dummy))
     }
   }
 

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantSkipSuspendSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantSkipSuspendSuite.scala
@@ -48,7 +48,7 @@ object IterantSkipSuspendSuite extends BaseTestSuite {
       val suffix = Iterant[Task].nextBatchS[Int](new ThrowExceptionBatch(dummy), Task.now(Iterant[Task].empty), Task.unit)
       val stream = iter.onErrorIgnore ++ suffix
       val received = stream.skipSuspendL
-      Iterant[Task].suspend(received) <-> Iterant[Task].haltS[Int](Some(dummy))
+      Iterant[Task].suspend(received) <-> iter.onErrorIgnore ++ Iterant[Task].haltS[Int](Some(dummy))
     }
   }
 
@@ -58,7 +58,7 @@ object IterantSkipSuspendSuite extends BaseTestSuite {
       val suffix = Iterant[Task].nextCursorS[Int](new ThrowExceptionCursor(dummy), Task.now(Iterant[Task].empty), Task.unit)
       val stream = iter.onErrorIgnore ++ suffix
       val received = stream.skipSuspendL
-      Iterant[Task].suspend(received) <-> Iterant[Task].haltS[Int](Some(dummy))
+      Iterant[Task].suspend(received) <-> iter.onErrorIgnore ++ Iterant[Task].haltS[Int](Some(dummy))
     }
   }
 

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantTailSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantTailSuite.scala
@@ -40,7 +40,7 @@ object IterantTailSuite extends BaseTestSuite {
       val suffix = Iterant[Task].nextBatchS[Int](new ThrowExceptionBatch(dummy), Task.now(Iterant[Task].empty), Task.unit)
       val stream = iter.onErrorIgnore ++ suffix
       val received = stream.tail
-      received <-> Iterant[Task].haltS[Int](Some(dummy))
+      received <-> iter.onErrorIgnore.tail ++ Iterant[Task].haltS[Int](Some(dummy))
     }
   }
 
@@ -50,7 +50,7 @@ object IterantTailSuite extends BaseTestSuite {
       val suffix = Iterant[Task].nextCursorS[Int](new ThrowExceptionCursor(dummy), Task.now(Iterant[Task].empty), Task.unit)
       val stream = iter.onErrorIgnore ++ suffix
       val received = stream.tail
-      received <-> Iterant[Task].haltS[Int](Some(dummy))
+      received <-> iter.onErrorIgnore.tail ++ Iterant[Task].haltS[Int](Some(dummy))
     }
   }
 

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantTakeEveryNthSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantTakeEveryNthSuite.scala
@@ -79,7 +79,7 @@ object IterantTakeEveryNthSuite extends BaseTestSuite {
       val suffix = Iterant[Task].nextBatchS[Int](new ThrowExceptionBatch(dummy), Task.now(Iterant[Task].empty), Task.unit)
       val stream = iter.onErrorIgnore ++ suffix
       val received = stream.takeEveryNth(1)
-      received <-> Iterant[Task].haltS[Int](Some(dummy))
+      received <-> iter.onErrorIgnore ++ Iterant[Task].haltS[Int](Some(dummy))
     }
   }
 
@@ -89,7 +89,7 @@ object IterantTakeEveryNthSuite extends BaseTestSuite {
       val suffix = Iterant[Task].nextCursorS[Int](new ThrowExceptionCursor(dummy), Task.now(Iterant[Task].empty), Task.unit)
       val stream = iter.onErrorIgnore ++ suffix
       val received = stream.takeEveryNth(1)
-      received <-> Iterant[Task].haltS[Int](Some(dummy))
+      received <-> iter.onErrorIgnore ++ Iterant[Task].haltS[Int](Some(dummy))
     }
   }
 

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantTakeSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantTakeSuite.scala
@@ -73,7 +73,7 @@ object IterantTakeSuite extends BaseTestSuite {
       val suffix = Iterant[Task].nextBatchS[Int](new ThrowExceptionBatch(dummy), Task.now(Iterant[Task].empty), Task.unit)
       val stream = iter.onErrorIgnore ++ suffix
       val received = stream.take(Int.MaxValue)
-      received <-> Iterant[Task].haltS[Int](Some(dummy))
+      received <-> iter.onErrorIgnore ++ Iterant[Task].haltS[Int](Some(dummy))
     }
   }
 
@@ -83,7 +83,7 @@ object IterantTakeSuite extends BaseTestSuite {
       val suffix = Iterant[Task].nextCursorS[Int](new ThrowExceptionCursor(dummy), Task.now(Iterant[Task].empty), Task.unit)
       val stream = iter.onErrorIgnore ++ suffix
       val received = stream.take(Int.MaxValue)
-      received <-> Iterant[Task].haltS[Int](Some(dummy))
+      received <-> iter.onErrorIgnore ++ Iterant[Task].haltS[Int](Some(dummy))
     }
   }
 

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantTakeWhileSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantTakeWhileSuite.scala
@@ -81,7 +81,7 @@ object IterantTakeWhileSuite extends BaseTestSuite {
       val suffix = Iterant[Task].nextBatchS[Int](new ThrowExceptionBatch(dummy), Task.now(Iterant[Task].empty), Task.unit)
       val stream = iter.onErrorIgnore ++ suffix
       val received = stream.takeWhile(_ => true)
-      received <-> Iterant[Task].haltS[Int](Some(dummy))
+      received <-> iter.onErrorIgnore ++ Iterant[Task].haltS[Int](Some(dummy))
     }
   }
 
@@ -91,7 +91,7 @@ object IterantTakeWhileSuite extends BaseTestSuite {
       val suffix = Iterant[Task].nextCursorS[Int](new ThrowExceptionCursor(dummy), Task.now(Iterant[Task].empty), Task.unit)
       val stream = iter.onErrorIgnore ++ suffix
       val received = stream.takeWhile(_ => true)
-      received <-> Iterant[Task].haltS[Int](Some(dummy))
+      received <-> iter.onErrorIgnore ++ Iterant[Task].haltS[Int](Some(dummy))
     }
   }
 

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantTakeWhileWithIndexSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantTakeWhileWithIndexSuite.scala
@@ -97,7 +97,7 @@ object IterantTakeWhileWithIndexSuite extends BaseTestSuite {
       val suffix = Iterant[Task].nextBatchS[Int](new ThrowExceptionBatch(dummy), Task.now(Iterant[Task].empty), Task.unit)
       val stream = iter.onErrorIgnore ++ suffix
       val received = stream.takeWhileWithIndex((_, _) => true)
-      received <-> Iterant[Task].haltS[Int](Some(dummy))
+      received <-> iter.onErrorIgnore ++ Iterant[Task].haltS[Int](Some(dummy))
     }
   }
 
@@ -107,7 +107,7 @@ object IterantTakeWhileWithIndexSuite extends BaseTestSuite {
       val suffix = Iterant[Task].nextCursorS[Int](new ThrowExceptionCursor(dummy), Task.now(Iterant[Task].empty), Task.unit)
       val stream = iter.onErrorIgnore ++ suffix
       val received = stream.takeWhileWithIndex((_, _) => true)
-      received <-> Iterant[Task].haltS[Int](Some(dummy))
+      received <-> iter.onErrorIgnore ++ Iterant[Task].haltS[Int](Some(dummy))
     }
   }
 

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantZipWithIndexSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantZipWithIndexSuite.scala
@@ -68,7 +68,7 @@ object IterantZipWithIndexSuite extends BaseTestSuite {
       val suffix = Iterant[Task].nextBatchS[Int](new ThrowExceptionBatch(dummy), Task.now(Iterant[Task].empty), Task.unit)
       val stream = iter.onErrorIgnore ++ suffix
       val received = stream.zipWithIndex
-      received <-> Iterant[Task].haltS[(Int, Long)](Some(dummy))
+      received <-> iter.onErrorIgnore.zipWithIndex ++ Iterant[Task].haltS[(Int, Long)](Some(dummy))
     }
   }
 
@@ -78,7 +78,7 @@ object IterantZipWithIndexSuite extends BaseTestSuite {
       val suffix = Iterant[Task].nextCursorS[Int](new ThrowExceptionCursor(dummy), Task.now(Iterant[Task].empty), Task.unit)
       val stream = iter.onErrorIgnore ++ suffix
       val received = stream.zipWithIndex
-      received <-> Iterant[Task].haltS[(Int, Long)](Some(dummy))
+      received <-> iter.onErrorIgnore.zipWithIndex ++ Iterant[Task].haltS[(Int, Long)](Some(dummy))
     }
   }
 


### PR DESCRIPTION
Closes #580.

Also discovered that `Iterant.doOnFinish` was behaving incorrectly on `Last` case: if a handler function throws, the element inside `Last` would never be emitted. E.g. this was the behavior:

    Iterant[IO].lastS(1).doOnFinish(_ => throw dummy).attempt <-> Iterant[IO].of(Left(dummy))

And now it is:

    Iterant[IO].lastS(1).doOnFinish(_ => throw dummy).attempt <-> Iterant[IO].of(Right(1), Left(dummy))