### PR TITLE
Add scan0, scanEval0 & scanMap0 for Iterant

### DIFF
--- a/monix-tail/shared/src/test/scala/monix/tail/IterantScanEvalSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantScanEvalSuite.scala
@@ -102,4 +102,18 @@ object IterantScanEvalSuite extends BaseTestSuite {
     assertEquals(r.value, List(Left(dummy)))
     assertEquals(effect, 1)
   }
+
+  test("scanEval0 emits seed as first element") { implicit s =>
+    check2 { (source: Iterant[Coeval, Int], seed: Coeval[Int]) =>
+      source.scanEval0(seed)((a, b) => Coeval.pure(a + b)).headOptionL <->
+        seed.map(Some(_))
+    }
+  }
+
+  test("scanEval0.drop(1) <-> scanEval") { implicit s =>
+    check2 { (source: Iterant[Coeval, Int], seed: Coeval[Int]) =>
+      source.scanEval0(seed)((a, b) => Coeval.pure(a + b)).drop(1) <->
+        source.scanEval(seed)((a, b) => Coeval.pure(a + b))
+    }
+  }
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantScanMapSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantScanMapSuite.scala
@@ -17,6 +17,7 @@
 
 package monix.tail
 
+import cats.Monoid
 import cats.laws._
 import cats.laws.discipline._
 import monix.eval.Coeval
@@ -35,6 +36,12 @@ object IterantScanMapSuite extends BaseTestSuite {
         .takeWhile(_ < 10)
 
       fa1.toListL <-> fa2.toListL
+    }
+  }
+
+  test("Iterant.scanMap0 starts with empty element") { implicit s =>
+    check1 { (source: Iterant[Coeval, Int]) =>
+      source.scanMap0(x => x).headOptionL <-> Coeval(Some(Monoid[Int].empty))
     }
   }
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantScanSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantScanSuite.scala
@@ -58,4 +58,16 @@ object IterantScanSuite extends BaseTestSuite {
     val r = fa.scan(0)((_, _) => throw dummy).attempt.toListL
     assertEquals(r.value, List(Left(dummy)))
   }
+
+  test("scan0 emits seed as first element") { implicit s =>
+    check2 { (source: Iterant[Coeval, Int], seed: Int) =>
+      source.scan0(seed)(_ + _).headOptionL <-> Coeval.pure(Some(seed))
+    }
+  }
+
+  test("scan0.drop(1) <-> scan") { implicit s =>
+    check2 { (source: Iterant[Coeval, Int], seed: Int) =>
+      source.scan0(seed)(_ + _).drop(1) <-> source.scan(seed)(_ + _)
+    }
+  }
 }


### PR DESCRIPTION
Closes #522 

With Iterant, it's possible to use `F.map` in combination with `Iterant.suspend` instead of `flatMap`