### PR TITLE
Add Sync & Async instances for Iterant

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ addCommandAlias("ci-js",      ";clean ;coreJS/test:compile  ;coreJS/test")
 addCommandAlias("release",    ";project monix ;+clean ;+package ;+publishSigned ;sonatypeReleaseAll")
 
 val catsVersion = "1.0.1"
-val catsEffectVersion = "0.8"
+val catsEffectVersion = "0.9"
 val jcToolsVersion = "2.1.1"
 val reactiveStreamsVersion = "1.0.2"
 val scalaTestVersion = "3.0.4"

--- a/monix-tail/shared/src/test/scala/monix/tail/TypeClassLawsForIterantCoevalSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/TypeClassLawsForIterantCoevalSuite.scala
@@ -19,7 +19,8 @@ package monix.tail
 
 import cats.Eq
 import cats.data.EitherT
-import cats.laws.discipline.{CoflatMapTests, MonadErrorTests, MonoidKTests, SemigroupalTests}
+import cats.effect.laws.discipline.SyncTests
+import cats.laws.discipline.{CoflatMapTests, MonoidKTests, SemigroupalTests}
 import monix.eval.Coeval
 
 object TypeClassLawsForIterantCoevalSuite extends BaseLawsSuite {
@@ -33,9 +34,9 @@ object TypeClassLawsForIterantCoevalSuite extends BaseLawsSuite {
   val eqEitherT: Eq[EitherT[F, Throwable, Int]] =
     implicitly[Eq[EitherT[F, Throwable, Int]]]
 
-  checkAllAsync("MonadError[Iterant[Coeval], Throwable]") { implicit ec =>
+  checkAllAsync("Sync[Iterant[Coeval]]") { implicit ec =>
     implicit val eqE = eqEitherT
-    MonadErrorTests[F, Throwable].monadError[Int, Int, Int]
+    SyncTests[F].sync[Int, Int, Int]
   }
 
   checkAllAsync("MonoidK[Iterant[Coeval]]") { implicit ec =>

--- a/monix-tail/shared/src/test/scala/monix/tail/TypeClassLawsForIterantIOSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/TypeClassLawsForIterantIOSuite.scala
@@ -20,7 +20,8 @@ package monix.tail
 import cats.Eq
 import cats.data.EitherT
 import cats.effect.IO
-import cats.laws.discipline.{CoflatMapTests, MonadErrorTests, MonoidKTests, SemigroupalTests}
+import cats.effect.laws.discipline.AsyncTests
+import cats.laws.discipline.{CoflatMapTests, MonoidKTests, SemigroupalTests}
 
 object TypeClassLawsForIterantIOSuite extends BaseLawsSuite {
   type F[α] = Iterant[IO, α]
@@ -33,9 +34,9 @@ object TypeClassLawsForIterantIOSuite extends BaseLawsSuite {
   val eqEitherT: Eq[EitherT[F, Throwable, Int]] =
     implicitly[Eq[EitherT[F, Throwable, Int]]]
 
-  checkAllAsync("MonadError[Iterant[IO], Throwable]") { implicit ec =>
+  checkAllAsync("Async[Iterant[IO]]") { implicit ec =>
     implicit val eqE = eqEitherT
-    MonadErrorTests[F, Throwable].monadError[Int, Int, Int]
+    AsyncTests[F].async[Int, Int, Int]
   }
 
   checkAllAsync("MonoidK[Iterant[IO]]") { implicit ec =>

--- a/monix-tail/shared/src/test/scala/monix/tail/TypeClassLawsForIterantTaskSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/TypeClassLawsForIterantTaskSuite.scala
@@ -19,7 +19,8 @@ package monix.tail
 
 import cats.Eq
 import cats.data.EitherT
-import cats.laws.discipline.{CoflatMapTests, MonadErrorTests, MonoidKTests, SemigroupalTests}
+import cats.effect.laws.discipline.AsyncTests
+import cats.laws.discipline.{CoflatMapTests, MonoidKTests, SemigroupalTests}
 import monix.eval.Task
 
 object TypeClassLawsForIterantTaskSuite extends BaseLawsSuite {
@@ -33,9 +34,9 @@ object TypeClassLawsForIterantTaskSuite extends BaseLawsSuite {
   val eqEitherT: Eq[EitherT[F, Throwable, Int]] =
     implicitly[Eq[EitherT[F, Throwable, Int]]]
 
-  checkAllAsync("MonadError[Iterant[Task], Throwable]") { implicit ec =>
+  checkAllAsync("Async[Iterant[Task]]") { implicit ec =>
     implicit val eqE = eqEitherT
-    MonadErrorTests[F, Throwable].monadError[Int, Int, Int]
+    AsyncTests[F].async[Int, Int, Int]
   }
 
   checkAllAsync("MonoidK[Iterant[Task]]") { implicit ec =>


### PR DESCRIPTION
Closes #599 

I went ahead and implemented `Async` instance too (under the assumption that callback will only be invoked once, so it just delegates to underlying `F`). Couldn't do `Effect` though in a similar way, because signature of `runAsync` sort-of implies cardinality of 1.