### PR TITLE
Fix Task.bracket for auto-cancelable run-loops

### DIFF
--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -1203,7 +1203,7 @@ sealed abstract class Task[+A] extends TaskBinCompat[A] with Serializable {
     * }}}
     *
     * Normally this isn't cancelable and it might take a long time, but
-    * by calling `cancelable` on the result, we ensure that when cancellation
+    * by calling `autoCancelable` on the result, we ensure that when cancellation
     * is observed, at async boundaries, the loop will stop with the task
     * becoming a non-terminating one.
     *
@@ -1219,7 +1219,7 @@ sealed abstract class Task[+A] extends TaskBinCompat[A] with Serializable {
     * }}}
     *
     * Normally [[Task.apply]] does not yield a cancelable task, but by applying
-    * the `cancelable` transformation to it, the `println` will execute,
+    * the `autoCancelable` transformation to it, the `println` will execute,
     * but not the subsequent `flatMap` operation.
     */
   def autoCancelable: Task[A] =

--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -1222,7 +1222,7 @@ sealed abstract class Task[+A] extends TaskBinCompat[A] with Serializable {
     * the `cancelable` transformation to it, the `println` will execute,
     * but not the subsequent `flatMap` operation.
     */
-  def cancelable: Task[A] =
+  def autoCancelable: Task[A] =
     TaskCancellation.makeCancelable(this)
 
   /** Returns a failed projection of this task.

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskBinCompat.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskBinCompat.scala
@@ -115,6 +115,17 @@ private[eval] abstract class TaskBinCompat[+A] { self: Task[A] =>
     self.flatMap(a => selector(a).map(_ => a))
     // $COVERAGE-OFF$
   }
+
+  /**
+    * DEPRECATED - renamed to [[autoCancelable]], in order to differentiate
+    * it from the `Task.cancelable` builder.
+    */
+  @deprecated("Renamed to autoCancelable", "3.0.0")
+  def cancelable: Task[A] = {
+    // $COVERAGE-OFF$
+    autoCancelable
+    // $COVERAGE-ON$
+  }
 }
 
 private[eval] abstract class TaskBinCompatCompanion {

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskBracket.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskBracket.scala
@@ -17,9 +17,12 @@
 
 package monix.eval.internal
 
-import java.util.concurrent.CancellationException
 import cats.effect.ExitCase
-import monix.eval.Task
+import cats.effect.ExitCase.{Completed, Error}
+import monix.eval.Task.Context
+import monix.eval.{Callback, Task}
+import monix.execution.Cancelable
+import monix.execution.atomic.Atomic
 import monix.execution.internal.Platform
 import monix.execution.misc.NonFatal
 
@@ -32,10 +35,21 @@ private[eval] object TaskBracket {
     use: A => Task[B],
     release: (A, Either[Option[Throwable], B]) => Task[Unit]): Task[B] = {
 
-    acquire.flatMap { a =>
-      val next = try use(a) catch { case NonFatal(e) => Task.raiseError(e) }
-      next.onCancelRaiseError(isCancel).flatMap(new ReleaseFrameE(a, release))
-    }
+    Task.Async(
+      new StartE(acquire, use, release),
+      trampolineBefore = true,
+      trampolineAfter = true,
+      restoreLocals = false)
+  }
+
+  private final class StartE[A, B](
+    acquire: Task[A],
+    use: A => Task[B],
+    release: (A, Either[Option[Throwable], B]) => Task[Unit])
+    extends BaseStart(acquire, use) {
+
+    def makeReleaseFrame(ctx: Context, value: A) =
+      new ReleaseFrameE(ctx, value, release)
   }
 
   /**
@@ -46,42 +60,134 @@ private[eval] object TaskBracket {
     use: A => Task[B],
     release: (A, ExitCase[Throwable]) => Task[Unit]): Task[B] = {
 
-    acquire.flatMap { a =>
-      val next = try use(a) catch { case NonFatal(e) => Task.raiseError(e) }
-      next.onCancelRaiseError(isCancel).flatMap(new ReleaseFrameCase(a, release))
-    }
+    Task.Async(
+      new StartCase(acquire, use, release),
+      trampolineBefore = true,
+      trampolineAfter = true,
+      restoreLocals = false)
   }
 
-  private final class ReleaseFrameCase[A, B](
-    a: A,
+  private final class StartCase[A, B](
+    acquire: Task[A],
+    use: A => Task[B],
     release: (A, ExitCase[Throwable]) => Task[Unit])
-    extends StackFrame[B, Task[B]] {
+    extends BaseStart(acquire, use) {
 
-    def apply(b: B): Task[B] =
-      release(a, ExitCase.Completed).map(_ => b)
+    def makeReleaseFrame(ctx: Context, value: A) =
+      new ReleaseFrameCase(ctx, value, release)
+  }
 
-    def recover(e: Throwable): Task[B] = {
-      if (e ne isCancel)
-        release(a, ExitCase.Error(e)).flatMap(new ReleaseRecover(e))
-      else
-        release(a, canceled).flatMap(neverFn)
+  private abstract class BaseStart[A, B](
+    acquire: Task[A],
+    use: A => Task[B])
+    extends ((Context, Callback[B]) => Unit) {
+
+    protected def makeReleaseFrame(ctx: Context, value: A): BaseReleaseFrame[A, B]
+
+    final def apply(ctx: Context, cb: Callback[B]): Unit = {
+      // Async boundary needed, but it is guaranteed via Task.Async below
+      Task.unsafeStartNow(acquire, ctx, new Callback[A] {
+        def onSuccess(value: A): Unit = {
+          implicit val sc = ctx.scheduler
+          val conn = ctx.connection
+
+          val releaseFrame = makeReleaseFrame(ctx, value)
+          val onNext = {
+            val fb = try use(value) catch { case NonFatal(e) => Task.raiseError(e) }
+            fb.flatMap(releaseFrame)
+          }
+
+          conn.push(releaseFrame)
+          Task.unsafeStartNow(onNext, ctx, cb)
+        }
+
+        def onError(ex: Throwable): Unit =
+          cb.onError(ex)
+      })
     }
   }
 
   private final class ReleaseFrameE[A, B](
+    ctx: Context,
     a: A,
     release: (A, Either[Option[Throwable], B]) => Task[Unit])
-    extends StackFrame[B, Task[B]] {
+    extends BaseReleaseFrame[A, B](ctx, a) {
 
-    def apply(b: B): Task[B] =
-      release(a, Right(b)).map(_ => b)
+    def releaseOnSuccess(a: A, b: B): Task[Unit] =
+      release(a, Right(b))
+    def releaseOnError(a: A, e: Throwable): Task[Unit] =
+      release(a, Left(Some(e)))
+    def releaseOnCancel(a: A): Task[Unit] =
+      release(a, leftNone)
+  }
 
-    def recover(e: Throwable): Task[B] = {
-      if (e ne isCancel)
-        release(a, Left(Some(e))).flatMap(new ReleaseRecover(e))
-      else
-        release(a, leftNone).flatMap(neverFn)
+  private final class ReleaseFrameCase[A, B](
+    ctx: Context,
+    a: A,
+    release: (A, ExitCase[Throwable]) => Task[Unit])
+    extends BaseReleaseFrame[A, B](ctx, a) {
+
+    def releaseOnSuccess(a: A, b: B): Task[Unit] =
+      release(a, Completed)
+    def releaseOnError(a: A, e: Throwable): Task[Unit] =
+      release(a, Error(e))
+    def releaseOnCancel(a: A): Task[Unit] =
+      release(a, canceled)
+  }
+
+
+  private abstract class BaseReleaseFrame[A, B](ctx: Context, a: A)
+    extends StackFrame[B, Task[B]] with Cancelable {
+
+    private[this] val waitsForResult = Atomic(true)
+
+    protected def releaseOnSuccess(a: A, b: B): Task[Unit]
+    protected def releaseOnError(a: A, e: Throwable): Task[Unit]
+    protected def releaseOnCancel(a: A): Task[Unit]
+
+    private final def applyEffect(b: B): Task[B] = {
+      if (waitsForResult.compareAndSet(expect = true, update = false)) {
+        ctx.connection.pop()
+        releaseOnSuccess(a, b).map(_ => b)
+      } else {
+        Task.never
+      }
     }
+
+    final def apply(b: B): Task[B] = {
+      if (ctx.options.autoCancelableRunLoops)
+        Task.suspend(applyEffect(b)).uncancelable
+      else
+        applyEffect(b)
+    }
+
+    private final def recoverEffect(e: Throwable): Task[B] = {
+      if (waitsForResult.compareAndSet(expect = true, update = false)) {
+        ctx.connection.pop()
+        releaseOnError(a, e).flatMap(new ReleaseRecover(e))
+      } else {
+        Task.never
+      }
+    }
+
+    final def recover(e: Throwable): Task[B] = {
+      if (ctx.options.autoCancelableRunLoops)
+        Task.suspend(recoverEffect(e)).uncancelable
+      else
+        recoverEffect(e)
+    }
+
+    final def cancel(): Unit =
+      if (waitsForResult.compareAndSet(expect = true, update = false)) {
+        implicit val ec = ctx.scheduler
+        try {
+          val task = releaseOnCancel(a)
+          task.runAsync(Callback.empty)
+        } catch {
+          case NonFatal(e) =>
+            ec.reportFailure(e)
+        }
+      }
   }
 
   private final class ReleaseRecover(e: Throwable)
@@ -94,8 +200,6 @@ private[eval] object TaskBracket {
       Task.raiseError(Platform.composeErrors(e, e2))
   }
 
-  private val isCancel = new CancellationException("bracket")
-  private val neverFn = (_: Unit) => Task.never[Nothing]
   private val leftNone = Left(None)
   private val canceled = ExitCase.canceled[Throwable]
 }

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskBracketSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskBracketSuite.scala
@@ -161,4 +161,20 @@ object TaskBracketSuite extends BaseTestSuite {
     sc.tick()
     assertEquals(f.value, Some(Success(())))
   }
+
+  test("bracket works with auto-cancelable run-loops") { implicit sc =>
+    import concurrent.duration._
+
+    var effect = 0
+    val task = Task(1).bracket(_ => Task.sleep(1.second))(_ => Task(effect += 1))
+      .autoCancelable
+
+    val f = task.runAsync
+    sc.tick()
+    assertEquals(f.value, None)
+
+    f.cancel()
+    assertEquals(f.value, None)
+    assertEquals(effect, 1)
+  }
 }

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskBracketSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskBracketSuite.scala
@@ -166,7 +166,8 @@ object TaskBracketSuite extends BaseTestSuite {
     import concurrent.duration._
 
     var effect = 0
-    val task = Task(1).bracket(_ => Task.sleep(1.second))(_ => Task(effect += 1))
+    val task = Task(1)
+      .bracket(_ => Task.sleep(1.second))(_ => Task(effect += 1))
       .autoCancelable
 
     val f = task.runAsync

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskCancellationSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskCancellationSuite.scala
@@ -55,7 +55,7 @@ object TaskCancellationSuite extends BaseTestSuite {
   test("task.fork.flatMap(fa => fa.cancel.flatMap(_ => fa)) <-> Task.never") { implicit ec =>
     check1 { (task: Task[Int]) =>
       val fa = for {
-        forked <- task.attempt.asyncBoundary.cancelable.fork
+        forked <- task.attempt.asyncBoundary.autoCancelable.fork
         _ <- forked.cancel
         r <- forked.join
       } yield r

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskErrorSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskErrorSuite.scala
@@ -230,7 +230,7 @@ object TaskErrorSuite extends BaseTestSuite {
       Task[Int](throw DummyException("dummy")).onErrorFallbackTo(Task.defer(recursive()))
     }
 
-    val task = recursive().cancelable
+    val task = recursive().autoCancelable
     val f = task.runAsync
     assertEquals(f.value, None)
 
@@ -272,7 +272,7 @@ object TaskErrorSuite extends BaseTestSuite {
     val task = Task[Int](throw DummyException("dummy"))
       .onErrorRestart(s.executionModel.recommendedBatchSize*2)
 
-    val f = task.cancelable.runAsync
+    val f = task.autoCancelable.runAsync
     assertEquals(f.value, None)
 
     // cancelling after scheduled for execution, but before execution
@@ -313,7 +313,7 @@ object TaskErrorSuite extends BaseTestSuite {
 
   test("Task.onErrorRestartIf should be cancelable if ExecutionModel permits") { implicit s =>
     val task = Task[Int](throw DummyException("dummy")).onErrorRestartIf(_ => true)
-    val f = task.cancelable.runAsync
+    val f = task.autoCancelable.runAsync
     assertEquals(f.value, None)
 
     // cancelling after scheduled for execution, but before execution

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskFlatMapSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskFlatMapSuite.scala
@@ -54,7 +54,7 @@ object TaskFlatMapSuite extends BaseTestSuite {
 
     val atomic = Atomic(0)
     val f = loop(atomic)
-      .cancelable
+      .autoCancelable
       .runAsync
 
     assertEquals(atomic.get, expected)
@@ -79,7 +79,7 @@ object TaskFlatMapSuite extends BaseTestSuite {
     var result = Option.empty[Try[Unit]]
 
     val c = loop(atomic)
-      .cancelable
+      .autoCancelable
       .runAsync(new Callback[Unit] {
         def onSuccess(value: Unit): Unit =
           result = Some(Success(value))


### PR DESCRIPTION
This test fails currently:

```scala
    var effect = 0
    val task = Task(1)
      .bracket(_ => Task.sleep(1.second))(_ => Task(effect += 1))
      .autoCancelable

    val f = task.runAsync
    sc.tick()
```

PR is fixing it for auto-cancelable loops.

Also renamed `Task#cancelable` to `Task#autoCancelable`, to differentiate it from the `Task.cancelable` builder.