### PR TITLE
Add ability to specify custom options on Effect[Task]

### DIFF
--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -3154,7 +3154,7 @@ private[eval] abstract class TaskInstancesLevel0 extends TaskParallelNewtype {
     * @param s is a [[monix.execution.Scheduler Scheduler]] that needs
     *        to be available in scope
     */
-  implicit def catsEffect(implicit s: Scheduler): CatsConcurrentEffectForTask =
+  implicit def catsEffect(implicit s: Scheduler, opts: Task.Options = Task.defaultOptions): CatsConcurrentEffectForTask =
     new CatsConcurrentEffectForTask
 
   /** Given an `A` type that has a `cats.Semigroup[A]` implementation,

--- a/monix-eval/shared/src/main/scala/monix/eval/instances/CatsEffectForTask.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/instances/CatsEffectForTask.scala
@@ -38,7 +38,7 @@ import monix.execution.Scheduler
   *  - [[https://typelevel.org/cats/ typelevel/cats]]
   *  - [[https://github.com/typelevel/cats-effect typelevel/cats-effect]]
   */
-class CatsEffectForTask(implicit s: Scheduler)
+class CatsEffectForTask(implicit s: Scheduler, opts: Task.Options)
   extends CatsBaseForTask with Effect[Task] {
 
   /** We need to mixin [[CatsAsyncForTask]], because if we
@@ -72,7 +72,7 @@ class CatsEffectForTask(implicit s: Scheduler)
   *  - [[https://typelevel.org/cats/ typelevel/cats]]
   *  - [[https://github.com/typelevel/cats-effect typelevel/cats-effect]]
   */
-class CatsConcurrentEffectForTask(implicit s: Scheduler)
+class CatsConcurrentEffectForTask(implicit s: Scheduler, opts: Task.Options)
   extends CatsEffectForTask with ConcurrentEffect[Task] {
 
   /** We need to mixin [[CatsAsyncForTask]], because if we

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskEffect.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskEffect.scala
@@ -69,20 +69,20 @@ private[eval] object TaskEffect {
     * `cats.effect.Effect#runAsync`
     */
   def runAsync[A](fa: Task[A])(cb: Either[Throwable, A] => IO[Unit])
-    (implicit s: Scheduler): IO[Unit] =
+    (implicit s: Scheduler, opts: Task.Options): IO[Unit] =
     IO { execute(fa, cb); () }
 
   /**
     * `cats.effect.ConcurrentEffect#runCancelable`
     */
   def runCancelable[A](fa: Task[A])(cb: Either[Throwable, A] => IO[Unit])
-    (implicit s: Scheduler): IO[IO[Unit]] =
+    (implicit s: Scheduler, opts: Task.Options): IO[IO[Unit]] =
     IO(execute(fa, cb).cancelIO)
 
   private def execute[A](fa: Task[A], cb: Either[Throwable, A] => IO[Unit])
-    (implicit s: Scheduler) = {
+    (implicit s: Scheduler, opts: Task.Options) = {
 
-    fa.runAsync(new Callback[A] {
+    fa.runAsyncOpt(new Callback[A] {
       private def signal(value: Either[Throwable, A]): Unit =
         try cb(value).unsafeRunAsync(noop)
         catch { case NonFatal(e) => s.reportFailure(e) }

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskEffectInstanceSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskEffectInstanceSuite.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval
+
+import cats.effect.{Effect, IO}
+
+import scala.concurrent.duration._
+
+object TaskEffectInstanceSuite extends BaseTestSuite {
+  test("Effect instance should make use of implicit TaskOptions") { implicit sc =>
+    val readOptions: Task[Task.Options] = Task.unsafeCreate { (ctx, cb) =>
+      cb.onSuccess(ctx.options)
+    }
+
+    implicit val customOptions: Task.Options = Task.Options(
+      autoCancelableRunLoops = true,
+      localContextPropagation = true
+    )
+
+    var received: Task.Options = null
+
+    val io = Effect[Task].runAsync(readOptions) {
+      case Right(opts) =>
+        received = opts
+        IO.unit
+      case _ =>
+        fail()
+        IO.unit
+    }
+
+    io.unsafeRunSync()
+    sc.tick(1.day)
+    assert(received eq customOptions)
+  }
+}


### PR DESCRIPTION
Closes #625.

I'm still thinking providing a default is not a good decision, but it seems we cannot provide an understandable message when implicit `Effect` is not found.