### PR TITLE
[WIP] Upgrade to Cats-Effect 1.0.0-RC3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,10 +11,10 @@ addCommandAlias("ci-jvm",     ";clean ;coreJVM/test:compile ;coreJVM/test")
 addCommandAlias("ci-js",      ";clean ;coreJS/test:compile  ;coreJS/test")
 addCommandAlias("release",    ";project monix ;+clean ;+package ;+publishSigned ;sonatypeReleaseAll")
 
-val catsVersion = "1.1.0"
+val catsVersion = "1.2.0"
 // Hash version is safe, containing a laws fix over 1.0.0-RC2:
 // https://github.com/typelevel/cats-effect/pull/277
-val catsEffectVersion = "1.0.0-RC2-93ac33d"
+val catsEffectVersion = "1.0.0-RC3"
 val jcToolsVersion = "2.1.1"
 val reactiveStreamsVersion = "1.0.2"
 val scalaTestVersion = "3.0.4"

--- a/monix-eval/shared/src/main/scala/monix/eval/instances/CatsAsyncForTask.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/instances/CatsAsyncForTask.scala
@@ -18,7 +18,7 @@
 package monix.eval
 package instances
 
-import cats.effect.{Async, Concurrent, ExitCase, IO}
+import cats.effect.{Async, CancelToken, Concurrent, ExitCase}
 import monix.eval.internal.TaskCreate
 
 /** Cats type class instance of [[monix.eval.Task Task]]
@@ -54,7 +54,7 @@ class CatsAsyncForTask extends CatsBaseForTask with Async[Task] {
   *  - [[https://github.com/typelevel/cats-effect typelevel/cats-effect]]
   */
 class CatsConcurrentForTask extends CatsAsyncForTask with Concurrent[Task] {
-  override def cancelable[A](k: (Either[Throwable, A] => Unit) => IO[Unit]): Task[A] =
+  override def cancelable[A](k: (Either[Throwable, A] => Unit) => CancelToken[Task]): Task[A] =
     TaskCreate.cancelableEffect(k)
   override def uncancelable[A](fa: Task[A]): Task[A] =
     fa.uncancelable

--- a/monix-eval/shared/src/main/scala/monix/eval/instances/CatsEffectForTask.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/instances/CatsEffectForTask.scala
@@ -18,7 +18,7 @@
 package monix.eval
 package instances
 
-import cats.effect.{ConcurrentEffect, Effect, ExitCase, IO}
+import cats.effect.{Fiber => _, _}
 import monix.eval.internal.TaskEffect
 import monix.execution.Scheduler
 
@@ -47,7 +47,7 @@ class CatsEffectForTask(implicit s: Scheduler, opts: Task.Options)
     */
   private[this] val F = CatsConcurrentForTask
 
-  override def runAsync[A](fa: Task[A])(cb: Either[Throwable, A] => IO[Unit]): IO[Unit] =
+  override def runAsync[A](fa: Task[A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[Unit] =
     TaskEffect.runAsync(fa)(cb)
   override def delay[A](thunk: => A): Task[A] =
     F.delay(thunk)
@@ -61,8 +61,6 @@ class CatsEffectForTask(implicit s: Scheduler, opts: Task.Options)
     F.bracket(acquire)(use)(release)
   override def bracketCase[A, B](acquire: Task[A])(use: A => Task[B])(release: (A, ExitCase[Throwable]) => Task[Unit]): Task[B] =
     F.bracketCase(acquire)(use)(release)
-  override def runSyncStep[A](fa: Task[A]): IO[Either[Task[A], A]] =
-    IO(fa.runSyncStepOpt(s, opts))
 }
 
 /** Cats type class instances of [[monix.eval.Task Task]] for
@@ -89,9 +87,9 @@ class CatsConcurrentEffectForTask(implicit s: Scheduler, opts: Task.Options)
     */
   private[this] val F = CatsConcurrentForTask
 
-  override def runCancelable[A](fa: Task[A])(cb: Either[Throwable, A] => IO[Unit]): IO[IO[Unit]] =
+  override def runCancelable[A](fa: Task[A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[CancelToken[Task]] =
     TaskEffect.runCancelable(fa)(cb)
-  override def cancelable[A](k: (Either[Throwable, A] => Unit) => IO[Unit]): Task[A] =
+  override def cancelable[A](k: (Either[Throwable, A] => Unit) => CancelToken[Task]): Task[A] =
     F.cancelable(k)
   override def uncancelable[A](fa: Task[A]): Task[A] =
     F.uncancelable(fa)

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskEffect.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskEffect.scala
@@ -18,7 +18,7 @@
 package monix.eval
 package internal
 
-import cats.effect.IO
+import cats.effect.{CancelToken, IO, SyncIO}
 import monix.execution.Scheduler
 import monix.execution.internal.AttemptCallback.noop
 import scala.util.control.NonFatal
@@ -33,15 +33,15 @@ private[eval] object TaskEffect {
     * `cats.effect.Effect#runAsync`
     */
   def runAsync[A](fa: Task[A])(cb: Either[Throwable, A] => IO[Unit])
-    (implicit s: Scheduler, opts: Task.Options): IO[Unit] =
-    IO { execute(fa, cb); () }
+    (implicit s: Scheduler, opts: Task.Options): SyncIO[Unit] =
+    SyncIO { execute(fa, cb); () }
 
   /**
     * `cats.effect.ConcurrentEffect#runCancelable`
     */
   def runCancelable[A](fa: Task[A])(cb: Either[Throwable, A] => IO[Unit])
-    (implicit s: Scheduler, opts: Task.Options): IO[IO[Unit]] =
-    IO(execute(fa, cb).cancelIO)
+    (implicit s: Scheduler, opts: Task.Options): SyncIO[CancelToken[Task]] =
+    SyncIO(Task.fromIO(execute(fa, cb).cancelIO))
 
   private def execute[A](fa: Task[A], cb: Either[Throwable, A] => IO[Unit])
     (implicit s: Scheduler, opts: Task.Options) = {

--- a/monix-execution/shared/src/main/scala/monix/execution/Cancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/Cancelable.scala
@@ -17,7 +17,7 @@
 
 package monix.execution
 
-import cats.effect.IO
+import cats.effect.{CancelToken, IO}
 import monix.execution.atomic.AtomicAny
 import monix.execution.exceptions.CompositeException
 import monix.execution.internal.AttemptCallback
@@ -152,12 +152,12 @@ object Cancelable {
 
   /** Extension methods for [[Cancelable]]. */
   implicit final class Extensions(val self: Cancelable) extends AnyVal {
-    /** Given a [[Cancelable]] reference, turn it into an `IO[Unit]`
+    /** Given a [[Cancelable]] reference, turn it into an `CancelToken[IO]`
       * that will trigger [[Cancelable.cancel cancel]] on evaluation.
       *
       * Useful when working with the `IO.cancelable` builder.
       */
-    def cancelIO: IO[Unit] =
+    def cancelIO: CancelToken[IO] =
       self match {
         case _: IsDummy => IO.unit
         case _ => IO(self.cancel())

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantIntervalAtFixedRate.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantIntervalAtFixedRate.scala
@@ -18,7 +18,7 @@
 package monix.tail.internal
 
 import cats.syntax.all._
-import cats.effect.{Async, Timer}
+import cats.effect.{Async, Clock, Timer}
 import monix.tail.Iterant
 import monix.tail.Iterant.Suspend
 import scala.concurrent.duration._
@@ -28,7 +28,7 @@ private[tail] object IterantIntervalAtFixedRate {
     * Implementation for `Iterant.intervalAtFixedRate`
     */
   def apply[F[_]](initialDelay: FiniteDuration, interval: FiniteDuration)
-    (implicit F: Async[F], timer: Timer[F]): Iterant[F, Long] = {
+    (implicit F: Async[F], timer: Timer[F], clock: Clock[F]): Iterant[F, Long] = {
 
     def loop(time: F[Long], index: Long): F[Iterant[F, Long]] =
       time.map { startTime =>
@@ -45,7 +45,7 @@ private[tail] object IterantIntervalAtFixedRate {
         Iterant.nextS[F, Long](index, rest)
       }
 
-    val time = timer.clockMonotonic(NANOSECONDS)
+    val time = clock.monotonic(NANOSECONDS)
     initialDelay match {
       case Duration.Zero =>
         Suspend(loop(time, 0))

--- a/monix-tail/shared/src/test/scala/monix/tail/IntervalIntervalSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IntervalIntervalSuite.scala
@@ -17,7 +17,7 @@
 
 package monix.tail
 
-import cats.effect.{IO, Timer}
+import cats.effect.IO
 import monix.eval.Task
 
 import scala.util.Success
@@ -159,7 +159,7 @@ object IntervalIntervalSuite extends BaseTestSuite {
 
     var effect = 0
     val lst = Iterant[IO].intervalAtFixedRate(1.second)
-      .mapEval(e => Timer[IO].sleep(100.millis).map { _ => effect += 1; e })
+      .mapEval(e => timer.sleep(100.millis).map { _ => effect += 1; e })
       .take(3)
       .toListL
       .unsafeToFuture()
@@ -207,7 +207,7 @@ object IntervalIntervalSuite extends BaseTestSuite {
 
     var effect = 0
     val lst = Iterant[IO].intervalAtFixedRate(2.seconds, 1.second)
-      .mapEval(e => Timer[IO].sleep(100.millis).map { _ => effect += 1; e })
+      .mapEval(e => timer.sleep(100.millis).map { _ => effect += 1; e })
       .take(3)
       .toListL
       .unsafeToFuture
@@ -256,7 +256,7 @@ object IntervalIntervalSuite extends BaseTestSuite {
 
     var effect = 0
     val lst = Iterant[IO].intervalAtFixedRate(1.second)
-      .mapEval(e => Timer[IO].sleep(2.seconds).map { _ => effect += 1; e })
+      .mapEval(e => timer.sleep(2.seconds).map { _ => effect += 1; e })
       .take(3)
       .toListL
       .unsafeToFuture

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantToReactivePublisherSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantToReactivePublisherSuite.scala
@@ -17,7 +17,7 @@
 
 package monix.tail
 
-import cats.effect.{Effect, ExitCase, IO}
+import cats.effect._
 import cats.laws._
 import cats.laws.discipline._
 import monix.eval.Task
@@ -83,7 +83,7 @@ object IterantToReactivePublisherSuite extends BaseTestSuite {
   }
 
   test("works with any Effect") { implicit s =>
-    implicit val ioEffect: Effect[IO] = new CustomIOEffect
+    implicit val ioEffect: Effect[IO] = new CustomIOEffect()(IO.contextShift(s))
     check1 { (stream: Iterant[IO, Int]) =>
       sum(stream, 1) <-> Task.fromEffect(stream.foldLeftL(0L)(_ + _))
     }
@@ -361,10 +361,8 @@ object IterantToReactivePublisherSuite extends BaseTestSuite {
       subscription
     }
 
-  class CustomIOEffect extends Effect[IO] {
-    def runSyncStep[A](fa: IO[A]): IO[Either[IO[A], A]] =
-      fa.runSyncStep
-    def runAsync[A](fa: IO[A])(cb: (Either[Throwable, A]) => IO[Unit]): IO[Unit] =
+  class CustomIOEffect(implicit contextShift: ContextShift[IO]) extends Effect[IO] {
+    def runAsync[A](fa: IO[A])(cb: (Either[Throwable, A]) => IO[Unit]): SyncIO[Unit]=
       fa.runAsync(cb)
     def async[A](k: ((Either[Throwable, A]) => Unit) => Unit): IO[A] =
       IO.async(k)
@@ -375,11 +373,11 @@ object IterantToReactivePublisherSuite extends BaseTestSuite {
     def flatMap[A, B](fa: IO[A])(f: (A) => IO[B]): IO[B] =
       fa.flatMap(f)
     def tailRecM[A, B](a: A)(f: (A) => IO[Either[A, B]]): IO[B] =
-      IO.ioEffect.tailRecM(a)(f)
+      IO.ioConcurrentEffect.tailRecM(a)(f)
     def raiseError[A](e: Throwable): IO[A] =
       IO.raiseError(e)
     def handleErrorWith[A](fa: IO[A])(f: (Throwable) => IO[A]): IO[A] =
-      IO.ioEffect.handleErrorWith(fa)(f)
+      IO.ioConcurrentEffect.handleErrorWith(fa)(f)
     def pure[A](x: A): IO[A] =
       IO.pure(x)
     override def liftIO[A](ioa: IO[A]): IO[A] =


### PR DESCRIPTION
My attempt at upgrading Cats-Effect version.

I hacked whatever I could to make it compile, mostly converting between `IO` and `F`. I won't be surprised if there are more direct ways but I am yet to become more comfortable with cancelation related internals so I didn't think about it too much.

One thing I don't like is that having `Scheduler` in scope doesn't give us  `ContextShift` for types other than `Task` (it could be done with any `ExecutionContext` + `Effect` but probably in Cats-Effect to avoid extra imports). It also means we don't have `Concurrent[IO]` unless we provide `ContextShift` on our own.

`evalOn` is implemented on top of bracket - do we want something else?

Things that don't work right now:

- `monix.eval.TaskConversionsSuite` fails this test:
```scala
test("Task.fromEffect(task.to[IO]) preserves cancelability") { implicit s =>
  check1 { (task: Task[Int]) =>
    val lh = Task.fromEffect(task.to[IO]).start.flatMap(f => f.cancel *> f.join)
    lh <-> task.start.flatMap(f => f.cancel *> f.join)
  }
}
```
I don't see why looking at the code, I'll have to play with it unless this is due to https://github.com/typelevel/cats-effect/pull/311 and the test itself need fixing ?

- `monix.tail.TypeClassLawsForIterantIOSuite` sometimes fails with:

```
[info] - MonadError[Iterant[IO]].monadError.semigroupal associativity *** FAILED ***
[info]   Exception raised on property evaluation. (Checkers.scala:39)
[info]   > ARG_0: Suspend(IO$1672045507)
[info]   > ARG_1: Suspend(IO$1743155629)
[info]   > ARG_2: Suspend(IO$1080941687)
[info]   > Exception: java.lang.StackOverflowError: null
[info]     minitest.api.Asserts.fail(Asserts.scala:103)
[info]     minitest.api.Asserts.fail$(Asserts.scala:102)
[info]     minitest.api.Asserts$.fail(Asserts.scala:106)
[info]     minitest.laws.Checkers.check(Checkers.scala:39)
[info]     minitest.laws.Checkers.check$(Checkers.scala:36)
[info]     monix.tail.TypeClassLawsForIterantIOSuite$.check(TypeClassLawsForIterantIOSuite.scala:27)
[info]     monix.tail.BaseLawsSuite.$anonfun$checkAllAsync$4(BaseLawsSuite.scala:73)
[info]     monix.eval.TestUtils.liftedTree1$1(TestUtils.scala:39)
[info]     monix.eval.TestUtils.silenceSystemErr(TestUtils.scala:38)
[info]     monix.eval.TestUtils.silenceSystemErr$(TestUtils.scala:32)
[info]     monix.tail.TypeClassLawsForIterantIOSuite$.silenceSystemErr(TypeClassLawsForIterantIOSuite.scala:27)
[info]     monix.tail.BaseLawsSuite.$anonfun$checkAllAsync$3(BaseLawsSuite.scala:73)
[info]     minitest.SimpleTestSuite.$anonfun$test$1(SimpleTestSuite.scala:27)
[info]     minitest.api.TestSpec$.$anonfun$sync$1(TestSpec.scala:51)
[info]     minitest.api.TestSpec.apply(TestSpec.scala:27)
[info]     minitest.api.Properties.$anonfun$iterator$2(Properties.scala:38)
[info]     minitest.api.TestSpec.apply(TestSpec.scala:27)
[info]     minitest.runner.Task.loop$1(Task.scala:40)
[info]     minitest.runner.Task.$anonfun$execute$1(Task.scala:47)
[info]     scala.concurrent.Future.$anonfun$flatMap$1(Future.scala:303)
[info]     ...
```