### PR TITLE
WIP: Make Task#start fork; deprecate Task#fork

### DIFF
--- a/monix-eval/jvm/src/test/scala/monix/eval/TypeClassLawsForTaskRunSyncUnsafeSuite.scala
+++ b/monix-eval/jvm/src/test/scala/monix/eval/TypeClassLawsForTaskRunSyncUnsafeSuite.scala
@@ -86,8 +86,8 @@ class BaseTypeClassLawsForTaskRunSyncUnsafeSuite(implicit opts: Task.Options)
 
   implicit def equalityIO[A](implicit A: Eq[A]): Eq[IO[A]] =
     Eq.instance { (a, b) =>
-      val ta = Try(a.unsafeRunSync())
-      val tb = Try(b.unsafeRunSync())
+      val ta = Try(a.unsafeRunTimed(timeout).get)
+      val tb = Try(b.unsafeRunTimed(timeout).get)
       equalityTry[A].eqv(ta, tb)
     }
 

--- a/monix-eval/shared/src/main/scala/monix/eval/instances/CatsBaseForTask.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/instances/CatsBaseForTask.scala
@@ -68,7 +68,7 @@ class CatsBaseForTask extends MonadError[Task, Throwable] with CoflatMap[Task] {
   override def fromTry[A](t: Try[A])(implicit ev: <:<[Throwable, Throwable]): Task[A] =
     Task.fromTry(t)
   override def coflatMap[A, B](fa: Task[A])(f: (Task[A]) => B): Task[B] =
-    fa.fork.map(fiber => f(fiber.join))
+    fa.start.map(fiber => f(fiber.join))
   override def coflatten[A](fa: Task[A]): Task[Task[A]] =
-    fa.fork.map(_.join)
+    fa.start.map(_.join)
 }

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskBinCompat.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskBinCompat.scala
@@ -22,6 +22,8 @@ import monix.eval.Task.{Async, Context}
 import monix.execution.annotations.UnsafeProtocol
 import monix.execution.{Cancelable, Scheduler}
 
+import scala.annotation.unchecked.uncheckedVariance
+
 private[eval] abstract class TaskBinCompat[+A] { self: Task[A] =>
   /** Deprecated — use [[redeem]] instead.
     *
@@ -127,6 +129,17 @@ private[eval] abstract class TaskBinCompat[+A] { self: Task[A] =>
     autoCancelable
     // $COVERAGE-ON$
   }
+
+  /**
+    * DEPRECATED - subsumed by [[start]].
+    *
+    * To be consistent with cats-effect 1.0.0, `start` now
+    * enforces an asynchronous boundary, being exactly the same
+    * as `fork` from 3.0.0-RC1
+    */
+  @deprecated("Replaced with start", since="3.0.0-RC2")
+  final def fork: Task[Fiber[A @uncheckedVariance]] =
+    this.start
 }
 
 private[eval] abstract class TaskBinCompatCompanion {

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskStart.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskStart.scala
@@ -23,18 +23,6 @@ import scala.concurrent.Promise
 
 private[eval] object TaskStart {
   /**
-    * Implementation for `Task.start`.
-    */
-  def trampolined[A](fa: Task[A]): Task[Fiber[A]] =
-    fa match {
-      // There's no point in evaluating strict stuff
-      case Task.Now(_) | Task.Error(_) =>
-        Task.Now(Fiber(fa))
-      case _ =>
-        Async(new StartTrampolined(fa), trampolineBefore = true, trampolineAfter = false)
-    }
-
-  /**
     * Implementation for `Task.fork`.
     */
   def forked[A](fa: Task[A]): Task[Fiber[A]] =
@@ -46,12 +34,7 @@ private[eval] object TaskStart {
         Async(new StartForked(fa), trampolineBefore = false, trampolineAfter = true)
     }
 
-  private class StartForked[A](fa: Task[A]) extends StartTrampolined[A](fa) {
-    override def start(fa: Task[A], ctx: Context, cb: Callback[A]): Unit =
-      Task.unsafeStartEnsureAsync(fa, ctx, cb)
-  }
-
-  private class StartTrampolined[A](fa: Task[A]) extends ((Context, Callback[Fiber[A]]) => Unit) {
+  private class StartForked[A](fa: Task[A]) extends ((Context, Callback[Fiber[A]]) => Unit) {
     final def apply(ctx: Context, cb: Callback[Fiber[A]]): Unit = {
       implicit val sc = ctx.scheduler
       // Standard Scala promise gets used for storing or waiting
@@ -61,13 +44,10 @@ private[eval] object TaskStart {
       // It needs its own context, its own cancelable
       val ctx2 = Task.Context(ctx.scheduler, ctx.options)
       // Starting actual execution of our newly created task;
-      start(fa, ctx2, Callback.fromPromise(p))
+      Task.unsafeStartEnsureAsync(fa, ctx2, Callback.fromPromise(p))
       // Signal the created fiber
       val task = TaskFromFuture.lightBuild(p.future, ctx2.connection)
       cb.onSuccess(Fiber(task))
     }
-
-    def start(fa: Task[A], ctx: Context, cb: Callback[A]): Unit =
-      Task.unsafeStartNow(fa, ctx, cb)
   }
 }

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskCancellationSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskCancellationSuite.scala
@@ -55,10 +55,10 @@ object TaskCancellationSuite extends BaseTestSuite {
     assertEquals(effect, 0)
   }
 
-  test("task.fork.flatMap(fa => fa.cancel.flatMap(_ => fa)) <-> Task.never") { implicit ec =>
+  test("task.start.flatMap(fa => fa.cancel.flatMap(_ => fa)) <-> Task.never") { implicit ec =>
     check1 { (task: Task[Int]) =>
       val fa = for {
-        forked <- task.attempt.asyncBoundary.autoCancelable.fork
+        forked <- task.attempt.asyncBoundary.autoCancelable.start
         _ <- forked.cancel
         r <- forked.join
       } yield r
@@ -131,11 +131,11 @@ object TaskCancellationSuite extends BaseTestSuite {
     }
   }
 
-  test("fa.onCancelRaiseError(e).fork.flatMap(fa => fa.cancel.flatMap(_ => fa)) <-> raiseError(e)") { implicit ec =>
+  test("fa.onCancelRaiseError(e).start.flatMap(fa => fa.cancel.flatMap(_ => fa)) <-> raiseError(e)") { implicit ec =>
     check2 { (fa: Task[Int], e: Throwable) =>
       val received = fa
         .onCancelRaiseError(e)
-        .fork
+        .start
         .flatMap(fa => fa.cancel.flatMap(_ => fa.join))
 
       received <-> Task.raiseError(e)
@@ -167,7 +167,7 @@ object TaskCancellationSuite extends BaseTestSuite {
   test("cancelBoundary cancels") { implicit ec =>
     check1 { (task: Task[Int]) =>
       (Task.cancelBoundary *> task)
-        .fork
+        .start
         .flatMap(f => f.cancel *> f.join) <-> Task.never
     }
   }

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskLocalSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskLocalSuite.scala
@@ -115,8 +115,8 @@ object TaskLocalSuite extends SimpleTestSuite {
 
     val test: Task[Unit] = for {
       local <- TaskLocal[String]("Good")
-      forked <- Task.sleep(1.second).fork
-      _ <- local.bind("Bad!")(forked.cancel).fork
+      forked <- Task.sleep(1.second).start
+      _ <- local.bind("Bad!")(forked.cancel).start
       _ <- Task.sleep(1.second)
       s <- local.read
       _ <- Task.now(assertEquals(s, "Good"))

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskStartSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskStartSuite.scala
@@ -71,11 +71,6 @@ object TaskStartSuite extends BaseTestSuite {
     }
   }
 
-  test("task.start starts evaluation immediately") { implicit sc =>
-    val task = Task(1 + 1).start.flatMap(_.join)
-    assertEquals(task.runAsync.value, Some(Success(2)))
-  }
-
   test("task.start is stack safe") { implicit sc =>
     val count = if (Platform.isJVM) 10000 else 1000
     def loop(n: Int): Task[Unit] =
@@ -88,24 +83,12 @@ object TaskStartSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(())))
   }
 
-  test("task.fork executes asynchronously") { implicit sc =>
-    val task = Task(1 + 1).fork.flatMap(_.join)
+  test("task.start executes asynchronously") { implicit sc =>
+    val task = Task(1 + 1).start.flatMap(_.join)
     val f = task.runAsync
 
     assertEquals(f.value, None)
     sc.tick()
     assertEquals(f.value, Some(Success(2)))
-  }
-
-  test("task.fork is stack safe") { implicit sc =>
-    val count = if (Platform.isJVM) 10000 else 1000
-    def loop(n: Int): Task[Unit] =
-      if (n > 0)
-        Task(n - 1).fork.flatMap(_.join).flatMap(loop)
-      else
-        Task.unit
-
-    val f = loop(count).runAsync; sc.tick()
-    assertEquals(f.value, Some(Success(())))
   }
 }


### PR DESCRIPTION
Currently failing tests:

In `monix.eval.TaskConversionsSuite`:
- [ ] Task.fromEffect(task.to[IO]) preserves cancelability


In `monix.eval.TypeClassLawsForTaskAutoCancelableRunSyncUnsafeSuite`:
- [ ] ConcurrentEffect[Task].concurrentEffect.runCancelable start.flatMap(_.cancel) coherence
- [ ] ConcurrentEffect[Task].concurrentEffect.release of bracket is not cancelable
- [ ] ConcurrentEffect[Task].concurrentEffect.asyncF registration can be cancelled
- [ ] ConcurrentEffect[Task].concurrentEffect.async cancelable receives cancel signal
- [ ] ConcurrentEffect[Task].concurrentEffect.acquire of bracket is not cancelable