### PR TITLE
Handle InterruptedException in NonFatal

### DIFF
--- a/monix-execution/shared/src/main/scala/monix/execution/misc/NonFatal.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/misc/NonFatal.scala
@@ -29,6 +29,9 @@ object NonFatal {
   def apply(t: Throwable): Boolean = t match {
     // VirtualMachineError includes OutOfMemoryError and StackOverflowError
     case _: VirtualMachineError => false
+    case _: InterruptedException =>
+      Thread.currentThread().interrupt()
+      true
     case _ => true
   }
 

--- a/monix-execution/shared/src/test/scala/monix/execution/misc/NonFatalSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/misc/NonFatalSuite.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.execution.misc
+
+import minitest.TestSuite
+import monix.execution.schedulers.TestScheduler
+
+object NonFatalSuite extends TestSuite[TestScheduler] {
+  override def setup(): TestScheduler = TestScheduler()
+
+  override def tearDown(env: TestScheduler): Unit = assert(env.state.tasks.isEmpty, "should not have tasks left to execute")
+
+  test("handling InterruptedException") { implicit s =>
+    try {
+      throw new InterruptedException
+    } catch {
+      case NonFatal(e) =>
+        assert(e.isInstanceOf[InterruptedException])
+        assertEquals(Thread.interrupted(), true)
+      case _: Throwable =>
+        fail("Exception wast't caught by NonFatal")
+    }
+  }
+}


### PR DESCRIPTION
Fixes #645, so far it's using a shared implementation, but could be changed to have a separate one for JS and JVM worlds.