### PR TITLE
fix all Scaladocs (except Task's) in monix.eval

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -469,7 +469,7 @@ lazy val executionJS = project.in(file("monix-execution/js"))
 
 lazy val doctestTestSettings = Seq(
   doctestTestFramework := DoctestTestFramework.Minitest,
-  doctestIgnoreRegex := Some("^(?!.*?(?:(Coeval|Fiber))).*$"),
+  doctestIgnoreRegex := Some(s".*Task(|App).scala"),
   doctestOnlyCodeBlocksMode := true
 )
 

--- a/monix-eval/shared/src/main/scala/monix/eval/MVar.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/MVar.scala
@@ -73,9 +73,10 @@ abstract class MVar[A] {
     * until there is a value available, at which point the operation
     * resorts to a [[take]] followed by a [[put]].
     *
-    * This `read` operation is equivalent to:
+    * This `read` operation is equivalent to a method like this:
     * {{{
-    *   for (a <- v.take; _ <- v.put(a)) yield a
+    *   def readMVar[A](v: MVar[A]) =
+    *     for (a <- v.take; _ <- v.put(a)) yield a
     * }}}
     *
     * This operation is not atomic. Being equivalent with a `take`

--- a/monix-eval/shared/src/main/scala/monix/eval/TaskApp.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/TaskApp.scala
@@ -38,14 +38,15 @@ import monix.execution.Scheduler
   * with the numeric value of the signal plus 128.
   *
   * {{{
-  *   import monix.eval._
+  *   import cats.effect._
   *   import cats.implicits._
+  *   import monix.eval._
   *
   *   object MyApp extends TaskApp {
   *     def run(args: List[String]): Task[ExitCode] =
   *       args.headOption match {
   *         case Some(name) =>
-  *           Task(println(s"Hello, \${name}.")).as(ExitCode.Success)
+  *           Task(println(s"Hello, \\${name}.")).as(ExitCode.Success)
   *         case None =>
   *           Task(System.err.println("Usage: MyApp name")).as(ExitCode(2))
   *       }

--- a/monix-eval/shared/src/main/scala/monix/eval/TaskCircuitBreaker.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/TaskCircuitBreaker.scala
@@ -109,7 +109,8 @@ import scala.util.{Failure, Success}
   *       throw new RuntimeException("dummy")
   *   }
   *
-  *   val task = circuitBreaker.protect(problematic)
+  *   val task = circuitBreaker
+  *     .flatMap(_.protect(problematic))
   * }}}
   *
   * When attempting to close the circuit breaker and resume normal
@@ -117,7 +118,7 @@ import scala.util.{Failure, Success}
   * failed attempts, like so:
   *
   * {{{
-  *   val circuitBreaker = TaskCircuitBreaker(
+  *   val exponential = TaskCircuitBreaker(
   *     maxFailures = 5,
   *     resetTimeout = 10.seconds,
   *     exponentialBackoffFactor = 2,
@@ -535,9 +536,9 @@ object TaskCircuitBreaker {
       * when the `Open` state is to transition to [[HalfOpen]].
       *
       * It is calculated as:
-      * {{{
+      * ```scala
       *   startedAt + resetTimeout.toMillis
-      * }}}
+      * ```
       */
     val expiresAt: Timestamp = startedAt + resetTimeout.toMillis
   }

--- a/monix-eval/shared/src/main/scala/monix/eval/TaskLike.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/TaskLike.scala
@@ -20,7 +20,7 @@ package monix.eval
 import cats.Eval
 import cats.effect.{ConcurrentEffect, Effect, IO, SyncIO}
 import scala.annotation.implicitNotFound
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 import scala.util.Try
 
 /** A lawless type class that provides conversions to [[Task]].
@@ -31,13 +31,13 @@ import scala.util.Try
   *   import cats.Eval
   *
   *   val source0 = Eval.always(1 + 1)
-  *   val task0 = TaskLike[Eval].toTask(source)
+  *   val task0 = TaskLike[Eval].toTask(source0)
   *
   *   // Conversion from Future
   *   import scala.concurrent.Future
   *
-  *   val source1 = Future(1 + 1)
-  *   val task1 = TaskLike[Future].toTask(source)
+  *   val source1 = Future.successful(1 + 1)
+  *   val task1 = TaskLike[Future].toTask(source1)
   *
   *   // Conversion from IO
   *   import cats.effect.IO
@@ -79,7 +79,7 @@ object TaskLike extends TaskLikeImplicits0 {
   /**
     * Converts to `Task` from [[scala.concurrent.Future]].
     */
-  implicit def fromFuture(implicit ec: ExecutionContext): TaskLike[Future] =
+  implicit val fromFuture: TaskLike[Future] =
     new TaskLike[Future] {
       def toTask[A](fa: Future[A]): Task[A] =
         Task.fromFuture(fa)

--- a/monix-eval/shared/src/main/scala/monix/eval/TaskLocal.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/TaskLocal.scala
@@ -38,7 +38,10 @@ import monix.execution.misc.Local
   * a single call is sufficient just before `runAsync`:
   *
   * {{{
-  *   task.executeWithOptions(_.enableLocalContextPropagation)
+  *   import monix.execution.Scheduler.Implicits.global
+  *
+  *   val t = Task(42)
+  *   t.executeWithOptions(_.enableLocalContextPropagation)
   *     // triggers the actual execution
   *     .runAsync
   * }}}
@@ -48,10 +51,12 @@ import monix.execution.misc.Local
   * and specify the set of options implicitly:
   *
   * {{{
-  *   implicit val opts = Task.defaultOptions.enableLocalContextPropagation
+  *   {
+  *     implicit val options = Task.defaultOptions.enableLocalContextPropagation
   *
-  *   // Options passed implicitly
-  *   val f = task.runAsyncOpt
+  *     // Options passed implicitly
+  *     val f = t.runAsyncOpt
+  *   }
   * }}}
   *
   * Full example:
@@ -59,10 +64,9 @@ import monix.execution.misc.Local
   * {{{
   *   import monix.eval.{Task, TaskLocal}
   *
-  *   val local = TaskLocal(0)
-  *
   *   val task: Task[Unit] =
   *     for {
+  *       local <- TaskLocal(0)
   *       value1 <- local.read // value1 == 0
   *       _ <- local.write(100)
   *       value2 <- local.read // value2 == 100
@@ -90,7 +94,7 @@ import monix.execution.misc.Local
   *   implicit val opts = Task.defaultOptions.enableLocalContextPropagation
   *
   *   // Triggering actual execution
-  *   val f = task.runAsyncOpt
+  *   val result = task.runAsyncOpt
   * }}}
   */
 final class TaskLocal[A] private (default: => A) {

--- a/monix-eval/shared/src/main/scala/monix/eval/TaskSemaphore.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/TaskSemaphore.scala
@@ -29,13 +29,17 @@ import monix.execution.schedulers.TrampolinedRunnable
   * maximum parallelism of 10:
   *
   * {{{
+  *   case class HttpRequest()
+  *   case class HttpResponse()
+  *
   *   val semaphore = TaskSemaphore(maxParallelism = 10)
   *
   *   def makeRequest(r: HttpRequest): Task[HttpResponse] = ???
   *
   *   // For such a task no more than 10 requests
   *   // are allowed to be executed in parallel.
-  *   val task = semaphore.greenLight(makeRequest(???))
+  *   val task = semaphore
+  *     .flatMap(_.greenLight(makeRequest(???)))
   * }}}
   */
 final class TaskSemaphore private (maxParallelism: Int) extends Serializable {

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskBinCompat.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskBinCompat.scala
@@ -84,6 +84,10 @@ private[eval] abstract class TaskBinCompat[+A] { self: Task[A] =>
     * redundant, as it can be expressed with `flatMap`, with the
     * same effect:
     * {{{
+    *   import monix.eval.Task
+    *
+    *   val trigger = Task(println("do it"))
+    *   val task = Task(println("must be done now"))
     *   trigger.flatMap(_ => task)
     * }}}
     *
@@ -108,6 +112,10 @@ private[eval] abstract class TaskBinCompat[+A] { self: Task[A] =>
     * with the same effect:
     *
     * {{{
+    *   import monix.eval.Task
+    *
+    *   val task = Task(5)
+    *   val selector = (n: Int) => Task(n.toString)
     *   task.flatMap(a => selector(a).map(_ => a))
     * }}}
     */
@@ -145,9 +153,9 @@ private[eval] abstract class TaskBinCompat[+A] { self: Task[A] =>
 
   /** DEPRECATED - replace with usage of [[Task.runSyncMaybe]]:
     *
-    * {{{
+    * ```scala
     *   task.coeval <-> Coeval(task.runSyncMaybe)
-    * }}}
+    * ```
     */
   @deprecated("Replaced with start", since="3.0.0-RC2")
   final def coeval(implicit s: Scheduler): Coeval[Either[CancelableFuture[A], A]] = {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/ObservableLike.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/ObservableLike.scala
@@ -23,7 +23,7 @@ import monix.eval.{Coeval, Task, TaskLike}
 import org.reactivestreams.{Publisher => RPublisher}
 
 import scala.annotation.implicitNotFound
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 import scala.util.Try
 
 /** A lawless type class that provides conversions to [[Observable]].
@@ -34,13 +34,13 @@ import scala.util.Try
   *   import cats.Eval
   *
   *   val source0 = Eval.always(1 + 1)
-  *   val task0 = ObservableLike[Eval].toObservable(source)
+  *   val task0 = ObservableLike[Eval].toObservable(source0)
   *
   *   // Conversion from Future
   *   import scala.concurrent.Future
   *
-  *   val source1 = Future(1 + 1)
-  *   val task1 = ObservableLike[Future].toObservable(source)
+  *   val source1 = Future.successful(1 + 1)
+  *   val task1 = ObservableLike[Future].toObservable(source1)
   *
   *   // Conversion from IO
   *   import cats.effect.IO
@@ -89,7 +89,7 @@ object ObservableLike extends ObservableLikeImplicits0 {
   /**
     * Converts to `Observable` from [[scala.concurrent.Future]].
     */
-  implicit def fromFuture(implicit ec: ExecutionContext): ObservableLike[Future] =
+  implicit val fromFuture: ObservableLike[Future] =
     new ObservableLike[Future] {
       def toObservable[A](fa: Future[A]): Observable[A] =
         Observable.fromFuture(fa)


### PR DESCRIPTION
this fixes almost all Scaladocs in `monix.eval` package
- `Task` excluded for now, as it is the biggest source of compile errors, just needs more time
- `TaskApp` is also excluded (though the code is compilable now) as it gives this strange warning (promoted to an error under `-X-fatal-warnings`)
```
Error:(40, 12) MyApp$2 has a main method with parameter type Array[String], but monix.eval.TaskAppDoctest.MyApp$2 will not be a runnable program.
  Reason: companion contains its own main method, which means no static forwarder can be generated.
    object MyApp extends TaskApp {
```
I think this is related to this object defined inside test method in generated test, not sure how to fix it
- also the Scaladoc in `TaskLike` lead me to removal of execution context parameter from `fromFuture`

so now instead of 
```scala
implicit def fromFuture(implicit ec: ExecutionContext): TaskLike[Future]
```
it's

```scala
implicit val fromFuture: TaskLike[Future]
```

looks like `ec` wasn't needed, but i'm not sure there wasn't some planned usage for it, lmk about this one

@oleg-py @alexandru please review