### PR TITLE
Change to Scala's Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,13 @@
+# Code of Conduct
+
+We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other such characteristics.
+
+Everyone is expected to follow the [Scala Code of Conduct] when discussing the project on the available communication channels. If you are being harassed, please contact us immediately so that we can support you.
+
+## Moderation
+
+Any questions, concerns, or moderation requests please contact a maintainer of the project.
+
+- Alexandru Nedelcu: [gitter](https://gitter.im/alexandru) | [twitter](https://twitter.com/alexelcu) | [email](mailto:coc@temp18.alexn.org)
+
+[Scala Code of Conduct]: https://www.scala-lang.org/conduct/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,7 +6,7 @@ Everyone is expected to follow the [Scala Code of Conduct] when discussing the p
 
 ## Moderation
 
-Any questions, concerns, or moderation requests please contact a maintainer of the project.
+Any questions, concerns, or moderation requests please contact a member of the project.
 
 - Alexandru Nedelcu: [gitter](https://gitter.im/alexandru) | [twitter](https://twitter.com/alexelcu) | [email](mailto:coc@temp18.alexn.org)
 

--- a/README.md
+++ b/README.md
@@ -131,9 +131,8 @@ licensed with the same license that Monix is licensed with (Apache
 2.0, see LICENSE.txt).
 
 People are expected to follow the
-[Scala Code of Conduct](https://www.scala-lang.org/conduct/) when
+[Scala Code of Conduct](./CODE_OF_CONDUCT.md) when
 discussing Monix on GitHub, Gitter channel, or other venues.
-If you want to contact a maintainer see [the details](./CODE_OF_CONDUCT.md).
 
 Feel free to open an issue if you notice a bug, have an idea for a
 feature, or have a question about the code. Pull requests are also

--- a/README.md
+++ b/README.md
@@ -131,8 +131,9 @@ licensed with the same license that Monix is licensed with (Apache
 2.0, see LICENSE.txt).
 
 People are expected to follow the
-[Typelevel Code of Conduct](https://typelevel.org/conduct.html) when
-discussing Monix on the Github page, Gitter channel, or other venues.
+[Scala Code of Conduct](https://www.scala-lang.org/conduct/) when
+discussing Monix on GitHub, Gitter channel, or other venues.
+If you want to contact a maintainer see [the details](./CODE_OF_CONDUCT.md).
 
 Feel free to open an issue if you notice a bug, have an idea for a
 feature, or have a question about the code. Pull requests are also


### PR DESCRIPTION
This changes the project policy to Scala's [Code of Conduct](https://www.scala-lang.org/conduct/).

The Scala Code of Conduct is compatible with Typelevel's goals, while having a more positive wording and being more standard in the ecosystem.