### PR TITLE
Proposal: make mapBoth always execute tasks in parallel

### DIFF
--- a/monix-eval/shared/src/test/scala/monix/eval/MVarSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/MVarSuite.scala
@@ -44,7 +44,9 @@ object MVarSuite extends BaseTestSuite {
       r2 <- Task.mapBoth(av.take, av.put(20))((r,_) => r)
     } yield List(r1,r2)
 
-    assertEquals(task.runSyncMaybe, Right(List(10,20)))
+    val f = task.runAsync
+    s.tick()
+    assertEquals(f.value, Some(Success(List(10,20))))
   }
 
   test("empty; put; put; put; take; take; take") { implicit s =>
@@ -123,7 +125,8 @@ object MVarSuite extends BaseTestSuite {
       av <- MVar.empty[Int]
       r  <- Task.mapBoth(av.read, av.put(10))((r, _) => r)
     } yield r
-    assertEquals(task.runSyncMaybe, Right(10))
+    val f = task.runAsync; s.tick()
+    assertEquals(f.value, Some(Success(10)))
   }
 
   test("put(null) throws NullPointerException") { implicit s =>

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskMapBothSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskMapBothSuite.scala
@@ -23,12 +23,14 @@ import cats.laws.discipline._
 import scala.util.{Failure, Success}
 
 object TaskMapBothSuite extends BaseTestSuite {
-  test("if both tasks are synchronous, then mapBoth is also synchronous") { implicit s =>
+  test("if both tasks are synchronous, then mapBoth does forking asynchronous") { implicit s =>
     val ta = Task.eval(1)
     val tb = Task.eval(2)
 
     val r = Task.mapBoth(ta,tb)(_ + _)
     val f = r.runAsync
+    assertEquals(f.value, None)
+    s.tickOne()
     assertEquals(f.value, Some(Success(3)))
   }
 


### PR DESCRIPTION
Got caught up by surprise by the following behavior:

```scala
import cats._, implicits._, effect._, monix.eval._
import java.util.concurrent.TimeUnit
import monix.execution.Scheduler.Implicits.global
import scala.concurrent.duration._

// Imagine this is some blocking operation
val blockingOp = Task.eval { Thread.sleep(1000) }

val nowL = Timer[Task].clockMonotonic(TimeUnit.SECONDS)

val task = for {
  start <- nowL
  _ <- Task.zip4(blockingOp, blockingOp, blockingOp, blockingOp)
  end <- nowL
  _ <- Task.eval(println(s"${end - start}s passed")) // 4s passed, expected: 1s
} yield ()

task.runSyncUnsafe(Duration.Inf)
```

This happens if Task is constructed by `.eval` as opposed to `.apply` (which I do all the time since this way I can control behavior later). In real example I have a flatMap-chain of `Task`s built on `Task.eval`.

This affects `Task.zipX`, `Task.parMapX` and also `Parallel` instance. I think it makes sense to always fork inside `mapBoth` because it's more likely to be what user expects.