### PR TITLE
Reference bufferTumbling instead of buffer in scaladoc

### DIFF
--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -355,7 +355,7 @@ abstract class Observable[+A] extends Serializable { self =>
     * For `count` and `skip` there are 3 possibilities:
     *
     *  1. in case `skip == count`, then there are no items dropped and
-    *     no overlap, the call being equivalent to `buffer(count)`
+    *     no overlap, the call being equivalent to `bufferTumbling(count)`
     *  1. in case `skip < count`, then overlap between buffers
     *     happens, with the number of elements being repeated being
     *     `count - skip`
@@ -367,7 +367,7 @@ abstract class Observable[+A] extends Serializable { self =>
     * @param skip how many items emitted by the source observable should
     *        be skipped before starting a new buffer. Note that when
     *        skip and count are equal, this is the same operation as
-    *        `buffer(count)`
+    *        `bufferTumbling(count)`
     */
   final def bufferSliding(count: Int, skip: Int): Observable[Seq[A]] =
     liftByOperator(new BufferSlidingOperator(count, skip))


### PR DESCRIPTION
Didn't create an issue since this is just typo-fixing.

There wasn't a method `buffer` with such a signature. The only one that fits the bill is `bufferTumbling`.