### PR TITLE
Make Coeval.value empty-parens to indicate side effects

### DIFF
--- a/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalShallowBindBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalShallowBindBenchmark.scala
@@ -49,7 +49,7 @@ class CoevalShallowBindBenchmark {
       if (i < size) Coeval.now(i + 1).flatMap(loop)
       else Coeval.now(i)
 
-    Coeval.now(0).flatMap(loop).value
+    Coeval.now(0).flatMap(loop).value()
   }
 
   @Benchmark
@@ -60,6 +60,6 @@ class CoevalShallowBindBenchmark {
       if (i < size) Coeval.eval(i + 1).flatMap(loop)
       else Coeval.eval(i)
 
-    Coeval.eval(0).flatMap(loop).value
+    Coeval.eval(0).flatMap(loop).value()
   }
 }

--- a/monix-eval/js/src/main/scala/monix/eval/TaskApp.scala
+++ b/monix-eval/js/src/main/scala/monix/eval/TaskApp.scala
@@ -57,6 +57,6 @@ trait TaskApp {
 
   @JSExport
   final def main(args: Array[String]): Unit = {
-    run(args).runAsyncOpt(scheduler.value, options.value)
+    run(args).runAsyncOpt(scheduler.value(), options.value())
   }
 }

--- a/monix-eval/jvm/src/main/scala/monix/eval/TaskApp.scala
+++ b/monix-eval/jvm/src/main/scala/monix/eval/TaskApp.scala
@@ -55,6 +55,6 @@ trait TaskApp {
     Coeval.evalOnce(Task.defaultOptions)
 
   final def main(args: Array[String]): Unit = {
-    run(args).runSyncUnsafeOpt(Inf)(scheduler.value, options.value, implicitly)
+    run(args).runSyncUnsafeOpt(Inf)(scheduler.value(), options.value(), implicitly)
   }
 }

--- a/monix-eval/shared/src/main/scala/monix/eval/Coeval.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Coeval.scala
@@ -210,7 +210,7 @@ sealed abstract class Coeval[+A] extends (() => A) with Serializable { self =>
     *
     * $unsafeRun
     */
-  def value: A = apply()
+  def value(): A = apply()
 
   /** Evaluates the underlying computation, reducing this `Coeval`
     * to a [[Coeval.Eager]] value, with successful results being
@@ -508,7 +508,7 @@ sealed abstract class Coeval[+A] extends (() => A) with Serializable { self =>
     * behavior, as the coeval is immediately executed.
     */
   final def foreach(f: A => Unit): Unit =
-    foreachL(f).value
+    foreachL(f).value()
 
   /** Returns a new `Coeval` that applies the mapping function to
     * the element emitted by the source.
@@ -563,7 +563,7 @@ sealed abstract class Coeval[+A] extends (() => A) with Serializable { self =>
       case Coeval.Now(value) => Eval.now(value)
       case Coeval.Error(e) => Eval.always(throw e)
       case Coeval.Always(thunk) => new cats.Always(thunk)
-      case other => Eval.always(other.value)
+      case other => Eval.always(other.value())
     }
 
   /** Converts the source [[Coeval]] into a `cats.effect.IO`. */
@@ -571,7 +571,7 @@ sealed abstract class Coeval[+A] extends (() => A) with Serializable { self =>
     this match {
       case Coeval.Now(value) => IO.pure(value)
       case Coeval.Error(e) => IO.raiseError(e)
-      case other => IO(other.value)
+      case other => IO(other.value())
     }
 
   /** Creates a new `Coeval` by applying the 'fa' function to the

--- a/monix-eval/shared/src/main/scala/monix/eval/TaskLocal.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/TaskLocal.scala
@@ -236,5 +236,5 @@ object TaskLocal {
     *        lazily evaluated and managed by [[Coeval]]
     */
   def lazyDefault[A](default: Coeval[A]): Task[TaskLocal[A]] =
-    Task.eval(new TaskLocal[A](default.value))
+    Task.eval(new TaskLocal[A](default.value()))
 }

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalCatsConversions.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalCatsConversions.scala
@@ -84,17 +84,17 @@ object CoevalCatsConversions extends BaseTestSuite {
     val effect = Atomic(0)
     val eval = Coeval.fromEval(Eval.always(effect.incrementAndGet()))
 
-    assertEquals(eval.value, 1)
-    assertEquals(eval.value, 2)
-    assertEquals(eval.value, 3)
+    assertEquals(eval.value(), 1)
+    assertEquals(eval.value(), 2)
+    assertEquals(eval.value(), 3)
   }
 
   test("Coeval.fromEval(Eval.later(v))") { _ =>
     val effect = Atomic(0)
     val eval = Coeval.fromEval(Eval.later(effect.incrementAndGet()))
 
-    assertEquals(eval.value, 1)
-    assertEquals(eval.value, 1)
+    assertEquals(eval.value(), 1)
+    assertEquals(eval.value(), 1)
   }
 
   test("Coeval.fromEval protects against user error") { implicit s =>

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalErrorSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalErrorSuite.scala
@@ -24,55 +24,55 @@ import scala.util.{Failure, Success}
 object CoevalErrorSuite extends BaseTestSuite {
   test("Coeval.attempt should expose error") { implicit s =>
     val dummy = DummyException("ex")
-    val r = Coeval.raiseError[Int](dummy).attempt.value
+    val r = Coeval.raiseError[Int](dummy).attempt.value()
     assertEquals(r, Left(dummy))
   }
 
   test("Coeval.attempt should expose successful value") { implicit s =>
-    val r = Coeval.now(10).attempt.value
+    val r = Coeval.now(10).attempt.value()
     assertEquals(r, Right(10))
   }
 
   test("Coeval.fail should expose error") { implicit s =>
     val dummy = DummyException("dummy")
-    val r = Coeval.raiseError[Int](dummy).failed.value
+    val r = Coeval.raiseError[Int](dummy).failed.value()
     assertEquals(r, dummy)
   }
 
   test("Coeval.fail should fail for successful values") { implicit s =>
     intercept[NoSuchElementException] {
-      Coeval.now(10).failed.value
+      Coeval.now(10).failed.value()
     }
   }
 
   test("Coeval.now.materialize") { implicit s =>
-    assertEquals(Coeval.now(10).materialize.value, Success(10))
+    assertEquals(Coeval.now(10).materialize.value(), Success(10))
   }
 
   test("Coeval.error.materialize") { implicit s =>
     val dummy = DummyException("dummy")
-    assertEquals(Coeval.raiseError[Int](dummy).materialize.value, Failure(dummy))
+    assertEquals(Coeval.raiseError[Int](dummy).materialize.value(), Failure(dummy))
   }
 
   test("Coeval.evalOnce.materialize") { implicit s =>
-    assertEquals(Coeval.evalOnce(10).materialize.value, Success(10))
+    assertEquals(Coeval.evalOnce(10).materialize.value(), Success(10))
   }
 
   test("Coeval.eval.materialize") { implicit s =>
-    assertEquals(Coeval.eval(10).materialize.value, Success(10))
+    assertEquals(Coeval.eval(10).materialize.value(), Success(10))
   }
 
   test("Coeval.defer.materialize") { implicit s =>
-    assertEquals(Coeval.defer(Coeval.now(10)).materialize.value, Success(10))
+    assertEquals(Coeval.defer(Coeval.now(10)).materialize.value(), Success(10))
   }
 
   test("Coeval.defer.flatMap.materialize") { implicit s =>
-    assertEquals(Coeval.defer(Coeval.now(10)).flatMap(Coeval.now).materialize.value, Success(10))
+    assertEquals(Coeval.defer(Coeval.now(10)).flatMap(Coeval.now).materialize.value(), Success(10))
   }
 
   test("Coeval.error.materialize") { implicit s =>
     val dummy = DummyException("dummy")
-    assertEquals(Coeval.raiseError[Int](dummy).materialize.value, Failure(dummy))
+    assertEquals(Coeval.raiseError[Int](dummy).materialize.value(), Failure(dummy))
   }
 
   test("Coeval.flatMap.materialize") { implicit s =>

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalEvalAlwaysSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalEvalAlwaysSuite.scala
@@ -102,7 +102,7 @@ object CoevalEvalAlwaysSuite extends BaseTestSuite {
 
   test("Coeval.eval.task") { implicit s =>
     val task = Coeval.eval(100).task
-    assertEquals(task.coeval.value, Right(100))
+    assertEquals(task.coeval.value(), Right(100))
   }
 
   test("Coeval.EvalAlways.runTry override") { implicit s =>

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalEvalOnceSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalEvalOnceSuite.scala
@@ -102,7 +102,7 @@ object CoevalEvalOnceSuite extends BaseTestSuite {
 
   test("Coeval.evalOnce.task") { implicit s =>
     val task = Coeval.evalOnce(100).task
-    assertEquals(task.coeval.value, Right(100))
+    assertEquals(task.coeval.value(), Right(100))
   }
 
   test("Coeval.evalOnce.runTry override") { implicit s =>

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalMiscSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalMiscSuite.scala
@@ -25,27 +25,27 @@ import scala.util.{Failure, Success}
 
 object CoevalMiscSuite extends BaseTestSuite {
   test("Coeval.now.attempt should succeed") { implicit s =>
-    val result = Coeval.now(1).attempt.value
+    val result = Coeval.now(1).attempt.value()
     assertEquals(result, Right(1))
   }
 
   test("Coeval.raiseError.attempt should expose error") { implicit s =>
     val ex = DummyException("dummy")
-    val result = Coeval.raiseError[Int](ex).attempt.value
+    val result = Coeval.raiseError[Int](ex).attempt.value()
     assertEquals(result, Left(ex))
   }
 
   test("Coeval.fail should expose error") { implicit s =>
     val dummy = DummyException("dummy")
     check1 { (fa: Coeval[Int]) =>
-      val r = fa.map(_ => throw dummy).failed.value
+      val r = fa.map(_ => throw dummy).failed.value()
       r == dummy
     }
   }
 
   test("Coeval.fail should fail for successful values") { implicit s =>
     intercept[NoSuchElementException] {
-      Coeval.eval(10).failed.value
+      Coeval.eval(10).failed.value()
     }
   }
 
@@ -68,7 +68,9 @@ object CoevalMiscSuite extends BaseTestSuite {
 
   test("Coeval.restartUntil") { implicit s =>
     var i = 0
-    val r = Coeval { i += 1; i }.restartUntil(_ > 10).value
+    val r = Coeval {
+      i += 1; i
+    }.restartUntil(_ > 10).value()
     assertEquals(r, 11)
   }
 
@@ -80,9 +82,9 @@ object CoevalMiscSuite extends BaseTestSuite {
     var i = 0
     val fa = Coeval.delay { i += 1; i }
 
-    assertEquals(fa.value, 1)
-    assertEquals(fa.value, 2)
-    assertEquals(fa.value, 3)
+    assertEquals(fa.value(), 1)
+    assertEquals(fa.value(), 2)
+    assertEquals(fa.value(), 3)
   }
 
   test("Coeval.flatten is equivalent with flatMap") { implicit s =>

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalNowSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalNowSuite.scala
@@ -51,7 +51,7 @@ object CoevalNowSuite extends BaseTestSuite {
   }
 
   test("Coeval.now.map should work") { implicit s =>
-    Coeval.now(1).map(_ + 1).value
+    Coeval.now(1).map(_ + 1).value()
     check1 { a: Int =>
       Coeval.now(a).map(_ + 1) <-> Coeval.now(a + 1)
     }
@@ -99,13 +99,13 @@ object CoevalNowSuite extends BaseTestSuite {
 
   test("Coeval.now.materialize should work") { implicit s =>
     val task = Coeval.now(1).materialize
-    assertEquals(task.value, Success(1))
+    assertEquals(task.value(), Success(1))
   }
 
 
   test("Coeval.error.materialize should work") { implicit s =>
     val dummy = DummyException("dummy")
     val task = Coeval.raiseError(dummy).materialize
-    assertEquals(task.value, Failure(dummy))
+    assertEquals(task.value(), Failure(dummy))
   }
 }

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalRunSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalRunSuite.scala
@@ -29,14 +29,14 @@ object CoevalRunSuite extends BaseTestSuite {
     assertEquals(eager1.toTry, Success(30))
     assertEquals(eager1.toEither, Right(30))
     assertEquals(eager1.run, eager1)
-    assertEquals(eager1.value, 30)
+    assertEquals(eager1.value(), 30)
     assertEquals(eager1(), 30)
     assert(eager1.isSuccess, "eager1.isSuccess")
     assert(!eager1.isError, "!eager1.isError")
 
     assertEquals(fa1.runAttempt, Right(30))
     assertEquals(fa1.runTry, Success(30))
-    assertEquals(fa1.value, 30)
+    assertEquals(fa1.value(), 30)
 
     val dummy = new DummyException("dummy")
     val fa2 = build(() => throw dummy)
@@ -46,14 +46,14 @@ object CoevalRunSuite extends BaseTestSuite {
     assertEquals(eager2.toTry, Failure(dummy))
     assertEquals(eager2.toEither, Left(dummy))
     assertEquals(eager2.run, eager2)
-    intercept[DummyException] { eager2.value }
+    intercept[DummyException] { eager2.value() }
     intercept[DummyException] { eager2() }
     assert(!eager2.isSuccess, "!eager2.isSuccess")
     assert(eager2.isError, "!eager2.isSuccess")
 
     assertEquals(fa2.runAttempt, Left(dummy))
     assertEquals(fa2.runTry, Failure(dummy))
-    intercept[DummyException] { fa2.value }
+    intercept[DummyException] { fa2.value() }
   }
 
   test("Coeval.Always") { _ =>

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskApplySuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskApplySuite.scala
@@ -110,7 +110,7 @@ object TaskApplySuite extends BaseTestSuite {
   }
 
   test("Task.apply.coeval") { implicit s =>
-    Task(100).coeval.value match {
+    Task(100).coeval.value() match {
       case Left(result) =>
         assertEquals(result.value, None)
         s.tick()

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskCoevalForeachSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskCoevalForeachSuite.scala
@@ -55,9 +55,9 @@ object TaskCoevalForeachSuite extends TestSuite[TestScheduler] {
     val coeval = Coeval(1).foreachL(x => effect += x)
 
     assertEquals(effect, 0)
-    coeval.value
+    coeval.value()
     assertEquals(effect, 1)
-    coeval.value
+    coeval.value()
     assertEquals(effect, 2)
   }
 

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskErrorSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskErrorSuite.scala
@@ -37,18 +37,18 @@ object TaskErrorSuite extends BaseTestSuite {
 
   test("Task.fail should expose error") { implicit s =>
     val dummy = DummyException("dummy")
-    val r = Task.raiseError[Int](dummy).failed.coeval.value
+    val r = Task.raiseError[Int](dummy).failed.coeval.value()
     assertEquals(r, Right(dummy))
   }
 
   test("Task.fail should fail for successful values") { implicit s =>
     intercept[NoSuchElementException] {
-      Task.now(10).failed.coeval.value
+      Task.now(10).failed.coeval.value()
     }
   }
 
   test("Task.now.materialize") { implicit s =>
-    assertEquals(Task.now(10).materialize.coeval.value, Right(Success(10)))
+    assertEquals(Task.now(10).materialize.coeval.value(), Right(Success(10)))
   }
 
   test("Task.error.materialize") { implicit s =>
@@ -57,7 +57,7 @@ object TaskErrorSuite extends BaseTestSuite {
   }
 
   test("Task.evalOnce.materialize") { implicit s =>
-    assertEquals(Task.evalOnce(10).materialize.coeval.value, Right(Success(10)))
+    assertEquals(Task.evalOnce(10).materialize.coeval.value(), Right(Success(10)))
   }
 
   test("Task.evalOnce.materialize should be stack safe") { implicit s =>
@@ -74,25 +74,25 @@ object TaskErrorSuite extends BaseTestSuite {
   }
 
   test("Task.eval.materialize") { implicit s =>
-    assertEquals(Task.eval(10).materialize.coeval.value, Right(Success(10)))
+    assertEquals(Task.eval(10).materialize.coeval.value(), Right(Success(10)))
   }
 
   test("Task.defer.materialize") { implicit s =>
-    assertEquals(Task.defer(Task.now(10)).materialize.coeval.value, Right(Success(10)))
+    assertEquals(Task.defer(Task.now(10)).materialize.coeval.value(), Right(Success(10)))
   }
 
   test("Task.defer.flatMap.materialize") { implicit s =>
-    assertEquals(Task.defer(Task.now(10)).flatMap(Task.now).materialize.coeval.value, Right(Success(10)))
+    assertEquals(Task.defer(Task.now(10)).flatMap(Task.now).materialize.coeval.value(), Right(Success(10)))
   }
 
   test("Task.error.materialize") { implicit s =>
     val dummy = DummyException("dummy")
-    assertEquals(Task.raiseError[Int](dummy).materialize.coeval.value, Right(Failure(dummy)))
+    assertEquals(Task.raiseError[Int](dummy).materialize.coeval.value(), Right(Failure(dummy)))
   }
 
   test("Task.flatMap.materialize") { implicit s =>
     assertEquals(Task.eval(10).flatMap(x => Task.now(x))
-      .materialize.coeval.value, Right(Success(10)))
+      .materialize.coeval.value(), Right(Success(10)))
   }
 
   test("Task.apply.materialize") { implicit s =>

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskEvalAlwaysSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskEvalAlwaysSuite.scala
@@ -95,7 +95,7 @@ object TaskEvalAlwaysSuite extends BaseTestSuite {
   }
 
   test("Task.eval.coeval") { implicit s =>
-    val result = Task.eval(100).coeval.value
+    val result = Task.eval(100).coeval.value()
     assertEquals(result, Right(100))
   }
 

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskEvalOnceSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskEvalOnceSuite.scala
@@ -84,7 +84,7 @@ object TaskEvalOnceSuite extends BaseTestSuite {
   }
 
   test("Task.evalOnce.coeval") { implicit s =>
-    val result = Task.evalOnce(100).coeval.value
+    val result = Task.evalOnce(100).coeval.value()
     assertEquals(result, Right(100))
   }
 

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskMiscSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskMiscSuite.scala
@@ -43,7 +43,7 @@ object TaskMiscSuite extends BaseTestSuite {
 
   test("Task.fail should fail for successful values") { implicit s =>
     intercept[NoSuchElementException] {
-      Task.eval(10).failed.coeval.value
+      Task.eval(10).failed.coeval.value()
     }
   }
 

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskNowSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskNowSuite.scala
@@ -132,7 +132,7 @@ object TaskNowSuite extends BaseTestSuite {
   }
 
   test("Task.now.map should work") { implicit s =>
-    Coeval.now(1).map(_ + 1).value
+    Coeval.now(1).map(_ + 1).value()
     check1 { a: Int =>
       Task.now(a).map(_ + 1) <-> Task.now(a + 1)
     }
@@ -200,7 +200,7 @@ object TaskNowSuite extends BaseTestSuite {
   }
 
   test("Task.now.coeval") { implicit s =>
-    val result = Task.now(100).coeval.value
+    val result = Task.now(100).coeval.value()
     assertEquals(result, Right(100))
   }
 

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskSemaphoreSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskSemaphoreSuite.scala
@@ -32,12 +32,12 @@ object TaskSemaphoreSuite extends TestSuite[TestScheduler] {
     val Right(semaphore) = TaskSemaphore(maxParallelism = 4).runSyncMaybe
     val future = semaphore.greenLight(Task(1)).runAsync
 
-    assertEquals(semaphore.activeCount.value, 1)
+    assertEquals(semaphore.activeCount.value(), 1)
     assert(!future.isCompleted, "!future.isCompleted")
 
     s.tick()
     assertEquals(future.value, Some(Success(1)))
-    assertEquals(semaphore.activeCount.value, 0)
+    assertEquals(semaphore.activeCount.value(), 0)
   }
 
   test("should release on cancel") { implicit s =>
@@ -50,11 +50,11 @@ object TaskSemaphoreSuite extends TestSuite[TestScheduler] {
       .runAsync
 
     s.tick()
-    assertEquals(semaphore.activeCount.value, 1)
+    assertEquals(semaphore.activeCount.value(), 1)
     assertEquals(future.value, None)
 
     future.cancel(); s.tick()
-    assertEquals(semaphore.activeCount.value, 0)
+    assertEquals(semaphore.activeCount.value(), 0)
     assertEquals(future.value, None)
     assertEquals(effect, 0)
   }
@@ -123,16 +123,16 @@ object TaskSemaphoreSuite extends TestSuite[TestScheduler] {
 
     val p3 = semaphore.acquire.runAsync
     assert(!p3.isCompleted, "!p3.isCompleted")
-    assertEquals(semaphore.activeCount.value, 2)
+    assertEquals(semaphore.activeCount.value(), 2)
 
     p3.cancel()
     semaphore.release.runAsync
-    assertEquals(semaphore.activeCount.value, 1)
+    assertEquals(semaphore.activeCount.value(), 1)
     semaphore.release.runAsync
-    assertEquals(semaphore.activeCount.value, 0)
+    assertEquals(semaphore.activeCount.value(), 0)
 
     s.tick()
-    assertEquals(semaphore.activeCount.value, 0)
+    assertEquals(semaphore.activeCount.value(), 0)
     assert(!p3.isCompleted, "!p3.isCompleted")
   }
 }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -3908,7 +3908,7 @@ object Observable {
     value match {
       case Coeval.Now(a) => Observable.now(a)
       case Coeval.Error(e) => Observable.raiseError(e)
-      case other => Observable.eval(other.value)
+      case other => Observable.eval(other.value())
     }
 
   /** Converts a `cats.Eval` value into an `Observable`

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/ForeachAsyncConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/ForeachAsyncConsumer.scala
@@ -38,7 +38,7 @@ final class ForeachAsyncConsumer[A](f: A => Task[Unit])
 
       def onNext(elem: A): Future[Ack] = {
         try {
-          f(elem).coeval.value match {
+          f(elem).coeval.value() match {
             case Left(future) =>
               future.map(_ => Continue)
             case Right(()) =>

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantBasicSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantBasicSuite.scala
@@ -87,7 +87,7 @@ object IterantBasicSuite extends BaseTestSuite {
         Iterant[Coeval].now[Either[Int, Int]](Right(a))
     }
 
-    val list = fa.toListL.value
+    val list = fa.toListL.value()
     assertEquals(list, (0 to 10).toList)
   }
 

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantBracketSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantBracketSuite.scala
@@ -279,7 +279,7 @@ object IterantBracketSuite extends BaseTestSuite {
       _ <- safeCloseable("Inner")
     } yield ()
 
-    iterant.completeL.value
+    iterant.completeL.value()
 
     assertEquals(log, Vector("Start: Outer", "Start: Inner", "Stop: Inner", "Stop: Outer"))
   }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantCollectSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantCollectSuite.scala
@@ -80,7 +80,7 @@ object IterantCollectSuite extends BaseTestSuite {
     val state = iter.collect { case _ => effect += 1; 1 }
 
     assertEquals(effect, 0)
-    assertEquals(state.toListL.value, List(1))
+    assertEquals(state.toListL.value(), List(1))
     assertEquals(effect, 1)
   }
 
@@ -90,7 +90,7 @@ object IterantCollectSuite extends BaseTestSuite {
     val state = iter.collect { case _ => effect += 1; 1 }
 
     assertEquals(effect, 0)
-    assertEquals(state.toListL.value, List(1))
+    assertEquals(state.toListL.value(), List(1))
     assertEquals(effect, 1)
   }
 
@@ -110,7 +110,7 @@ object IterantCollectSuite extends BaseTestSuite {
     val stop = Coeval.eval(effect += 1)
     val source = Iterant[Coeval].nextCursorS(BatchCursor(1,2,3), Coeval.now(Iterant[Coeval].empty[Int]), stop)
     val stream = source.collect { case x => x }
-    stream.earlyStop.value
+    stream.earlyStop.value()
     assertEquals(effect, 1)
   }
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantDoOnEarlyStopSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantDoOnEarlyStopSuite.scala
@@ -33,7 +33,7 @@ object IterantDoOnEarlyStopSuite extends BaseTestSuite {
     val ref2 = Coeval.eval { effect = effect :+ 2 }
 
     val iterant = Iterant[Coeval].nextS(1, Coeval.now(Iterant[Coeval].empty[Int]), ref1).doOnEarlyStop(ref2)
-    iterant.earlyStop.value
+    iterant.earlyStop.value()
     assertEquals(effect, Vector(1, 2))
   }
 
@@ -49,7 +49,7 @@ object IterantDoOnEarlyStopSuite extends BaseTestSuite {
     val ref2 = Coeval.eval { effect = effect :+ 2 }
 
     val iterant = Iterant[Coeval].nextCursorS(BatchCursor.empty[Int], Coeval.now(Iterant[Coeval].empty[Int]), ref1).doOnEarlyStop(ref2)
-    iterant.earlyStop.value
+    iterant.earlyStop.value()
     assertEquals(effect, Vector(1, 2))
   }
 
@@ -65,7 +65,7 @@ object IterantDoOnEarlyStopSuite extends BaseTestSuite {
     val ref2 = Coeval.eval { effect = effect :+ 2 }
 
     val iterant = Iterant[Coeval].nextBatchS(Batch.empty[Int], Coeval.now(Iterant[Coeval].empty[Int]), ref1).doOnEarlyStop(ref2)
-    iterant.earlyStop.value
+    iterant.earlyStop.value()
     assertEquals(effect, Vector(1, 2))
   }
 
@@ -81,7 +81,7 @@ object IterantDoOnEarlyStopSuite extends BaseTestSuite {
     val ref2 = Coeval.eval { effect = effect :+ 2 }
 
     val iterant = Iterant[Coeval].suspendS(Coeval.now(Iterant[Coeval].empty[Int]), ref1).doOnEarlyStop(ref2)
-    iterant.earlyStop.value
+    iterant.earlyStop.value()
     assertEquals(effect, Vector(1, 2))
   }
 
@@ -94,7 +94,7 @@ object IterantDoOnEarlyStopSuite extends BaseTestSuite {
     var effect = Vector.empty[Int]
     val ref1 = Coeval.eval { effect = effect :+ 1 }
     val iterant = Iterant[Coeval].lastS(1).doOnEarlyStop(ref1)
-    iterant.earlyStop.value
+    iterant.earlyStop.value()
     assertEquals(effect, Vector.empty)
   }
 
@@ -107,7 +107,7 @@ object IterantDoOnEarlyStopSuite extends BaseTestSuite {
     var effect = Vector.empty[Int]
     val ref1 = Coeval.eval { effect = effect :+ 1 }
     val iterant = Iterant[Coeval].empty[Int].doOnEarlyStop(ref1)
-    iterant.earlyStop.value
+    iterant.earlyStop.value()
     assertEquals(effect, Vector.empty)
   }
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantDoOnFinishSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantDoOnFinishSuite.scala
@@ -31,7 +31,7 @@ object IterantDoOnFinishSuite extends BaseTestSuite {
     val ref2 = Coeval.eval { effect = effect :+ 2 }
 
     val iterant = Iterant[Coeval].nextS(1, Coeval.now(Iterant[Coeval].empty[Int]), ref1).doOnFinish(_ => ref2)
-    iterant.earlyStop.value
+    iterant.earlyStop.value()
     assertEquals(effect, Vector(1, 2))
   }
 
@@ -41,7 +41,7 @@ object IterantDoOnFinishSuite extends BaseTestSuite {
     val ref2 = Coeval.eval { effect = effect :+ 2 }
 
     val iterant = Iterant[Coeval].nextS(1, Coeval.now(Iterant[Coeval].empty[Int]), ref1).doOnFinish(_ => ref2)
-    assertEquals(iterant.foldLeftL(0)(_+_).value, 1)
+    assertEquals(iterant.foldLeftL(0)(_ + _).value(), 1)
     assertEquals(effect, Vector(2))
   }
 
@@ -56,7 +56,7 @@ object IterantDoOnFinishSuite extends BaseTestSuite {
       ref1)
       .doOnFinish(_ => ref2)
     
-    iterant.earlyStop.value
+    iterant.earlyStop.value()
     assertEquals(effect, Vector(1, 2))
   }
 
@@ -66,7 +66,7 @@ object IterantDoOnFinishSuite extends BaseTestSuite {
     val ref2 = Coeval.eval { effect = effect :+ 2 }
 
     val iterant = Iterant[Coeval].nextCursorS(BatchCursor(1), Coeval.now(Iterant[Coeval].empty[Int]), ref1).doOnFinish(_ => ref2)
-    assertEquals(iterant.foldLeftL(0)(_+_).value, 1)
+    assertEquals(iterant.foldLeftL(0)(_ + _).value(), 1)
     assertEquals(effect, Vector(2))
   }
 
@@ -76,7 +76,7 @@ object IterantDoOnFinishSuite extends BaseTestSuite {
     val ref2 = Coeval.eval { effect = effect :+ 2 }
 
     val iterant = Iterant[Coeval].nextBatchS(Batch(1), Coeval.now(Iterant[Coeval].empty[Int]), ref1).doOnFinish(_ => ref2)
-    iterant.earlyStop.value
+    iterant.earlyStop.value()
     assertEquals(effect, Vector(1, 2))
   }
 
@@ -86,7 +86,7 @@ object IterantDoOnFinishSuite extends BaseTestSuite {
     val ref2 = Coeval.eval { effect = effect :+ 2 }
 
     val iterant = Iterant[Coeval].nextBatchS(Batch(1), Coeval.now(Iterant[Coeval].empty[Int]), ref1).doOnFinish(_ => ref2)
-    assertEquals(iterant.foldLeftL(0)(_+_).value, 1)
+    assertEquals(iterant.foldLeftL(0)(_ + _).value(), 1)
     assertEquals(effect, Vector(2))
   }
 
@@ -97,7 +97,7 @@ object IterantDoOnFinishSuite extends BaseTestSuite {
 
     val suspended = Iterant[Coeval].now(1)
     val iterant = Iterant[Coeval].suspendS(Coeval.now(suspended), ref1).doOnFinish(_ => ref2)
-    iterant.earlyStop.value
+    iterant.earlyStop.value()
     assertEquals(effect, Vector(1, 2))
   }
 
@@ -108,7 +108,7 @@ object IterantDoOnFinishSuite extends BaseTestSuite {
 
     val suspended = Iterant[Coeval].now(1)
     val iterant = Iterant[Coeval].suspendS(Coeval.now(suspended), ref1).doOnFinish(_ => ref2)
-    assertEquals(iterant.foldLeftL(0)(_+_).value, 1)
+    assertEquals(iterant.foldLeftL(0)(_ + _).value(), 1)
     assertEquals(effect, Vector(2))
   }
 
@@ -117,7 +117,7 @@ object IterantDoOnFinishSuite extends BaseTestSuite {
     val ref1 = Coeval.eval { effect = effect :+ 1 }
 
     val iterant = Iterant[Coeval].lastS(1).doOnFinish(_ => ref1)
-    iterant.earlyStop.value
+    iterant.earlyStop.value()
     assertEquals(effect, Vector(1))
   }
 
@@ -126,7 +126,7 @@ object IterantDoOnFinishSuite extends BaseTestSuite {
     val ref1 = Coeval.eval { effect = effect :+ 1 }
 
     val iterant = Iterant[Coeval].lastS(1).doOnFinish(_ => ref1)
-    assertEquals(iterant.foldLeftL(0)(_+_).value, 1)
+    assertEquals(iterant.foldLeftL(0)(_ + _).value(), 1)
     assertEquals(effect, Vector(1))
   }
 
@@ -135,7 +135,7 @@ object IterantDoOnFinishSuite extends BaseTestSuite {
     val ref1 = Coeval.eval { effect = effect :+ 1 }
 
     val iterant = Iterant[Coeval].haltS[Int](None).doOnFinish(_ => ref1)
-    iterant.earlyStop.value
+    iterant.earlyStop.value()
     assertEquals(effect, Vector(1))
   }
 
@@ -144,7 +144,7 @@ object IterantDoOnFinishSuite extends BaseTestSuite {
     val ref1 = Coeval.eval { effect = effect :+ 1 }
 
     val iterant = Iterant[Coeval].haltS[Int](None).doOnFinish(_ => ref1)
-    assertEquals(iterant.foldLeftL(0)(_+_).value, 0)
+    assertEquals(iterant.foldLeftL(0)(_ + _).value(), 0)
     assertEquals(effect, Vector(1))
   }
 

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantDropLastSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantDropLastSuite.scala
@@ -59,7 +59,7 @@ object IterantDropLastSuite extends BaseTestSuite {
     val stop = Coeval.eval(effect += 1)
     val source = Iterant[Coeval].nextCursorS(BatchCursor(1, 2, 3), Coeval.now(Iterant[Coeval].empty[Int]), stop)
     val stream = source.dropLast(3)
-    stream.earlyStop.value
+    stream.earlyStop.value()
     assertEquals(effect, 1)
   }
 
@@ -71,7 +71,7 @@ object IterantDropLastSuite extends BaseTestSuite {
       val stream = (iter.onErrorIgnore ++ suffix).doOnEarlyStop(Coeval.eval(cancelable.cancel()))
 
       intercept[DummyException] {
-        stream.dropLast(1).toListL.value
+        stream.dropLast(1).toListL.value()
       }
       cancelable.isCanceled
     }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantDropSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantDropSuite.scala
@@ -67,7 +67,7 @@ object IterantDropSuite extends BaseTestSuite {
     val stop = Coeval.eval(effect += 1)
     val source = Iterant[Coeval].nextCursorS(BatchCursor(1,2,3), Coeval.now(Iterant[Coeval].empty[Int]), stop)
     val stream = source.drop(1)
-    stream.earlyStop.value
+    stream.earlyStop.value()
     assertEquals(effect, 1)
   }
 
@@ -82,7 +82,7 @@ object IterantDropSuite extends BaseTestSuite {
 
     val source = Iterant[Coeval].nextBatchS(batch, Coeval(Iterant[Coeval].empty[Int]), Coeval.unit)
     assertEquals(effect, 0)
-    assertEquals(source.foldLeftL(0)(_ + _).value, 3)
+    assertEquals(source.foldLeftL(0)(_ + _).value(), 3)
     assertEquals(effect, 1)
   }
 
@@ -98,7 +98,7 @@ object IterantDropSuite extends BaseTestSuite {
     val source = Iterant[Coeval].nextCursorS(cursor, Coeval(Iterant[Coeval].empty[Int]), Coeval.unit)
     assertEquals(effect, 0)
 
-    assertEquals(source.foldLeftL(0)(_ + _).value, 3)
+    assertEquals(source.foldLeftL(0)(_ + _).value(), 3)
     assertEquals(effect, 2)
   }
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantDropWhileIndexSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantDropWhileIndexSuite.scala
@@ -99,7 +99,7 @@ object IterantDropWhileIndexSuite extends BaseTestSuite {
     val stop = Coeval.eval(effect += 1)
     val source = Iterant[Coeval].nextCursorS(BatchCursor(1, 2, 3), Coeval.now(Iterant[Coeval].empty[Int]), stop)
     val stream = source.dropWhileWithIndex((_, _) => true)
-    stream.earlyStop.value
+    stream.earlyStop.value()
     assertEquals(effect, 1)
   }
 

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantDropWhileSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantDropWhileSuite.scala
@@ -88,7 +88,7 @@ object IterantDropWhileSuite extends BaseTestSuite {
     val stop = Coeval.eval(effect += 1)
     val source = Iterant[Coeval].nextCursorS(BatchCursor(1,2,3), Coeval.now(Iterant[Coeval].empty[Int]), stop)
     val stream = source.dropWhile(_ => true)
-    stream.earlyStop.value
+    stream.earlyStop.value()
     assertEquals(effect, 1)
   }
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantDumpSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantDumpSuite.scala
@@ -129,7 +129,7 @@ object IterantDumpSuite extends BaseTestSuite {
     val stop = Coeval.eval(effect += 1)
     val source = Iterant[Coeval].nextCursorS(BatchCursor(1, 2, 3), Coeval.now(Iterant[Coeval].empty[Int]), stop)
     val stream = source.dump("O", dummyOut(AtomicInt(0)))
-    stream.earlyStop.value
+    stream.earlyStop.value()
 
     assertEquals(effect, 1)
   }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantFilterSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantFilterSuite.scala
@@ -104,7 +104,7 @@ object IterantFilterSuite extends BaseTestSuite {
     val stop = Coeval.eval(effect += 1)
     val source = Iterant[Coeval].nextCursorS(BatchCursor(1,2,3), Coeval.now(Iterant[Coeval].empty[Int]), stop)
     val stream = source.filter(_ => true)
-    stream.earlyStop.value
+    stream.earlyStop.value()
     assertEquals(effect, 1)
   }
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantFlatMapSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantFlatMapSuite.scala
@@ -232,7 +232,7 @@ object IterantFlatMapSuite extends BaseTestSuite {
       for (x <- stream1; y <- stream2; z <- stream3)
         yield x + y + z
 
-    assertEquals(composed.headOptionL.value, Some(6))
+    assertEquals(composed.headOptionL.value(), Some(6))
     assertEquals(effects, Vector(3,2,1))
   }
 
@@ -264,10 +264,10 @@ object IterantFlatMapSuite extends BaseTestSuite {
       for (x <- stream1; y <- stream2; z <- stream3)
         yield x + y + z
 
-    firstNext(composed).value match {
+    firstNext(composed).value() match {
       case Iterant.NextCursor(head, _, stop) =>
         assertEquals(head.toList, List(6))
-        assertEquals(stop.value, ())
+        assertEquals(stop.value(), ())
         assertEquals(effects, Vector(3,2,1))
       case state =>
         fail(s"Invalid state: $state")
@@ -319,7 +319,7 @@ object IterantFlatMapSuite extends BaseTestSuite {
     val stop = Coeval.eval(effect += 1)
     val source = Iterant[Coeval].nextCursorS(BatchCursor(1,2,3), Coeval.now(Iterant[Coeval].empty[Int]), stop)
     val stream = source.flatMap(x => Iterant[Coeval].now(x))
-    stream.earlyStop.value
+    stream.earlyStop.value()
     assertEquals(effect, 1)
   }
 

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantFoldLeftSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantFoldLeftSuite.scala
@@ -120,14 +120,14 @@ object IterantFoldLeftSuite extends BaseTestSuite {
 
   test("Iterant[Coeval].toList (Comonad)") { implicit s =>
     check1 { (list: List[Int]) =>
-      val result = Iterant[Coeval].fromIterable(list).toListL.value
+      val result = Iterant[Coeval].fromIterable(list).toListL.value()
       result == list
     }
   }
 
   test("Iterant[Coeval].foldLeft (Comonad)") { implicit s =>
     check1 { (list: List[Int]) =>
-      val result = Iterant[Coeval].fromIterable(list).foldLeftL(0)(_ + _).value
+      val result = Iterant[Coeval].fromIterable(list).foldLeftL(0)(_ + _).value()
       result == list.sum
     }
   }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantFoldRightSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantFoldRightSuite.scala
@@ -93,26 +93,26 @@ object IterantFoldRightSuite extends BaseTestSuite {
     assertEquals(effect, 0)
     assertEquals(emitted, 0)
 
-    assertEquals(all.headOptionL.value, Some(1))
+    assertEquals(all.headOptionL.value(), Some(1))
     assertEquals(effect, 1)
     assertEquals(emitted, 1)
 
     emitted = 0
     effect = 0
 
-    assertEquals(all.take(2).toListL.value, List(1, 2))
+    assertEquals(all.take(2).toListL.value(), List(1, 2))
     assertEquals(effect, 2)
     assertEquals(emitted, 2)
 
     emitted = 0
     effect = 0
 
-    assertEquals(all.take(3).toListL.value, List(1, 2, 3))
+    assertEquals(all.take(3).toListL.value(), List(1, 2, 3))
     assertEquals(effect, 3)
     assertEquals(emitted, 3)
 
     effect = 0
-    assertEquals(all.take(4).toListL.value, List(1, 2, 3, 4))
+    assertEquals(all.take(4).toListL.value(), List(1, 2, 3, 4))
     assertEquals(effect, 100)
   }
 

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantFromStateActionSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantFromStateActionSuite.scala
@@ -48,14 +48,14 @@ object IterantFromStateActionSuite extends BaseTestSuite {
     val dummy = DummyException("dummy")
     val received = Iterant[Coeval].fromStateAction[Int, Int](e => (e, e))(throw dummy).attempt.toListL
 
-    assertEquals(received.value, List(Left(dummy)))
+    assertEquals(received.value(), List(Left(dummy)))
   }
 
   test("Iterant.fromStateAction protects against exceptions in f") { implicit s =>
     val dummy = DummyException("dummy")
     val received = Iterant[Coeval].fromStateAction[Int, Int](_ => (throw dummy, throw dummy))(0).attempt.toListL
 
-    assertEquals(received.value, List(Left(dummy)))
+    assertEquals(received.value(), List(Left(dummy)))
   }
 
   test("Iterant.fromStateActionL should evolve state") { implicit s =>
@@ -92,6 +92,6 @@ object IterantFromStateActionSuite extends BaseTestSuite {
     val dummy = DummyException("dummy")
     val received = Iterant[Coeval].fromStateActionL[Int, Int](_ => throw dummy)(Coeval.pure(0)).attempt.toListL
 
-    assertEquals(received.value, List(Left(dummy)))
+    assertEquals(received.value(), List(Left(dummy)))
   }
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantHeadOptionSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantHeadOptionSuite.scala
@@ -52,10 +52,10 @@ object IterantHeadOptionSuite extends BaseTestSuite {
 
   test("Iterant.headOption works for empty NextCursor or NextBatch") { _ =>
     val iter1 = Iterant[Coeval].nextBatchS(Batch[Int](), Coeval.now(Iterant[Coeval].empty[Int]), Coeval.unit)
-    assertEquals(iter1.headOptionL.value, None)
+    assertEquals(iter1.headOptionL.value(), None)
 
     val iter2 = Iterant[Coeval].nextCursorS(BatchCursor[Int](), Coeval.now(Iterant[Coeval].empty[Int]), Coeval.unit)
-    assertEquals(iter2.headOptionL.value, None)
+    assertEquals(iter2.headOptionL.value(), None)
   }
 
   test("Iterant.headOption doesn't touch Halt") { implicit s =>

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantInterleaveSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantInterleaveSuite.scala
@@ -46,7 +46,7 @@ object IterantInterleaveSuite extends BaseTestSuite {
       val stream1 = arbitraryListToIterant[Coeval, Int](list1, math.abs(idx1) + 1, allowErrors = false)
       val stream2 = arbitraryListToIterant[Coeval, Int](list2, math.abs(idx2) + 1, allowErrors = false)
 
-      val expected = Coeval(list1.zip(list2).flatMap { case (a, b) => List(a, b) }).value
+      val expected = Coeval(list1.zip(list2).flatMap { case (a, b) => List(a, b) }).value()
       naiveImp(stream1, stream2).toListL.value <-> expected
     }
   }
@@ -66,7 +66,7 @@ object IterantInterleaveSuite extends BaseTestSuite {
     val source1 = Iterant[Coeval].nextCursorS(BatchCursor(1,2,3), Coeval.now(Iterant[Coeval].empty[Int]), stop)
     val source2 = Iterant[Coeval].nextCursorS(BatchCursor(1,2,3), Coeval.now(Iterant[Coeval].empty[Int]), stop)
     val stream = source1.interleave(source2)
-    stream.earlyStop.value
+    stream.earlyStop.value()
     assertEquals(effect, 2)
   }
 

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantIntersperseSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantIntersperseSuite.scala
@@ -44,7 +44,7 @@ object IterantIntersperseSuite extends BaseTestSuite {
       stop
     )
     val interspersed = source.intersperse(0)
-    interspersed.earlyStop.value
+    interspersed.earlyStop.value()
     assertEquals(effect, 1)
   }
 

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantMapBatchSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantMapBatchSuite.scala
@@ -154,7 +154,7 @@ object IterantMapBatchSuite extends BaseTestSuite {
       val stream = (iter.onErrorIgnore ++ suffix).doOnEarlyStop(Coeval.eval(cancelable.cancel()))
 
       intercept[DummyException] {
-        stream.mapBatch(Batch.apply(_)).toListL.value
+        stream.mapBatch(Batch.apply(_)).toListL.value()
       }
       cancelable.isCanceled
     }
@@ -227,7 +227,7 @@ object IterantMapBatchSuite extends BaseTestSuite {
     val stop = Coeval.eval(effect += 1)
     val source = Iterant[Coeval].nextCursorS(BatchCursor(1, 2, 3), Coeval.now(Iterant[Coeval].empty[Int]), stop)
     val stream = source.mapBatch(Batch.apply(_))
-    stream.earlyStop.value
+    stream.earlyStop.value()
     assertEquals(effect, 1)
   }
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantMapEvalSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantMapEvalSuite.scala
@@ -314,7 +314,7 @@ object IterantMapEvalSuite extends BaseTestSuite {
     val stop = Coeval.eval(effect += 1)
     val source = Iterant[Coeval].nextCursorS(BatchCursor(1,2,3), Coeval.now(Iterant[Coeval].empty[Int]), stop)
     val stream = source.mapEval(x => Coeval.now(x))
-    stream.earlyStop.value
+    stream.earlyStop.value()
     assertEquals(effect, 1)
   }
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantMapSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantMapSuite.scala
@@ -169,7 +169,7 @@ object IterantMapSuite extends BaseTestSuite {
     val stop = Coeval.eval(effect += 1)
     val source = Iterant[Coeval].nextCursorS(BatchCursor(1,2,3), Coeval.now(Iterant[Coeval].empty[Int]), stop)
     val stream = source.map(x => x)
-    stream.earlyStop.value
+    stream.earlyStop.value()
     assertEquals(effect, 1)
   }
 

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantOnErrorSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantOnErrorSuite.scala
@@ -30,8 +30,8 @@ object IterantOnErrorSuite extends BaseTestSuite {
     val i = Iterant[Coeval].of(1, 2, 3)
 
     assertEquals(
-      i.attempt.toListL.value,
-      i.map(Right.apply).toListL.value
+      i.attempt.toListL.value(),
+      i.map(Right.apply).toListL.value()
     )
   }
 
@@ -40,7 +40,7 @@ object IterantOnErrorSuite extends BaseTestSuite {
     val i = Iterant[Coeval].of(1, 2, 3) ++ Iterant[Coeval].raiseError[Int](dummy)
 
     assertEquals(
-      i.attempt.toListL.value,
+      i.attempt.toListL.value(),
       List(Right(1), Right(2), Right(3), Left(dummy))
     )
   }
@@ -72,7 +72,7 @@ object IterantOnErrorSuite extends BaseTestSuite {
     val iter2 = Iterant[Coeval].fromArray(Array(4, 5, 6))
 
     assertEquals(
-      iter1.onErrorHandleWith(_ => iter2).toListL.value,
+      iter1.onErrorHandleWith(_ => iter2).toListL.value(),
       List(1, 2, 3, 4, 5, 6)
     )
   }
@@ -116,7 +116,7 @@ object IterantOnErrorSuite extends BaseTestSuite {
       val out = broken
         .onErrorHandleWith(_ => Iterant[Coeval].fromSeq(fallback))
         .toListL
-        .value
+        .value()
 
       assertEquals(out.takeRight(fallback.length), fallback)
     }
@@ -135,7 +135,7 @@ object IterantOnErrorSuite extends BaseTestSuite {
       Coeval { effect = 1 }
     )
     errorInTail.onErrorHandleWith(_ => Iterant[Coeval].empty[Int])
-      .completeL.value
+      .completeL.value()
     assertEquals(effect, 2)
   }
 
@@ -143,7 +143,7 @@ object IterantOnErrorSuite extends BaseTestSuite {
     for (broken <- brokenTails) {
       val end = broken.attempt
         .toListL
-        .value
+        .value()
         .last
 
       assertEquals(end, Left(DummyException("dummy")))
@@ -162,7 +162,7 @@ object IterantOnErrorSuite extends BaseTestSuite {
       },
       Coeval { effect = 1 }
     )
-    errorInTail.attempt.completeL.value
+    errorInTail.attempt.completeL.value()
     assertEquals(effect, 2)
   }
 

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantRangesSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantRangesSuite.scala
@@ -21,32 +21,32 @@ import monix.eval.Coeval
 
 object IterantRangesSuite extends BaseTestSuite {
   test("Iterant.range(0, 10, 1)") { implicit s =>
-    val lst = Iterant[Coeval].range(0, 10).toListL.value
+    val lst = Iterant[Coeval].range(0, 10).toListL.value()
     assertEquals(lst, (0 until 10).toList)
   }
 
   test("Iterant.range(0, 10, 2)") { implicit s =>
-    val lst = Iterant[Coeval].range(0, 10, 2).toListL.value
+    val lst = Iterant[Coeval].range(0, 10, 2).toListL.value()
     assertEquals(lst, 0.until(10, 2).toList)
   }
 
   test("Iterant.range(10, 0, -1)") { implicit s =>
-    val lst = Iterant[Coeval].range(10, 0, -1).toListL.value
+    val lst = Iterant[Coeval].range(10, 0, -1).toListL.value()
     assertEquals(lst, 10.until(0, -1).toList)
   }
 
   test("Iterant.range(10, 0, -2)") { implicit s =>
-    val lst = Iterant[Coeval].range(10, 0, -2).toListL.value
+    val lst = Iterant[Coeval].range(10, 0, -2).toListL.value()
     assertEquals(lst, 10.until(0, -2).toList)
   }
 
   test("Iterant.range(0, 10, -1)") { implicit s =>
-    val lst = Iterant[Coeval].range(0, 10, -1).toListL.value
+    val lst = Iterant[Coeval].range(0, 10, -1).toListL.value()
     assertEquals(lst, 0.until(10, -1).toList)
   }
 
   test("Iterant.range(10, 0, 1)") { implicit s =>
-    val lst = Iterant[Coeval].range(10, 0).toListL.value
+    val lst = Iterant[Coeval].range(10, 0).toListL.value()
     assertEquals(lst, 10.until(0, 1).toList)
   }
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantRepeatSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantRepeatSuite.scala
@@ -34,9 +34,13 @@ object IterantRepeatSuite extends BaseTestSuite {
     val source = Iterant[Coeval].nextS(1, Coeval(Iterant[Coeval].empty[Int]), Coeval.unit)
 
     intercept[DummyException] {
-      source.repeat.map { x => if (effect == 6) throw dummy else {
-        effect += 1; values ::= x; x
-      }}.toListL.value}
+      source.repeat.map { x =>
+        if (effect == 6) throw dummy else {
+          effect += 1;
+          values ::= x;
+          x
+        }
+      }.toListL.value()}
 
     assertEquals(values, expectedValues)
   }
@@ -66,7 +70,7 @@ object IterantRepeatSuite extends BaseTestSuite {
     val stop = Coeval.eval(effect += 1)
     val source = Iterant[Coeval].nextCursorS(BatchCursor(1, 2, 3), Coeval.now(Iterant[Coeval].empty[Int]), stop)
     val stream = source.repeat
-    stream.earlyStop.value
+    stream.earlyStop.value()
     assertEquals(effect, 1)
   }
 
@@ -78,7 +82,7 @@ object IterantRepeatSuite extends BaseTestSuite {
       val stream = (iter.onErrorIgnore ++ suffix).doOnEarlyStop(Coeval.eval(cancelable.cancel()))
 
       intercept[DummyException] {
-        stream.repeat.toListL.value
+        stream.repeat.toListL.value()
       }
       cancelable.isCanceled
     }
@@ -91,9 +95,12 @@ object IterantRepeatSuite extends BaseTestSuite {
     val source = Iterant[Coeval].nextBatchS(Batch(1, 2, 3), Coeval(Iterant[Coeval].empty[Int]), Coeval.unit)
 
     intercept[DummyException] {
-      source.repeat.map { x => if (values.size == 6) throw dummy else {
-        values ::= x; x
-      }}.toListL.value}
+      source.repeat.map { x =>
+        if (values.size == 6) throw dummy else {
+          values ::= x;
+          x
+        }
+      }.toListL.value()}
 
     assertEquals(values, expectedValues)
   }
@@ -106,9 +113,12 @@ object IterantRepeatSuite extends BaseTestSuite {
       Coeval(Iterant[Coeval].nextBatchS(Batch(1, 2, 3), Coeval(Iterant[Coeval].empty[Int]), Coeval.unit)), Coeval.unit)
 
     intercept[DummyException] {
-      source.repeat.map { x => if (values.size == 6) throw dummy else {
-        values ::= x; x
-      }}.toListL.value}
+      source.repeat.map { x =>
+        if (values.size == 6) throw dummy else {
+          values ::= x;
+          x
+        }
+      }.toListL.value()}
 
     assertEquals(values, expectedValues)
   }
@@ -120,9 +130,12 @@ object IterantRepeatSuite extends BaseTestSuite {
     val source = Iterant[Coeval].nextCursorS(BatchCursor(1, 2, 3), Coeval(Iterant[Coeval].empty[Int]), Coeval.unit)
 
     intercept[DummyException] {
-      source.repeat.map { x => if (values.size == 6) throw dummy else {
-        values ::= x; x
-      }}.toListL.value}
+      source.repeat.map { x =>
+        if (values.size == 6) throw dummy else {
+          values ::= x;
+          x
+        }
+      }.toListL.value()}
 
     assertEquals(values, expectedValues)
   }
@@ -135,9 +148,12 @@ object IterantRepeatSuite extends BaseTestSuite {
       Coeval(Iterant[Coeval].nextCursorS(BatchCursor(1, 2, 3), Coeval(Iterant[Coeval].empty[Int]), Coeval.unit)), Coeval.unit)
 
     intercept[DummyException] {
-      source.repeat.map { x => if (values.size == 6) throw dummy else {
-        values ::= x; x
-      }}.toListL.value}
+      source.repeat.map { x =>
+        if (values.size == 6) throw dummy else {
+          values ::= x;
+          x
+        }
+      }.toListL.value()}
 
     assertEquals(values, expectedValues)
   }
@@ -149,9 +165,12 @@ object IterantRepeatSuite extends BaseTestSuite {
     val source = Iterant[Coeval].lastS(1)
 
     intercept[DummyException] {
-      source.repeat.map { x => if (values.size == 6) throw dummy else {
-        values ::= x; x
-      }}.toListL.value}
+      source.repeat.map { x =>
+        if (values.size == 6) throw dummy else {
+          values ::= x;
+          x
+        }
+      }.toListL.value()}
 
     assertEquals(values, expectedValues)
   }
@@ -163,9 +182,12 @@ object IterantRepeatSuite extends BaseTestSuite {
     val source = Iterant[Coeval].suspendS[Int](Coeval(Iterant.nextS(1, Coeval(Iterant.empty), Coeval.unit)), Coeval.unit)
 
     intercept[DummyException] {
-      source.repeat.map { x => if (values.size == 6) throw dummy else {
-        values ::= x; x
-      }}.toListL.value}
+      source.repeat.map { x =>
+        if (values.size == 6) throw dummy else {
+          values ::= x;
+          x
+        }
+      }.toListL.value()}
 
     assertEquals(values, expectedValues)
   }
@@ -175,9 +197,9 @@ object IterantRepeatSuite extends BaseTestSuite {
     val source2 = Iterant[Coeval].suspendS(Coeval(source1), Coeval.unit)
     val source3 = Iterant[Coeval].nextCursorS[Int](BatchCursor(), Coeval(source1), Coeval.unit)
 
-    assertEquals(source1.repeat.toListL.value, List.empty[Int])
-    assertEquals(source2.repeat.toListL.value, List.empty[Int])
-    assertEquals(source3.repeat.toListL.value, List.empty[Int])
+    assertEquals(source1.repeat.toListL.value(), List.empty[Int])
+    assertEquals(source2.repeat.toListL.value(), List.empty[Int])
+    assertEquals(source3.repeat.toListL.value(), List.empty[Int])
   }
 
   test("Iterant.repeat doesn't touch Halt") { implicit s =>
@@ -195,9 +217,12 @@ object IterantRepeatSuite extends BaseTestSuite {
     val source = Iterant[Coeval].repeat(1)
 
     intercept[DummyException] {
-      source.repeat.map { x => if (values.size == 6) throw dummy else {
-        values ::= x; x
-      }}.toListL.value}
+      source.repeat.map { x =>
+        if (values.size == 6) throw dummy else {
+          values ::= x;
+          x
+        }
+      }.toListL.value()}
 
     assertEquals(values, expectedValues)
   }
@@ -209,9 +234,12 @@ object IterantRepeatSuite extends BaseTestSuite {
     val source = Iterant[Coeval].repeat(List(1, 2, 3): _*)
 
     intercept[DummyException] {
-      source.repeat.map { x => if (values.size == 6) throw dummy else {
-        values ::= x; x
-      }}.toListL.value}
+      source.repeat.map { x =>
+        if (values.size == 6) throw dummy else {
+          values ::= x;
+          x
+        }
+      }.toListL.value()}
 
     assertEquals(values, expectedValues)
   }
@@ -246,7 +274,7 @@ object IterantRepeatSuite extends BaseTestSuite {
     var effect = 0
     val increment = Coeval { effect += 1 }
     Iterant[Coeval].repeatEvalF(increment).take(repeats)
-      .completeL.value
+      .completeL.value()
     assertEquals(effect, repeats)
   }
 

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantScanEvalSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantScanEvalSuite.scala
@@ -59,7 +59,7 @@ object IterantScanEvalSuite extends BaseTestSuite {
 
       val expected = source.take(20).toListL.map(ls =>
         ls.take(19)
-          .map(x => requestPersonDetails(x).value)
+          .map(x => requestPersonDetails(x).value())
           .collect { case Some(p) => p.name }
       )
 
@@ -75,7 +75,7 @@ object IterantScanEvalSuite extends BaseTestSuite {
     val r = fa.scanEval(Coeval.raiseError[Int](dummy))((_, e) => Coeval(e)).attempt.toListL
 
     assertEquals(effect, 0)
-    assertEquals(r.value, List(Left(dummy)))
+    assertEquals(r.value(), List(Left(dummy)))
     assertEquals(effect, 1)
   }
 
@@ -87,7 +87,7 @@ object IterantScanEvalSuite extends BaseTestSuite {
     val r = fa.scanEval(Coeval(0))((_, _) => throw dummy).attempt.toListL
 
     assertEquals(effect, 0)
-    assertEquals(r.value, List(Left(dummy)))
+    assertEquals(r.value(), List(Left(dummy)))
     assertEquals(effect, 1)
   }
 
@@ -99,7 +99,7 @@ object IterantScanEvalSuite extends BaseTestSuite {
     val r = fa.scanEval(Coeval(0))((_, _) => Coeval.raiseError(dummy)).attempt.toListL
 
     assertEquals(effect, 0)
-    assertEquals(r.value, List(Left(dummy)))
+    assertEquals(r.value(), List(Left(dummy)))
     assertEquals(effect, 1)
   }
 

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantScanSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantScanSuite.scala
@@ -49,14 +49,14 @@ object IterantScanSuite extends BaseTestSuite {
     val dummy = DummyException("dummy")
     val fa = Iterant[Coeval].of(1, 2, 3)
     val r = fa.scan((throw dummy) : Int)((_, e) => e).attempt.toListL
-    assertEquals(r.value, List(Left(dummy)))
+    assertEquals(r.value(), List(Left(dummy)))
   }
 
   test("scan protects against exceptions in f") { implicit s =>
     val dummy = DummyException("dummy")
     val fa = Iterant[Coeval].of(1, 2, 3)
     val r = fa.scan(0)((_, _) => throw dummy).attempt.toListL
-    assertEquals(r.value, List(Left(dummy)))
+    assertEquals(r.value(), List(Left(dummy)))
   }
 
   test("scan0 emits seed as first element") { implicit s =>

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantSwitchIfEmptySuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantSwitchIfEmptySuite.scala
@@ -48,7 +48,7 @@ object IterantSwitchIfEmptySuite extends BaseTestSuite {
     val ex = DummyException("dummy")
     val source = Iterant[Coeval].raiseError[Int](ex).switchIfEmpty(backupStream)
     intercept[DummyException] {
-      source.toListL.value
+      source.toListL.value()
     }
   }
 
@@ -56,7 +56,7 @@ object IterantSwitchIfEmptySuite extends BaseTestSuite {
     val cancelable = BooleanCancelable()
     val left = emptyInts.doOnFinish(_ => Coeval { cancelable.cancel() })
 
-    left.switchIfEmpty(backupStream).toListL.value
+    left.switchIfEmpty(backupStream).toListL.value()
 
     assert(cancelable.isCanceled)
   }
@@ -65,7 +65,7 @@ object IterantSwitchIfEmptySuite extends BaseTestSuite {
     val cancelable = BooleanCancelable()
     val right = emptyInts.doOnFinish(_ => Coeval { cancelable.cancel() })
 
-    backupStream.switchIfEmpty(right).toListL.value
+    backupStream.switchIfEmpty(right).toListL.value()
 
     assert(!cancelable.isCanceled)
   }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantTailSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantTailSuite.scala
@@ -63,7 +63,7 @@ object IterantTailSuite extends BaseTestSuite {
       .tail
 
     assert(iter.isInstanceOf[Suspend[Coeval, Int]], "iter.isInstanceOf[Suspend[Coeval, Int]]")
-    intercept[DummyException](iter.toListL.value)
+    intercept[DummyException](iter.toListL.value())
   }
 
   test("Iterant.tail suspends execution for NextBatch") { implicit s =>
@@ -75,7 +75,7 @@ object IterantTailSuite extends BaseTestSuite {
       .tail
 
     assert(iter.isInstanceOf[Suspend[Coeval, Int]], "iter.isInstanceOf[Suspend[Coeval, Int]]")
-    intercept[DummyException](iter.toListL.value)
+    intercept[DummyException](iter.toListL.value())
   }
 
   test("Iterant.tail preserves the source earlyStop") { implicit s =>
@@ -83,7 +83,7 @@ object IterantTailSuite extends BaseTestSuite {
     val stop = Coeval.eval(effect += 1)
     val source = Iterant[Coeval].nextCursorS(BatchCursor(1,2,3), Coeval.now(Iterant[Coeval].empty[Int]), stop)
     val stream = source.tail
-    stream.earlyStop.value
+    stream.earlyStop.value()
     assertEquals(effect, 1)
   }
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantTakeEveryNthSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantTakeEveryNthSuite.scala
@@ -52,10 +52,10 @@ object IterantTakeEveryNthSuite extends BaseTestSuite {
   test("naiveImp smoke test") { implicit s =>
     val input = List(1, 2, 3, 4, 5, 6)
     val iter = Iterant[Coeval].fromList(input)
-    assertEquals(naiveImp(iter, 1).toListL.value, input)
-    assertEquals(naiveImp(iter, 2).toListL.value, List(2, 4, 6))
-    assertEquals(naiveImp(iter, 3).toListL.value, List(3, 6))
-    assertEquals(naiveImp(iter, input.length + 1).toListL.value, List.empty[Int])
+    assertEquals(naiveImp(iter, 1).toListL.value(), input)
+    assertEquals(naiveImp(iter, 2).toListL.value(), List(2, 4, 6))
+    assertEquals(naiveImp(iter, 3).toListL.value(), List(3, 6))
+    assertEquals(naiveImp(iter, input.length + 1).toListL.value(), List.empty[Int])
   }
 
   test("Iterant[Task].takeEveryNth equivalence with naiveImp") { implicit s =>
@@ -109,7 +109,7 @@ object IterantTakeEveryNthSuite extends BaseTestSuite {
     val stop = Coeval.eval(effect += 1)
     val source = Iterant[Coeval].nextCursorS(BatchCursor(1,2,3), Coeval.now(Iterant[Coeval].empty[Int]), stop)
     val stream = source.takeEveryNth(1)
-    stream.earlyStop.value
+    stream.earlyStop.value()
     assertEquals(effect, 1)
   }
 
@@ -121,11 +121,11 @@ object IterantTakeEveryNthSuite extends BaseTestSuite {
   test("Iterant.takeEveryNth suspends execution for NextCursor or NextBatch") { _ =>
     val iter1 = Iterant[Coeval].nextBatchS(Batch(1,2,3), Coeval.now(Iterant[Coeval].empty[Int]), Coeval.unit)
     assert(iter1.takeEveryNth(2).isInstanceOf[Suspend[Coeval, Int]], "NextBatch should be suspended")
-    assertEquals(iter1.takeEveryNth(2).toListL.value, List(2))
+    assertEquals(iter1.takeEveryNth(2).toListL.value(), List(2))
 
     val iter2 = Iterant[Coeval].nextCursorS(BatchCursor(1,2,3), Coeval.now(Iterant[Coeval].empty[Int]), Coeval.unit)
     assert(iter2.takeEveryNth(2).isInstanceOf[Suspend[Coeval, Int]], "NextCursor should be suspended")
-    assertEquals(iter2.takeEveryNth(2).toListL.value, List(2))
+    assertEquals(iter2.takeEveryNth(2).toListL.value(), List(2))
   }
 
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantTakeLastSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantTakeLastSuite.scala
@@ -58,7 +58,7 @@ object IterantTakeLastSuite extends BaseTestSuite {
     val stop = Coeval.eval(effect += 1)
     val source = Iterant[Coeval].nextCursorS(BatchCursor(1,2,3), Coeval.now(Iterant[Coeval].empty[Int]), stop)
     val stream = source.takeLast(3)
-    stream.earlyStop.value
+    stream.earlyStop.value()
     assertEquals(effect, 1)
   }
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantTakeSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantTakeSuite.scala
@@ -94,7 +94,7 @@ object IterantTakeSuite extends BaseTestSuite {
       val suffix = Iterant[Coeval].nextCursorS[Int](new ThrowExceptionCursor(dummy), Coeval.now(Iterant[Coeval].empty), Coeval.unit)
       val stream = (iter.onErrorIgnore ++ suffix).doOnEarlyStop(Coeval.eval(cancelable.cancel()))
 
-      intercept[DummyException] { stream.take(Int.MaxValue).toListL.value }
+      intercept[DummyException] { stream.take(Int.MaxValue).toListL.value() }
       cancelable.isCanceled
     }
   }
@@ -102,11 +102,11 @@ object IterantTakeSuite extends BaseTestSuite {
   test("Iterant.take suspends execution for NextCursor or NextBatch") { _ =>
     val iter1 = Iterant[Coeval].nextBatchS(Batch(1,2,3), Coeval.now(Iterant[Coeval].empty[Int]), Coeval.unit)
     assert(iter1.take(2).isInstanceOf[Suspend[Coeval, Int]], "NextBatch should be suspended")
-    assertEquals(iter1.take(2).toListL.value, List(1, 2))
+    assertEquals(iter1.take(2).toListL.value(), List(1, 2))
 
     val iter2 = Iterant[Coeval].nextCursorS(BatchCursor(1,2,3), Coeval.now(Iterant[Coeval].empty[Int]), Coeval.unit)
     assert(iter2.take(2).isInstanceOf[Suspend[Coeval, Int]], "NextCursor should be suspended")
-    assertEquals(iter2.take(2).toListL.value, List(1, 2))
+    assertEquals(iter2.take(2).toListL.value(), List(1, 2))
   }
 
   test("Iterant.take preserves the source earlyStop") { implicit s =>
@@ -114,7 +114,7 @@ object IterantTakeSuite extends BaseTestSuite {
     val stop = Coeval.eval(effect += 1)
     val source = Iterant[Coeval].nextCursorS(BatchCursor(1,2,3), Coeval.now(Iterant[Coeval].empty[Int]), stop)
     val stream = source.take(3)
-    stream.earlyStop.value
+    stream.earlyStop.value()
     assertEquals(effect, 1)
   }
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantTakeWhileSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantTakeWhileSuite.scala
@@ -111,7 +111,7 @@ object IterantTakeWhileSuite extends BaseTestSuite {
       val suffix = Iterant[Coeval].nextCursorS[Int](new ThrowExceptionCursor(dummy), Coeval.now(Iterant[Coeval].empty), Coeval.unit)
       val stream = (iter.onErrorIgnore ++ suffix).doOnEarlyStop(Coeval.eval(cancelable.cancel()))
 
-      intercept[DummyException] { stream.takeWhile(_ => true).toListL.value }
+      intercept[DummyException] { stream.takeWhile(_ => true).toListL.value() }
       cancelable.isCanceled
     }
   }
@@ -121,7 +121,7 @@ object IterantTakeWhileSuite extends BaseTestSuite {
     val stop = Coeval.eval(effect += 1)
     val source = Iterant[Coeval].nextCursorS(BatchCursor(1,2,3), Coeval.now(Iterant[Coeval].empty[Int]), stop)
     val stream = source.takeWhile(_ => true)
-    stream.earlyStop.value
+    stream.earlyStop.value()
     assertEquals(effect, 1)
   }
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantTakeWhileWithIndexSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantTakeWhileWithIndexSuite.scala
@@ -54,10 +54,10 @@ object IterantTakeWhileWithIndexSuite extends BaseTestSuite {
   test("naiveImp smoke test") { implicit s =>
     val input = List(2, 3, 4, 5, 6)
     val iter = Iterant[Coeval].fromList(input)
-    assertEquals(naiveImp(iter, (_: Int, _) => true).toListL.value, input)
-    assertEquals(naiveImp(iter, (_: Int, idx) => idx != 3).toListL.value, List(2, 3, 4))
-    assertEquals(naiveImp(iter, (a: Int, _) => a % 2 == 0).toListL.value, List(2))
-    assertEquals(naiveImp(iter, (_: Int, _) => false).toListL.value, List.empty[Int])
+    assertEquals(naiveImp(iter, (_: Int, _) => true).toListL.value(), input)
+    assertEquals(naiveImp(iter, (_: Int, idx) => idx != 3).toListL.value(), List(2, 3, 4))
+    assertEquals(naiveImp(iter, (a: Int, _) => a % 2 == 0).toListL.value(), List(2))
+    assertEquals(naiveImp(iter, (_: Int, _) => false).toListL.value(), List.empty[Int])
   }
 
   test("Iterant[Task].takeWhileWithIndex((_, _) => true) mirrors the source") { implicit s =>
@@ -127,7 +127,7 @@ object IterantTakeWhileWithIndexSuite extends BaseTestSuite {
       val suffix = Iterant[Coeval].nextCursorS[Int](new ThrowExceptionCursor(dummy), Coeval.now(Iterant[Coeval].empty), Coeval.unit)
       val stream = (iter.onErrorIgnore ++ suffix).doOnEarlyStop(Coeval.eval(cancelable.cancel()))
 
-      intercept[DummyException] { stream.takeWhileWithIndex((_, _) => true).toListL.value }
+      intercept[DummyException] { stream.takeWhileWithIndex((_, _) => true).toListL.value() }
       cancelable.isCanceled
     }
   }
@@ -137,7 +137,7 @@ object IterantTakeWhileWithIndexSuite extends BaseTestSuite {
     val stop = Coeval.eval(effect += 1)
     val source = Iterant[Coeval].nextCursorS(BatchCursor(1,2,3), Coeval.now(Iterant[Coeval].empty[Int]), stop)
     val stream = source.takeWhileWithIndex((_, _) => true)
-    stream.earlyStop.value
+    stream.earlyStop.value()
     assertEquals(effect, 1)
   }
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantZipMapSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantZipMapSuite.scala
@@ -90,7 +90,7 @@ object IterantZipMapSuite extends BaseTestSuite {
     val source1 = Iterant[Coeval].nextCursorS(BatchCursor(1,2,3), Coeval.now(Iterant[Coeval].empty[Int]), stop)
     val source2 = Iterant[Coeval].nextCursorS(BatchCursor(1,2,3), Coeval.now(Iterant[Coeval].empty[Int]), stop)
     val stream = source1.zip(source2)
-    stream.earlyStop.value
+    stream.earlyStop.value()
     assertEquals(effect, 2)
   }
 

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantZipWithIndexSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantZipWithIndexSuite.scala
@@ -90,7 +90,7 @@ object IterantZipWithIndexSuite extends BaseTestSuite {
       val stream = (iter.onErrorIgnore ++ suffix).doOnEarlyStop(Coeval.eval(cancelable.cancel()))
 
       intercept[DummyException] {
-        stream.zipWithIndex.toListL.value
+        stream.zipWithIndex.toListL.value()
       }
       cancelable.isCanceled
     }
@@ -102,7 +102,7 @@ object IterantZipWithIndexSuite extends BaseTestSuite {
     val source = Iterant[Coeval].nextCursorS(BatchCursor(1, 2, 3), Coeval.now(Iterant[Coeval].empty[Int]), stop)
     val stream = source.zipWithIndex
 
-    stream.earlyStop.value
+    stream.earlyStop.value()
     assertEquals(effect, 1)
   }
 }


### PR DESCRIPTION
We discussed this on gitter some time ago. `Coeval#value` is now empty-parens, aligning with conventional way to indicate side-effects in Scala.

This does not trigger any warnings or errors. Only if using some kind of linter (e.g. Intellij does that) you will get something shown.

I went ahead and changed pretty much every usage of `value` to `value()` in monix codebase too.