### PR TITLE
Fix eagerness of .bracket on Last nodes

### DIFF
--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantBracket.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantBracket.scala
@@ -55,9 +55,10 @@ private[tail] object IterantBracket {
             earlyRelease(a) *> stop
           )
 
-        case h @ Last(_) =>
+        case Last(value) =>
+          val done = F.suspend(release(a, Completed))
           Suspend[F, B](
-            F.suspend(release(a, Completed)).as(h),
+            F.pure(Iterant.nextS(value, done.as(Halt(None)), earlyRelease(a))),
             earlyRelease(a)
           )
 


### PR DESCRIPTION
Fixes #632 

For `Last` nodes, the `release` was incorrectly called before yielding the value. Now the node constructed is `Next`, where `release` will only be called after the value was consumed.