### PR TITLE
Fix ack.future called when ack is null

### DIFF
--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayBySelectorObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayBySelectorObservable.scala
@@ -94,7 +94,8 @@ class DelayBySelectorObservable[A,S](source: Observable[A], selector: A => Obser
 
       def onComplete(): Unit = {
         completeTriggered = true
-        ack.future.syncTryFlatten.syncOnContinue {
+        val ackFuture = if (ack ne null) ack.future else Continue
+        ackFuture.syncTryFlatten.syncOnContinue {
           if (!isDone) {
             isDone = true
             out.onComplete()

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DelayBySelectorSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DelayBySelectorSuite.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.reactive.Observable
 import scala.concurrent.duration._
+import scala.util.Success
 
 object DelayBySelectorSuite extends BaseOperatorSuite {
   def createObservable(sourceCount: Int) = Some {
@@ -52,5 +53,16 @@ object DelayBySelectorSuite extends BaseOperatorSuite {
     val o = Observable.now(1L)
       .delayOnNextBySelector(x => Observable.now(x).delaySubscription(1.second))
     Seq(Sample(o, 0, 0, 0.seconds, 0.seconds))
+  }
+
+  test("should terminate immediately on empty observable") { implicit s =>
+    val f = Observable.empty[Int]
+      .delayOnNextBySelector(n => Observable.empty)
+      .completedL
+      .runAsync
+
+    s.tick(1.day)
+
+    assertEquals(f.value, Some(Success(())))
   }
 }


### PR DESCRIPTION
A bug from gitter with .delayOnNextBySelector. See unit test for previously-failing case.