### PR TITLE
Fix unwanted side effect in FutureUtils.timeoutTo (#695)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,3 +42,6 @@ https://github.com/greenhat
 
 Oleg Pyzhcov
 https://github.com/oleg-py
+
+Yuriy Badalyantc
+https://github.com/lmnet

--- a/monix-execution/jvm/src/test/scala/monix/execution/FutureUtilsJVMSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/FutureUtilsJVMSuite.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.execution
+
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicLong
+
+import minitest.TestSuite
+import monix.execution.FutureUtils.extensions._
+import monix.execution.schedulers.TestScheduler
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+object FutureUtilsJVMSuite extends TestSuite[TestScheduler] {
+
+  def setup() = TestScheduler()
+
+  def tearDown(env: TestScheduler): Unit = {
+    assert(env.state.tasks.isEmpty, "should not have tasks left to execute")
+  }
+
+  testAsync("timeoutTo should not evaluate fallback when future and timeout are finished at the same time") { _ =>
+    implicit val scheduler: Scheduler = Scheduler(Executors.newWorkStealingPool())
+
+    case class TestException() extends RuntimeException
+
+    val total = new AtomicLong(0)
+    val sideEffect = new AtomicLong(0)
+    val error = new AtomicLong(0)
+    val success = new AtomicLong(0)
+
+    val originalTimeout = 50.millis
+
+    def runFuture(timeout: FiniteDuration): Future[Unit] = {
+      total.incrementAndGet()
+
+      (for {
+        _ <- Future.delayedResult(originalTimeout) {
+          15
+        }.timeoutTo(timeout, {
+          sideEffect.incrementAndGet()
+          Future.failed(TestException())
+        })(Scheduler.Implicits.global)
+        _ <- FutureUtils.delayedResult(100.millis)(()) // wait for all concurrent processes
+      } yield ()).map { _ =>
+        success.incrementAndGet()
+        ()
+      }.recover {
+        case _: TestException =>
+          error.incrementAndGet()
+          ()
+      }
+    }
+
+    // this function runs a lot of futures and tries to adjust timeouts to catch race condition,
+    // when some futures finish with success and some finish with a timeout
+    def waitingForRace(timeout: FiniteDuration): Future[FiniteDuration] = {
+      total.set(0)
+      sideEffect.set(0)
+      error.set(0)
+      success.set(0)
+
+      val futures = (1 to 10000).map { _ =>
+        runFuture(timeout)
+      }
+
+      Future.sequence(futures).flatMap { _ =>
+        if (total.get == error.get) {
+          waitingForRace(timeout + 1.millis)
+        } else if (total.get == success.get) {
+          waitingForRace(timeout - 1.millis)
+        } else {
+          Future.successful(timeout)
+        }
+      }
+    }
+
+    waitingForRace(originalTimeout).map { _ =>
+      assertEquals(error.get + success.get, total.get)
+      assertEquals(sideEffect.get, error.get)
+    }
+  }
+
+}

--- a/monix-execution/shared/src/main/scala_2.11/monix/execution/FutureUtils.scala
+++ b/monix-execution/shared/src/main/scala_2.11/monix/execution/FutureUtils.scala
@@ -67,18 +67,24 @@ object FutureUtils {
   def timeoutTo[A](source: Future[A], atMost: FiniteDuration, fallback: => Future[A])
     (implicit s: Scheduler): Future[A] = {
 
-    val promise = Promise[A]()
+    val promise = Promise[Either[Unit, Try[A]]]()
     val task = s.scheduleOnce(atMost.length, atMost.unit,
-      new Runnable { def run() = promise.tryCompleteWith(fallback) })
+      new Runnable { def run() = promise.trySuccess(Left(())) })
 
     source.onComplete { r =>
       // canceling task to prevent waisted CPU resources and memory leaks
       // if the task has been executed already, this has no effect
       task.cancel()
-      promise.tryComplete(r)
+      promise.trySuccess(Right(r))
     }
 
-    promise.future
+    promise.future.flatMap {
+      case Right(res) => Future.fromTry(res)
+      case Left(_) =>
+        // evaluate fallback only here to exclude possibility of race condition
+        // between source and fallback when they are finishing at the same time
+        fallback
+    }
   }
 
   /** Utility that lifts a `Future[A]` into a `Future[Try[A]]`, exposing

--- a/monix-execution/shared/src/main/scala_2.12/monix/execution/FutureUtils.scala
+++ b/monix-execution/shared/src/main/scala_2.12/monix/execution/FutureUtils.scala
@@ -66,18 +66,24 @@ object FutureUtils {
   def timeoutTo[A](source: Future[A], atMost: FiniteDuration, fallback: => Future[A])
     (implicit s: Scheduler): Future[A] = {
 
-    val promise = Promise[A]()
+    val promise = Promise[Either[Unit, Try[A]]]()
     val task = s.scheduleOnce(atMost.length, atMost.unit,
-      new Runnable { def run() = promise.tryCompleteWith(fallback) })
+      new Runnable { def run() = promise.trySuccess(Left(())) })
 
     source.onComplete { r =>
       // canceling task to prevent waisted CPU resources and memory leaks
       // if the task has been executed already, this has no effect
       task.cancel()
-      promise.tryComplete(r)
+      promise.trySuccess(Right(r))
     }
 
-    promise.future
+    promise.future.flatMap {
+      case Right(res) => Future.fromTry(res)
+      case Left(_) =>
+        // evaluate fallback only here to exclude possibility of race condition
+        // between source and fallback when they are finishing at the same time
+        fallback
+    }
   }
 
   /** Utility that lifts a `Future[A]` into a `Future[Try[A]]`, exposing

--- a/monix-execution/shared/src/main/scala_2.12/monix/execution/FutureUtils.scala
+++ b/monix-execution/shared/src/main/scala_2.12/monix/execution/FutureUtils.scala
@@ -66,20 +66,20 @@ object FutureUtils {
   def timeoutTo[A](source: Future[A], atMost: FiniteDuration, fallback: => Future[A])
     (implicit s: Scheduler): Future[A] = {
 
-    val promise = Promise[Either[Unit, Try[A]]]()
+    val promise = Promise[Option[Try[A]]]()
     val task = s.scheduleOnce(atMost.length, atMost.unit,
-      new Runnable { def run() = promise.trySuccess(Left(())) })
+      new Runnable { def run() = promise.trySuccess(None) })
 
     source.onComplete { r =>
       // canceling task to prevent waisted CPU resources and memory leaks
       // if the task has been executed already, this has no effect
       task.cancel()
-      promise.trySuccess(Right(r))
+      promise.trySuccess(Some(r))
     }
 
     promise.future.flatMap {
-      case Right(res) => Future.fromTry(res)
-      case Left(_) =>
+      case Some(res) => Future.fromTry(res)
+      case None =>
         // evaluate fallback only here to exclude possibility of race condition
         // between source and fallback when they are finishing at the same time
         fallback

--- a/monix-execution/shared/src/test/scala/monix/execution/FutureUtilsSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/FutureUtilsSuite.scala
@@ -76,6 +76,19 @@ object FutureUtilsSuite extends TestSuite[TestScheduler] {
     assertEquals(t.value, Some(Failure(dummy)))
   }
 
+  test("timeoutTo should not evaluate fallback when future finished earlier than timeout") { implicit s =>
+    @volatile var called = false
+    val expected = 15
+    val f = Future.delayedResult(50.millis)(expected).timeoutTo(100.millis, {
+      called = true
+      Future.failed (new RuntimeException)
+    })
+
+    s.tick(1.second)
+    assertEquals(f.value, Some(Success(expected)))
+    assertEquals(called, false)
+  }
+
   test("materialize synchronous") { implicit s =>
     val f1 = Future.successful(1).materialize
     assertEquals(f1.value, Some(Success(Success(1))))


### PR DESCRIPTION
Fix for #695

To eliminate the possibility of race condition I moved `fallback` evaluation after promise resolving. It will lead to some overhead (extra `Either` allocation and `flatMap` on future), but I didn't find any better way to guarantee to fix the problem.

I added 2 test cases. First is pretty simple - just check that side-effect is not evaluated when future finished earlier than timeout. I placed it in the shared tests. 
The second one is a lot more interesting. I placed it on the JVM tests because this issue is reproducible only in environments with the real multithreading. This test runs on a real thread pool and tries to adjust timeout to find race condition. And when this race condition is found, it checks that the number of errors and side-effect evaluations is the same. This test is non-deterministic and takes some time to find race condition, but with this test, I was able to reproduce issue from #695 before this fix.