### PR TITLE
Add Alternative instance for Observable

### DIFF
--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -20,7 +20,7 @@ package monix.reactive
 import java.io.{BufferedReader, InputStream, PrintStream, Reader}
 
 import cats.effect.{Effect, IO}
-import cats.{Applicative, Apply, CoflatMap, Eq, Eval, FlatMap, MonadError, Monoid, MonoidK, NonEmptyParallel, Order, ~>}
+import cats.{Alternative, Applicative, Apply, CoflatMap, Eq, Eval, FlatMap, MonadError, Monoid, NonEmptyParallel, Order, ~>}
 import monix.eval.Coeval.Eager
 import monix.eval.{Callback, Coeval, Task, TaskLift, TaskLike}
 import monix.execution.Ack.{Continue, Stop}
@@ -4628,7 +4628,7 @@ object Observable {
 
   /** Cats instances for [[Observable]]. */
   class CatsInstances extends MonadError[Observable, Throwable]
-    with MonoidK[Observable]
+    with Alternative[Observable]
     with CoflatMap[Observable]
     with TaskLift[Observable] {
 

--- a/monix-reactive/shared/src/test/scala/monix/reactive/TypeClassLawsForObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/TypeClassLawsForObservableSuite.scala
@@ -17,7 +17,7 @@
 
 package monix.reactive
 
-import cats.laws.discipline.{ApplyTests, CoflatMapTests, MonadErrorTests, MonoidKTests, NonEmptyParallelTests}
+import cats.laws.discipline.{AlternativeTests, ApplyTests, CoflatMapTests, MonadErrorTests, MonoidKTests, NonEmptyParallelTests}
 import monix.reactive.observables.CombineObservable
 
 object TypeClassLawsForObservableSuite extends BaseLawsTestSuite {
@@ -27,6 +27,10 @@ object TypeClassLawsForObservableSuite extends BaseLawsTestSuite {
 
   checkAllAsync("CoflatMap[Observable]") { implicit ec =>
     CoflatMapTests[Observable].coflatMap[Int, Int, Int]
+  }
+
+  checkAllAsync("Alternative[Observable]") { implicit ec =>
+    AlternativeTests[Observable].alternative[Int, Int, Int]
   }
 
   checkAllAsync("MonoidK[Observable]") { implicit ec =>


### PR DESCRIPTION
There are instances for Applicative and MonoidK, but not for Alternative. Observable already implements all the necessary abstract methods and follows the Alternative laws.

This adds Alternative to Observable.CatsInstances so that Alternative methods like `guard` can be used. It's also more convenient as an implicit dependency than `MonoidK with Applicative`.

Resolves #722.