### PR TITLE
Fix Task.foreach waiting / error reporting

### DIFF
--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -1230,9 +1230,11 @@ sealed abstract class Task[+A] extends Serializable {
     *
     * The application of this function has strict behavior, as the
     * task is immediately executed.
+    *
+    * Exceptions in `f` are reported using provided (implicit) Scheduler
     */
-  final def foreach(f: A => Unit)(implicit s: Scheduler): CancelableFuture[Unit] =
-    foreachL(f).runAsync(s)
+  final def foreach(f: A => Unit)(implicit s: Scheduler): Unit =
+    runAsync.foreach(f)
 
   /** Returns a new `Task` that repeatedly executes the source as long
     * as it continues to succeed. It never produces a terminal value.

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskCoevalForeachSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskCoevalForeachSuite.scala
@@ -18,6 +18,7 @@
 package monix.eval
 
 import minitest.TestSuite
+import monix.execution.exceptions.DummyException
 import monix.execution.schedulers.TestScheduler
 
 object TaskCoevalForeachSuite extends TestSuite[TestScheduler] {
@@ -47,6 +48,13 @@ object TaskCoevalForeachSuite extends TestSuite[TestScheduler] {
     assertEquals(effect, 1)
     task.foreach(x => effect += x); s.tick()
     assertEquals(effect, 2)
+  }
+
+  test("Task.foreach reports exceptions using scheduler") { implicit s =>
+    val dummy = DummyException("dummy")
+    Task(1).foreach(_ => throw dummy)
+    s.tick()
+    assertEquals(s.state.lastReportedError, dummy)
   }
 
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EvalOnCompleteOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EvalOnCompleteOperator.scala
@@ -34,11 +34,11 @@ class EvalOnCompleteOperator[A](task: Task[Unit]) extends Operator[A,A] {
       def onError(ex: Throwable): Unit = out.onError(ex)
 
       def onComplete(): Unit =
-        task.attempt.foreach {
+        task.attempt.map {
           case Right(()) =>
             out.onComplete()
           case Left(ex) =>
             out.onError(ex)
-        }
+        }.runAsync
     }
 }


### PR DESCRIPTION
Partial fix for #619

By piggy-backing on stdlib Future methods, it's easy to get error reporting AND correct order of operations. It required the change in signature to return `Unit`, however.