### PR TITLE
Fix potential nontermination in Observable.zip[Map]3

### DIFF
--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip2Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip2Suite.scala
@@ -29,7 +29,7 @@ import scala.concurrent.duration._
 object Zip2Suite extends BaseOperatorSuite {
   def createObservable(sourceCount: Int) = Some {
     val o1 = Observable.range(0, sourceCount)
-    val o2 = Observable.range(0, sourceCount)
+    val o2 = Observable.range(0, sourceCount + 2)
 
     val o = Observable.zipMap2(o1, o2) { (x1, x2) => x1 + x2 }
     Sample(o, count(sourceCount), sum(sourceCount), Zero, Zero)

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip3Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip3Suite.scala
@@ -24,8 +24,8 @@ import scala.concurrent.duration.Duration.Zero
 object Zip3Suite extends BaseOperatorSuite {
   def createObservable(sourceCount: Int) = Some {
     val o1 = Observable.range(0, sourceCount).executeAsync
-    val o2 = Observable.range(0, sourceCount).executeAsync
-    val o3 = Observable.range(0, sourceCount).executeAsync
+    val o2 = Observable.range(0, sourceCount + 1).executeAsync
+    val o3 = Observable.range(0, sourceCount + 2).executeAsync
 
     val o = Observable.zipMap3(o1,o2,o3)(_+_+_)
     Sample(o, count(sourceCount), sum(sourceCount), Zero, Zero)

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip4Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip4Suite.scala
@@ -24,9 +24,9 @@ import scala.concurrent.duration.Duration._
 object Zip4Suite extends BaseOperatorSuite {
   def createObservable(sourceCount: Int) = Some {
     val o1 = Observable.range(0, sourceCount).executeAsync
-    val o2 = Observable.range(0, sourceCount).executeAsync
-    val o3 = Observable.range(0, sourceCount).executeAsync
-    val o4 = Observable.range(0, sourceCount).executeAsync
+    val o2 = Observable.range(0, sourceCount + 1).executeAsync
+    val o3 = Observable.range(0, sourceCount + 2).executeAsync
+    val o4 = Observable.range(0, sourceCount + 3).executeAsync
 
     val o = Observable.zipMap4(o1,o2,o3,o4)(_+_+_+_)
     Sample(o, count(sourceCount), sum(sourceCount), Zero, Zero)

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip5Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip5Suite.scala
@@ -24,10 +24,10 @@ import scala.concurrent.duration.Duration.Zero
 object Zip5Suite extends BaseOperatorSuite {
   def createObservable(sourceCount: Int) = Some {
     val o1 = Observable.range(0, sourceCount).executeAsync
-    val o2 = Observable.range(0, sourceCount).executeAsync
-    val o3 = Observable.range(0, sourceCount).executeAsync
-    val o4 = Observable.range(0, sourceCount).executeAsync
-    val o5 = Observable.range(0, sourceCount).executeAsync
+    val o2 = Observable.range(0, sourceCount + 1).executeAsync
+    val o3 = Observable.range(0, sourceCount + 2).executeAsync
+    val o4 = Observable.range(0, sourceCount + 3).executeAsync
+    val o5 = Observable.range(0, sourceCount + 4).executeAsync
 
     val o = Observable.zipMap5(o1,o2,o3,o4,o5)(_+_+_+_+_)
     Sample(o, count(sourceCount), sum(sourceCount), Zero, Zero)

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip6Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip6Suite.scala
@@ -24,11 +24,11 @@ import scala.concurrent.duration.Duration.Zero
 object Zip6Suite extends BaseOperatorSuite {
   def createObservable(sourceCount: Int) = Some {
     val o1 = Observable.range(0, sourceCount).executeAsync
-    val o2 = Observable.range(0, sourceCount).executeAsync
-    val o3 = Observable.range(0, sourceCount).executeAsync
-    val o4 = Observable.range(0, sourceCount).executeAsync
-    val o5 = Observable.range(0, sourceCount).executeAsync
-    val o6 = Observable.range(0, sourceCount).executeAsync
+    val o2 = Observable.range(0, sourceCount + 1).executeAsync
+    val o3 = Observable.range(0, sourceCount + 2).executeAsync
+    val o4 = Observable.range(0, sourceCount + 3).executeAsync
+    val o5 = Observable.range(0, sourceCount + 4).executeAsync
+    val o6 = Observable.range(0, sourceCount + 5).executeAsync
 
     val o = Observable.zipMap6(o1,o2,o3,o4,o5,o6)(_+_+_+_+_+_)
     Sample(o, count(sourceCount), sum(sourceCount), Zero, Zero)


### PR DESCRIPTION
Fixes #590 

This needs to be replicated for other `zipMapX` operators, but I want some feedback first :)

The behavior expected for zipped observable is to complete as soon as any single of zipped stream completes, which is totally not what current implementation does. Before this fix, it would complete only if one of streams called `onComplete` not concurrently with `onNext` or, if neither did, when all streams called `onComplete`. Waiting for all streams would result on non-termination when backpressuring, as a zipped one would never emit its next result, or would attempt to resolve same promise twice, concurrently.

Tests didn't catch this because they only use equally sized observables.