### PR TITLE
Make TaskApp scheduler and options defs

### DIFF
--- a/monix-eval/js/src/main/scala/monix/eval/TaskApp.scala
+++ b/monix-eval/js/src/main/scala/monix/eval/TaskApp.scala
@@ -44,19 +44,17 @@ trait TaskApp {
   /** Scheduler for executing the [[Task]] action.
     * Defaults to `global`, but can be overridden.
     */
-  protected val scheduler: Coeval[Scheduler] =
-    Coeval.evalOnce(Scheduler.global)
+  protected def scheduler: Scheduler = Scheduler.global
 
   /** [[monix.eval.Task.Options Options]] for executing the
     * [[Task]] action. The default value is defined in
     * [[monix.eval.Task.defaultOptions defaultOptions]],
     * but can be overridden.
     */
-  protected val options: Coeval[Task.Options] =
-    Coeval.evalOnce(Task.defaultOptions)
+  protected def options: Task.Options = Task.defaultOptions
 
   @JSExport
   final def main(args: Array[String]): Unit = {
-    run(args).runAsyncOpt(scheduler.value(), options.value())
+    run(args).runAsyncOpt(scheduler, options)
   }
 }

--- a/monix-eval/js/src/test/scala/monix/eval/TaskAppSuite.scala
+++ b/monix-eval/js/src/test/scala/monix/eval/TaskAppSuite.scala
@@ -28,7 +28,7 @@ object TaskAppSuite extends SimpleTestSuite {
     var wasExecuted = false
 
     val app = new TaskApp {
-      override val scheduler = Coeval.now(testS)
+      override val scheduler = testS
       override def runl(args: List[String]) =
         Task { wasExecuted = args.headOption.getOrElse("false") == "true" }
     }
@@ -42,7 +42,7 @@ object TaskAppSuite extends SimpleTestSuite {
     var wasExecuted = false
 
     val app = new TaskApp {
-      override val scheduler = Coeval.now(testS)
+      override val scheduler = testS
       override def runc = Task { wasExecuted = true }
     }
 
@@ -65,7 +65,7 @@ object TaskAppSuite extends SimpleTestSuite {
       }
 
     val app = new TaskApp {
-      override val options = Coeval(opts2)
+      override val options = opts2
       override def runc =
         exposeOpts.map { x => p.success(x) }
     }

--- a/monix-eval/jvm/src/main/scala/monix/eval/TaskApp.scala
+++ b/monix-eval/jvm/src/main/scala/monix/eval/TaskApp.scala
@@ -43,18 +43,16 @@ trait TaskApp {
   /** Scheduler for executing the [[Task]] action.
     * Defaults to `global`, but can be overridden.
     */
-  protected val scheduler: Coeval[Scheduler] =
-    Coeval.evalOnce(Scheduler.global)
+  protected def scheduler: Scheduler = Scheduler.global
 
   /** [[monix.eval.Task.Options Options]] for executing the
     * [[Task]] action. The default value is defined in
     * [[monix.eval.Task.defaultOptions defaultOptions]],
     * but can be overridden.
     */
-  protected val options: Coeval[Task.Options] =
-    Coeval.evalOnce(Task.defaultOptions)
+  protected def options: Task.Options = Task.defaultOptions
 
   final def main(args: Array[String]): Unit = {
-    run(args).runSyncUnsafeOpt(Inf)(scheduler.value(), options.value(), implicitly)
+    run(args).runSyncUnsafeOpt(Inf)(scheduler, options, implicitly)
   }
 }

--- a/monix-eval/jvm/src/test/scala/monix/eval/TaskAppSuite.scala
+++ b/monix-eval/jvm/src/test/scala/monix/eval/TaskAppSuite.scala
@@ -58,7 +58,7 @@ object TaskAppSuite extends SimpleTestSuite {
       }
 
     val app = new TaskApp {
-      override val options = Coeval(opts2)
+      override val options = opts2
       override def runc =
         exposeOpts.map { x => p.success(x) }
     }


### PR DESCRIPTION
We discussed this at gitter a while ago

Benefits of using `def`s:

* You can override them with an `implicit val`, which is quite relevant for options after #634. Doing so will make `ConcurrentEffect[Task]` instance materializable with expected configuration.
* You can do simple alterations by doing `super`, e.g.
```scala
override val scheduler = super.scheduler.withExecutionModel(AlwaysAsyncExecution)
override val options = super.options.enableLocalContextPropagation
```