### PR TITLE
Add Concat and Scope to Iterant description

### DIFF
--- a/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
@@ -69,6 +69,13 @@ import scala.concurrent.duration.{Duration, FiniteDuration}
   *  - [[monix.tail.Iterant.Suspend Suspend]] is for suspending the
   *    evaluation of a stream.
   *
+  *  - [[monix.tail.Iterant.Concat Concat]] represents concatenation
+  *    of two streams.
+  *
+  *  - [[monix.tail.Iterant.Scope Scope]] is to specify the acquisition
+  *    and release of resources. It is effectively encoding of
+  *    [[https://typelevel.org/cats-effect/typeclasses/bracket.html Bracket]].
+  *
   *  - [[monix.tail.Iterant.Halt Halt]] represents an empty stream,
   *    signaling the end, either in success or in error.
   *

--- a/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
@@ -69,11 +69,11 @@ import scala.concurrent.duration.{Duration, FiniteDuration}
   *  - [[monix.tail.Iterant.Suspend Suspend]] is for suspending the
   *    evaluation of a stream.
   *
-  *  - [[monix.tail.Iterant.Concat Concat]] represents concatenation
+  *  - [[monix.tail.Iterant.Concat Concat]] represents the concatenation
   *    of two streams.
   *
   *  - [[monix.tail.Iterant.Scope Scope]] is to specify the acquisition
-  *    and release of resources. It is effectively encoding of
+  *    and release of resources. It is effectively the encoding of
   *    [[https://typelevel.org/cats-effect/typeclasses/bracket.html Bracket]].
   *
   *  - [[monix.tail.Iterant.Halt Halt]] represents an empty stream,


### PR DESCRIPTION
It seems like we've forgotten to do it during `Iterant` rewrite