### PR TITLE
Observable.scan0 & friends

### DIFF
--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -1352,9 +1352,20 @@ abstract class Observable[+A] extends Serializable { self =>
     * producing and concatenating observables along the way.
     *
     * It's the combination between [[scan]] and [[flatMap]].
+    *
+    * @see [[flatScan0]] for the version that emits seed element at the beginning
     */
   final def flatScan[R](seed: => R)(op: (R, A) => Observable[R]): Observable[R] =
     new FlatScanObservable[A, R](self, seed _, op, delayErrors = false)
+
+  /** Applies a binary operator to a start value and to elements
+    * produced by the source observable, going from left to right,
+    * producing and concatenating observables along the way.
+    *
+    * It's the combination between [[scan0]] and [[flatMap]].
+    */
+  final def flatScan0[R](seed: => R)(op: (R, A) => Observable[R]): Observable[R] =
+    Observable.eval(seed).flatMap(s => s +: flatScan(s)(op))
 
   /** Applies a binary operator to a start value and to elements
     * produced by the source observable, going from left to right,
@@ -1367,6 +1378,18 @@ abstract class Observable[+A] extends Serializable { self =>
     */
   final def flatScanDelayErrors[R](seed: => R)(op: (R, A) => Observable[R]): Observable[R] =
     new FlatScanObservable[A, R](self, seed _, op, delayErrors = true)
+
+  /** Applies a binary operator to a start value and to elements
+    * produced by the source observable, going from left to right,
+    * producing and concatenating observables along the way.
+    *
+    * This version of [[flatScan0]] delays all errors until `onComplete`,
+    * when it will finally emit a
+    * [[monix.execution.exceptions.CompositeException CompositeException]].
+    * It's the combination between [[scan0]] and [[flatMapDelayErrors]].
+    */
+  final def flatScan0DelayErrors[R](seed: => R)(op: (R, A) => Observable[R]): Observable[R] =
+    Observable.eval(seed).flatMap(s => s +: flatScanDelayErrors(s)(op))
 
   /** $concatDescription
     *
@@ -2021,9 +2044,22 @@ abstract class Observable[+A] extends Serializable { self =>
     *
     * Similar to [[foldLeftF]], but emits the state on each
     * step. Useful for modeling finite state machines.
+    *
+    * @see [[scan0]] for the version that emits seed element at the beginning
     */
   final def scan[S](seed: => S)(op: (S, A) => S): Observable[S] =
     new ScanObservable[A, S](self, seed _, op)
+
+  /** Applies a binary operator to a start value and all elements of
+    * this Observable, going left to right and returns a new
+    * Observable that emits on each step the result of the applied
+    * function.
+    *
+    * This is a version of [[scan]] that emits seed element at the beginning,
+    * similar to `scanLeft` on Scala collections
+    */
+  final def scan0[S](seed: => S)(op: (S, A) => S): Observable[S] =
+    Observable.eval(seed).flatMap(s => s +: scan(s)(op))
 
   /** Applies a binary operator to a start value and all elements of
     * this stream, going left to right and returns a new stream that
@@ -2069,6 +2105,8 @@ abstract class Observable[+A] extends Serializable { self =>
     *     .collect { case Current(a, _) => a }
     * }}}
     *
+    * @see [[scanEval0]] for the version that emits seed element at the beginning
+    *
     * @see [[scan]] for the synchronous, non-lazy version, or
     *      [[scanTask]] for the [[monix.eval.Task Task]]-specialized
     *      version.
@@ -2086,6 +2124,16 @@ abstract class Observable[+A] extends Serializable { self =>
     */
   final def scanEval[F[_], S](seed: F[S])(op: (S, A) => F[S])(implicit F: Effect[F]): Observable[S] =
     scanTask(Task.fromEffect(seed)(F))((s, a) => Task.fromEffect(op(s, a))(F))
+
+/** Applies a binary operator to a start value and all elements of
+  * this stream, going left to right and returns a new stream that
+  * emits on each step the result of the applied function.
+  *
+  * This is a version of [[scanEval]] that emits seed element at the beginning,
+  * similar to `scanLeft` on Scala collections
+  */
+  final def scanEval0[F[_], S](seed: F[S])(op: (S, A) => F[S])(implicit F: Effect[F]): Observable[S] =
+    Observable.fromEffect(seed).flatMap(s => s +: scanEval(F.pure(s))(op))
 
   /** Given a mapping function that returns a `B` type for which we have
     * a [[cats.Monoid]] instance, returns a new stream that folds the incoming
@@ -2115,6 +2163,17 @@ abstract class Observable[+A] extends Serializable { self =>
     */
   final def scanMap[B](f: A => B)(implicit B: Monoid[B]): Observable[B] =
     self.scan(B.empty)((acc, a) => B.combine(acc, f(a)))
+
+  /** Given a mapping function that returns a `B` type for which we have
+    * a [[cats.Monoid]] instance, returns a new stream that folds the incoming
+    * elements of the sources using the provided `Monoid[B].combine`, with the
+    * initial seed being the `Monoid[B].empty` value, emitting the generated values
+    * at each step.
+    *
+    * This is a version of [[scanMap]] that emits seed element at the beginning.
+    */
+  final def scanMap0[B](f: A => B)(implicit B: Monoid[B]): Observable[B] =
+    B.empty +: scanMap(f)
 
   /** Applies a binary operator to a start value and all elements of
     * this stream, going left to right and returns a new stream that
@@ -2156,6 +2215,7 @@ abstract class Observable[+A] extends Serializable { self =>
     *     .collect { case Current(a, _) => a }
     * }}}
     *
+    * @see [[scanTask0]] for the version that emits seed element at the beginning
     * @see [[scan]] for the version that does not require using `Task`
     *      in the provided operator
     *
@@ -2167,6 +2227,15 @@ abstract class Observable[+A] extends Serializable { self =>
     */
   final def scanTask[S](seed: Task[S])(op: (S, A) => Task[S]): Observable[S] =
     new ScanTaskObservable(self, seed, op)
+
+  /** Applies a binary operator to a start value and all elements of
+    * this stream, going left to right and returns a new stream that
+    * emits on each step the result of the applied function.
+    *
+    * This is a version of [[scanTask]] that emits seed element at the beginning.
+    */
+  final def scanTask0[S](seed: Task[S])(op: (S, A) => Task[S]): Observable[S] =
+    Observable.fromTask(seed).flatMap(s => s +: scanTask(Task.pure(s))(op))
 
   /** Creates a new Observable that emits the given elements and then
     * it also emits the events of the source (prepend operation).

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ScanEffectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ScanEffectSuite.scala
@@ -17,6 +17,8 @@
 
 package monix.reactive.internal.operators
 
+import cats.laws._
+import cats.laws.discipline._
 import cats.effect.IO
 import monix.reactive.Observable
 import scala.concurrent.duration._
@@ -67,5 +69,18 @@ object ScanEffectSuite extends BaseOperatorSuite {
       Sample(sample, 0, 0, 0.seconds, 0.seconds),
       Sample(sample, 1, 1, 1.seconds, 0.seconds)
     )
+  }
+
+
+  test("scanEval0.headL.toIO <-> seed") { implicit s =>
+    check2 { (obs: Observable[Int], seed: IO[Int]) =>
+      obs.scanEval0(seed)((a, b) => IO.pure(a + b)).headL.toIO <-> seed
+    }
+  }
+
+  test("scanEval0.drop(1) <-> scanEval") { implicit s =>
+    check2 { (obs: Observable[Int], seed: IO[Int]) =>
+      obs.scanEval0(seed)((a, b) => IO.pure(a + b)).drop(1) <-> obs.scanEval(seed)((a, b) => IO.pure(a + b))
+    }
   }
 }

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ScanMapSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ScanMapSuite.scala
@@ -17,6 +17,10 @@
 
 package monix.reactive.internal.operators
 
+import cats.Monoid
+import cats.laws._
+import cats.laws.discipline._
+import monix.eval.Task
 import monix.reactive.{BaseTestSuite, Observable}
 
 object ScanMapSuite extends BaseTestSuite {
@@ -28,5 +32,17 @@ object ScanMapSuite extends BaseTestSuite {
     val f2 = obs2.runAsyncGetLast
     s.tick()
     assertEquals(f1.value, f2.value)
+  }
+
+  test("Observable.scanMap0.drop(1) <-> Observable.scanMap") { implicit s =>
+    check1 { (obs: Observable[Int]) =>
+      obs.scanMap0(x => x).drop(1) <-> obs.scanMap(x => x)
+    }
+  }
+
+  test("Observable.scanMap0 emits empty element as head") { implicit s =>
+    check1 { (obs: Observable[Int]) =>
+      obs.scanMap0(x => x).headL <-> Task.pure(Monoid[Int].empty)
+    }
   }
 }

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ScanTaskSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ScanTaskSuite.scala
@@ -19,6 +19,9 @@ package monix.reactive.internal.operators
 
 import java.util.concurrent.TimeUnit
 
+import cats.laws._
+import cats.laws.discipline._
+
 import monix.eval.Task
 import monix.execution.exceptions.DummyException
 import monix.reactive.Observable
@@ -216,5 +219,17 @@ object ScanTaskSuite extends BaseOperatorSuite {
     assertEquals(f.value, None)
     assert(s.state.tasks.isEmpty, "tasks.isEmpty")
     assertEquals(s.state.lastReportedError, dummy)
+  }
+
+  test("scanTask0.headL <-> seed") { implicit s =>
+    check2 { (obs: Observable[Int], seed: Task[Int]) =>
+      obs.scanTask0(seed)((a, b) => Task.pure(a + b)).headL <-> seed
+    }
+  }
+
+  test("scanTask0.drop(1) <-> scanTask") { implicit s =>
+    check2 { (obs: Observable[Int], seed: Task[Int]) =>
+      obs.scanTask0(seed)((a, b) => Task.pure(a + b)).drop(1) <-> obs.scanTask(seed)((a, b) => Task.pure(a + b))
+    }
   }
 }


### PR DESCRIPTION
Alternative to #587

I went ahead and made versions that emit seed element for all scan operators that exist for `Observable`.