### PR TITLE
Make Iterant's ++ take a lazy (by-name) parameter #642

### DIFF
--- a/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
@@ -2358,6 +2358,12 @@ object Iterant extends IterantInstances {
     (implicit F: Async[F], timer: Timer[F]): Iterant[F, Long] =
     IterantIntervalWithFixedDelay(initialDelay, delay)
 
+  /** Concatenates list of Iterants into a single stream
+    */
+  def concat[F[_], A](xs: Iterant[F, A]*)(implicit F: Applicative[F]): Iterant[F, A] = {
+    xs.foldLeft(Iterant.empty[F, A])(IterantConcat.concat(_, _)(F))
+  }
+
   /** $NextDesc
     *
     * @param item $headParamDesc

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantConcatSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantConcatSuite.scala
@@ -62,4 +62,20 @@ object IterantConcatSuite extends BaseTestSuite {
     assertEquals(nats.toListL.value(), List(1, 2, 3, 4))
   }
 
+  test("Iterant.concat(Iterant*)") { implicit s =>
+    check1 { (ll: List[List[Int]]) =>
+      val li = ll.map(Iterant[Coeval].fromList)
+      val concat = Iterant.concat(li: _*)
+      val expected = Iterant[Coeval].fromList(ll.flatten)
+      concat <-> expected
+    }
+  }
+
+  test("Iterant.concat is eager") { implicit s =>
+    lazy val i: Iterant[Coeval, Int] = Iterant.concat(Iterant[Coeval].now(1), i)
+    intercept[StackOverflowError] {
+      i.take(1).sumL.value()
+    }
+  }
+
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantConcatSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantConcatSuite.scala
@@ -71,11 +71,4 @@ object IterantConcatSuite extends BaseTestSuite {
     }
   }
 
-  test("Iterant.concat is eager") { implicit s =>
-    lazy val i: Iterant[Coeval, Int] = Iterant.concat(Iterant[Coeval].now(1), i)
-    intercept[StackOverflowError] {
-      i.take(1).sumL.value()
-    }
-  }
-
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantConcatSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantConcatSuite.scala
@@ -56,4 +56,10 @@ object IterantConcatSuite extends BaseTestSuite {
       (i :+ e) <-> (i ++ Iterant[Coeval].pure(e))
     }
   }
+
+  test("Iterant ++ Iterant rhs by name") { implicit s =>
+    lazy val nats: Iterant[Coeval, Long] = Iterant[Coeval].of(1L) ++ nats.map(_ + 1L) take(4)
+    assertEquals(nats.toListL.value(), List(1, 2, 3, 4))
+  }
+
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantConcatSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantConcatSuite.scala
@@ -57,7 +57,7 @@ object IterantConcatSuite extends BaseTestSuite {
     }
   }
 
-  test("Iterant ++ Iterant rhs by name") { implicit s =>
+  test("Iterant ++ Iterant is stack safe") { implicit s =>
     lazy val nats: Iterant[Coeval, Long] = Iterant[Coeval].of(1L) ++ nats.map(_ + 1L) take(4)
     assertEquals(nats.toListL.value(), List(1, 2, 3, 4))
   }


### PR DESCRIPTION
Please note of the following lazy ++ performance issue:
```scala
val n = 1000
lazy val nats: Iterant[Coeval, Long] = Iterant[Coeval].of(1L) ++ nats.map(_ + 1L) take(n)
nats.sumL.value()
```
The following code has running time O(n^2) (as opposed to O(n) for the analogous `Stream` example, due to Stream memoization).
