### PR TITLE
Add forever for Task

### DIFF
--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -1235,10 +1235,10 @@ sealed abstract class Task[+A] extends Serializable {
     foreachL(f).runAsync(s)
 
   /** Returns a new `Task` that executes the source repetitively
-    * and never produces a value.
+    * as long as it succeeds and never produces a value.
     */
-  final def forever: Task[Nothing] =
-    flatMap(_ => this.forever)
+  final def loopForever: Task[Nothing] =
+    flatMap(_ => this.loopForever)
 
   /** Start asynchronous execution of the source suspended in the `Task` context.
     *

--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -1234,8 +1234,17 @@ sealed abstract class Task[+A] extends Serializable {
   final def foreach(f: A => Unit)(implicit s: Scheduler): CancelableFuture[Unit] =
     foreachL(f).runAsync(s)
 
-  /** Returns a new `Task` that executes the source repetitively
-    * as long as it succeeds and never produces a value.
+  /** Returns a new `Task` that executes the source repeatedly,
+    * as long as it succeeds. It never produces a terminal value.
+    *
+    * Example:
+    *
+    * {{{
+    *   Task.eval(println("Tick!"))
+    *     .delayExecution(1.second)
+    *     .loopForever
+    * }}}
+    *
     */
   final def loopForever: Task[Nothing] =
     flatMap(_ => this.loopForever)

--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -1234,12 +1234,14 @@ sealed abstract class Task[+A] extends Serializable {
   final def foreach(f: A => Unit)(implicit s: Scheduler): CancelableFuture[Unit] =
     foreachL(f).runAsync(s)
 
-  /** Returns a new `Task` that executes the source repeatedly,
-    * as long as it succeeds. It never produces a terminal value.
+  /** Returns a new `Task` that repeatedly executes the source as long
+    * as it continues to succeed. It never produces a terminal value.
     *
     * Example:
     *
     * {{{
+    *   import scala.concurrent.duration._
+    *
     *   Task.eval(println("Tick!"))
     *     .delayExecution(1.second)
     *     .loopForever

--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -1234,6 +1234,12 @@ sealed abstract class Task[+A] extends Serializable {
   final def foreach(f: A => Unit)(implicit s: Scheduler): CancelableFuture[Unit] =
     foreachL(f).runAsync(s)
 
+  /** Returns a new `Task` that executes the source repetitively.
+    *
+    */
+  final def forever: Task[A] =
+    flatMap(_ => this.forever)
+
   /** Start asynchronous execution of the source suspended in the `Task` context.
     *
     * This can be used for non-deterministic / concurrent execution.

--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -1234,10 +1234,10 @@ sealed abstract class Task[+A] extends Serializable {
   final def foreach(f: A => Unit)(implicit s: Scheduler): CancelableFuture[Unit] =
     foreachL(f).runAsync(s)
 
-  /** Returns a new `Task` that executes the source repetitively.
-    *
+  /** Returns a new `Task` that executes the source repetitively
+    * and never produces a value.
     */
-  final def forever: Task[A] =
+  final def forever: Task[Nothing] =
     flatMap(_ => this.forever)
 
   /** Start asynchronous execution of the source suspended in the `Task` context.

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskMiscSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskMiscSuite.scala
@@ -53,6 +53,16 @@ object TaskMiscSuite extends BaseTestSuite {
     assertEquals(result.value, Some(Failure(ex)))
   }
 
+  test("Task.forever") { implicit s =>
+    val ex = DummyException("dummy")
+    var effect = 0
+    val result = Task.eval { if (effect < 10) effect += 1 else throw ex }
+      .loopForever
+      .onErrorFallbackTo(Task.eval(effect))
+      .runAsync
+    assertEquals(result.value.get.get, 10)
+  }
+
   test("Task.restartUntil") { implicit s =>
     var effect = 0
     val r = Task { effect += 1; effect }.restartUntil(_ >= 10).runAsync


### PR DESCRIPTION
Didn't see a method similar to this, correct me if I'm wrong. Basically, given a source Task, return another Task that continuously executes the source Task forever, until an error happens or cancelled. Will add better documentation and necessary tests if needed

My use case for this was in a producer/consumer system where a consumer takes something off a (blocking) queue, does some processing, and loops back.

What I had was something recursive like this:

```scala
def loop: Task[Unit] = {
  for {
    item <- Task.eval(queue.take())
    _       <- process(item)
    _       <- loop       
  } yield ()
}
```

which could be expressed as:

```scala
val task = for {
  item <- Task.eval(queue.take())
  _       <- process(item)
} yield ()

val loop = task.forever
```

Is this a good idea or is there something I'm missing about why it shouldn't be done or should be done another way?