### PR TITLE
Make Task auto-cancelable

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -361,6 +361,11 @@ def mimaSettings(projectName: String) = Seq(
     // Breakage - PR #700: renamed methods
     exclude[DirectMissingMethodProblem]("monix.reactive.Observable.delaySubscriptionWith"),
     exclude[DirectMissingMethodProblem]("monix.reactive.Observable.delaySubscription"),
+    // Breakage — PR 724: https://github.com/monix/monix/pull/724
+    exclude[MissingClassProblem]("monix.eval.Fiber$Impl"),
+    exclude[DirectMissingMethodProblem]("monix.eval.Fiber.apply"),
+    exclude[DirectMissingMethodProblem]("monix.eval.internal.TaskFromFuture.lightBuild"),
+    exclude[DirectMissingMethodProblem]("monix.eval.internal.TaskCancellation.signal"),
     // Internals ...
     exclude[DirectMissingMethodProblem]("monix.eval.Task#MaterializeTask.recover"),
     exclude[DirectMissingMethodProblem]("monix.eval.Coeval#MaterializeCoeval.recover"),

--- a/monix-eval/shared/src/main/scala/monix/eval/Fiber.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Fiber.scala
@@ -17,7 +17,7 @@
 
 package monix.eval
 
-import monix.eval.internal.TaskCancellation
+import cats.effect.CancelToken
 
 /** `Fiber` represents the (pure) result of a [[Task]] being started concurrently
   * and that can be either joined or cancelled.
@@ -63,7 +63,7 @@ trait Fiber[A] extends cats.effect.Fiber[Task, A] {
     * of the underlying fiber is already complete, then there's nothing
     * to cancel.
     */
-  def cancel: Task[Unit]
+  def cancel: CancelToken[Task]
 
   /** Returns a new task that will await for the completion of the
     * underlying fiber, (asynchronously) blocking the current run-loop
@@ -74,16 +74,11 @@ trait Fiber[A] extends cats.effect.Fiber[Task, A] {
 
 object Fiber {
   /**
-    * Wraps a [[Task]] value in a `Fiber` interface.
-    *
-    * This is usually done when the given `Task` reference is linked
-    * to some mutable variable and thus something that's worth cancelling.
+    * Builds a [[Fiber]] value out of a `task` and its cancelation token.
     */
-  def apply[A](task: Task[A]): Fiber[A] =
-    new Impl(task)
+  def apply[A](task: Task[A], cancel: CancelToken[Task]): Fiber[A] =
+    new Tuple(task, cancel)
 
-  private final class Impl[A](val join: Task[A]) extends Fiber[A] {
-    def cancel: Task[Unit] =
-      TaskCancellation.signal(join)
-  }
+  private final case class Tuple[A](join: Task[A], cancel: CancelToken[Task])
+    extends Fiber[A]
 }

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskBinCompat.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskBinCompat.scala
@@ -127,13 +127,16 @@ private[eval] abstract class TaskBinCompat[+A] { self: Task[A] =>
   }
 
   /**
-    * DEPRECATED - renamed to [[autoCancelable]], in order to differentiate
-    * it from the `Task.cancelable` builder.
+    * DEPRECATED - since Monix 3.0 the `Task` implementation has switched
+    * to auto-cancelable run-loops by default (which can still be turned off
+    * in its configuration).
+    *
+    * For ensuring the old behavior, you can use [[executeWithOptions]].
     */
-  @deprecated("Renamed to autoCancelable", "3.0.0")
+  @deprecated("Switch to executeWithOptions(_.enableAutoCancelableRunLoops)", "3.0.0")
   def cancelable: Task[A] = {
     // $COVERAGE-OFF$
-    autoCancelable
+    executeWithOptions(_.enableAutoCancelableRunLoops)
     // $COVERAGE-ON$
   }
 

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskCancellation.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskCancellation.scala
@@ -144,8 +144,14 @@ private[eval] object TaskCancellation {
     (_, _, old, current) => current.withOptions(old.options)
 
   private[this] val withConnectionUncancelable: Context => Context =
-    ct => ct.withConnection(StackedCancelable.uncancelable)
+    ct => {
+      ct.withConnection(StackedCancelable.uncancelable)
+        .withOptions(ct.options.disableAutoCancelableRunLoops)
+    }
 
   private[this] val restoreConnection: (Any, Throwable, Context, Context) => Context =
-    (_, _, old, current) => current.withConnection(old.connection)
+    (_, _, old, ct) => {
+      ct.withConnection(old.connection)
+        .withOptions(old.options)
+    }
 }

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskFromFuture.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskFromFuture.scala
@@ -73,18 +73,6 @@ private[eval] object TaskFromFuture {
           else sc.reportFailure(ex)
       }
     }
-
-  /** Internal implementation used in `Task.start`. */
-  def lightBuild[A](f: Future[A], c: Cancelable): Task[A] = {
-    // The task could have been a strict or easily computed value
-    // in which case we're already there
-    f.value match {
-      case None =>
-        rawAsync(startCancelable(_, _, f, c))
-      case Some(value) =>
-        Task.fromTry(value)
-    }
-  }
   
   private def rawAsync[A](start: (Context, Callback[A]) => Unit): Task[A] =
     Task.Async(

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskFromFuture.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskFromFuture.scala
@@ -59,6 +59,7 @@ private[eval] object TaskFromFuture {
             // Already completed future, streaming value immediately,
             // but with light async boundary to prevent stack overflows
             callback(value)
+
           case None =>
             future match {
               case cf: CancelableFuture[A] @unchecked =>
@@ -73,7 +74,7 @@ private[eval] object TaskFromFuture {
           else sc.reportFailure(ex)
       }
     }
-  
+
   private def rawAsync[A](start: (Context, Callback[A]) => Unit): Task[A] =
     Task.Async(
       start,

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskMemoize.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskMemoize.scala
@@ -75,7 +75,7 @@ private[eval] object TaskMemoize {
       // or only successful results?
       if (self.cacheErrors || value.isSuccess) {
         state.getAndSet(value) match {
-          case (p: Promise[A] @unchecked, _) =>
+          case p: Promise[A] @unchecked =>
             if (!p.tryComplete(value)) {
               // $COVERAGE-OFF$
               if (value.isFailure)
@@ -90,10 +90,10 @@ private[eval] object TaskMemoize {
       } else {
         // Error happened and we are not caching errors!
         state.get match {
-          case current @ (p: Promise[A] @unchecked, _) =>
+          case p: Promise[A] @unchecked =>
             // Resetting the state to `null` will trigger the
             // execution again on next `runAsync`
-            if (state.compareAndSet(current, null)) {
+            if (state.compareAndSet(p, null)) {
               p.tryComplete(value)
             } else {
               // Race condition, retry
@@ -122,17 +122,17 @@ private[eval] object TaskMemoize {
       * that will receive the result once the task is complete.
       */
     private def registerListener(
-      ref: (Promise[A], StackedCancelable),
+      p: Promise[A],
       context: Context,
       cb: Callback[A])
       (implicit ec: ExecutionContext): Unit = {
 
-      val (p, c) = ref
-      context.connection.push(c)
       p.future.onComplete { r =>
-        context.connection.pop()
-        context.frameRef.reset()
-        startFull(Task.fromTry(r), context, cb, null, null, null, 1)
+        // Listener is cancelable: we simply ensure that the result isn't streamed
+        if (!context.connection.isCanceled) {
+          context.frameRef.reset()
+          startFull(Task.fromTry(r), context, cb, null, null, null, 1)
+        }
       }
     }
 
@@ -143,19 +143,26 @@ private[eval] object TaskMemoize {
       implicit val sc: Scheduler = context.scheduler
       self.state.get match {
         case null =>
-          val update = (Promise[A](), context.connection)
+          val update = Promise[A]()
 
           if (!self.state.compareAndSet(null, update)) {
             // $COVERAGE-OFF$
             start(context, cb) // retry
             // $COVERAGE-ON$
           } else {
+            // Registering listener callback for when listener is ready
             self.registerListener(update, context, cb)
-            // With light async boundary to prevent stack-overflows!
-            Task.unsafeStartTrampolined(self.thunk, context, self.complete)
+
+            // Running main task in `uncancelable` model
+            val ctx2 = context
+              .withOptions(context.options.disableAutoCancelableRunLoops)
+              .withConnection(StackedCancelable.uncancelable)
+
+            // Start with light async boundary to prevent stack-overflows!
+            Task.unsafeStartTrampolined(self.thunk, ctx2, self.complete)
           }
 
-        case ref: (Promise[A], StackedCancelable) @unchecked =>
+        case ref: Promise[A] @unchecked =>
           self.registerListener(ref, context, cb)
 
         case ref: Try[A] @unchecked =>

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRacePair.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRacePair.scala
@@ -60,7 +60,7 @@ private[eval] object TaskRacePair {
       Task.unsafeStartEnsureAsync(fa, contextA, new Callback[A] {
         def onSuccess(valueA: A): Unit =
           if (isActive.getAndSet(false)) {
-            val fiberB = Fiber(TaskFromFuture.lightBuild(pb.future, connB))
+            val fiberB = Fiber(TaskFromFuture.strict(pb.future), Task(connB.cancel()))
             conn.pop()
             cb.onSuccess(Left((valueA, fiberB)))
           } else {
@@ -81,7 +81,7 @@ private[eval] object TaskRacePair {
       Task.unsafeStartEnsureAsync(fb, contextB, new Callback[B] {
         def onSuccess(valueB: B): Unit =
           if (isActive.getAndSet(false)) {
-            val fiberA = Fiber(TaskFromFuture.lightBuild(pa.future, connA))
+            val fiberA = Fiber(TaskFromFuture.strict(pa.future), Task(connA.cancel()))
             conn.pop()
             cb.onSuccess(Right((fiberA, valueB)))
           } else {

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskStart.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskStart.scala
@@ -29,7 +29,7 @@ private[eval] object TaskStart {
     fa match {
       // There's no point in evaluating strict stuff
       case Task.Now(_) | Task.Error(_) =>
-        Task.Now(Fiber(fa))
+        Task.Now(Fiber(fa, Task.unit))
       case _ =>
         Async(new StartForked(fa), trampolineBefore = false, trampolineAfter = true)
     }
@@ -46,8 +46,8 @@ private[eval] object TaskStart {
       // Starting actual execution of our newly created task;
       Task.unsafeStartEnsureAsync(fa, ctx2, Callback.fromPromise(p))
       // Signal the created fiber
-      val task = TaskFromFuture.lightBuild(p.future, ctx2.connection)
-      cb.onSuccess(Fiber(task))
+      val task = TaskFromFuture.strict(p.future)
+      cb.onSuccess(Fiber(task, Task(ctx2.connection.cancel())))
     }
   }
 }

--- a/monix-eval/shared/src/test/scala/monix/eval/BaseLawsSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/BaseLawsSuite.scala
@@ -142,9 +142,6 @@ trait ArbitraryInstancesBase extends monix.execution.ArbitraryInstances {
         Task.ContextSwitch[A](t, x => x.copy(), (_, _, old, _) => old)
       }
 
-    def genAutoCancelable: Gen[Task[A]] =
-      for (t <- genSimpleTask) yield t.autoCancelable
-
     def genFlatMap: Gen[Task[A]] =
       for {
         ioa <- genSimpleTask
@@ -170,7 +167,6 @@ trait ArbitraryInstancesBase extends monix.execution.ArbitraryInstances {
       1 -> genEval,
       1 -> genFail,
       1 -> genContextSwitch,
-      1 -> genAutoCancelable,
       1 -> genCancelable,
       1 -> genBindSuspend,
       1 -> genAsync,

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskBracketSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskBracketSuite.scala
@@ -168,7 +168,7 @@ object TaskBracketSuite extends BaseTestSuite {
     var effect = 0
     val task = Task(1)
       .bracket(_ => Task.sleep(1.second))(_ => Task(effect += 1))
-      .autoCancelable
+      .executeWithOptions(_.enableAutoCancelableRunLoops)
 
     val f = task.runAsync
     sc.tick()

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskCreateSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskCreateSuite.scala
@@ -39,12 +39,14 @@ object TaskCreateSuite extends BaseTestSuite {
   }
 
   test("returning Unit yields non-cancelable tasks") { implicit sc =>
+    implicit val opts = Task.defaultOptions.disableAutoCancelableRunLoops
+
     val task = Task.create[Int] { (sc, cb) =>
       sc.scheduleOnce(1.second)(cb.onSuccess(1))
       ()
     }
 
-    val f = task.runAsync
+    val f = task.runAsyncOpt
     sc.tick()
     assertEquals(f.value, None)
 

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskErrorSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskErrorSuite.scala
@@ -230,7 +230,7 @@ object TaskErrorSuite extends BaseTestSuite {
       Task[Int](throw DummyException("dummy")).onErrorFallbackTo(Task.defer(recursive()))
     }
 
-    val task = recursive().autoCancelable
+    val task = recursive().executeWithOptions(_.enableAutoCancelableRunLoops)
     val f = task.runAsync
     assertEquals(f.value, None)
 
@@ -272,7 +272,7 @@ object TaskErrorSuite extends BaseTestSuite {
     val task = Task[Int](throw DummyException("dummy"))
       .onErrorRestart(s.executionModel.recommendedBatchSize*2)
 
-    val f = task.autoCancelable.runAsync
+    val f = task.executeWithOptions(_.enableAutoCancelableRunLoops).runAsync
     assertEquals(f.value, None)
 
     // cancelling after scheduled for execution, but before execution
@@ -313,7 +313,7 @@ object TaskErrorSuite extends BaseTestSuite {
 
   test("Task.onErrorRestartIf should be cancelable if ExecutionModel permits") { implicit s =>
     val task = Task[Int](throw DummyException("dummy")).onErrorRestartIf(_ => true)
-    val f = task.autoCancelable.runAsync
+    val f = task.executeWithOptions(_.enableAutoCancelableRunLoops).runAsync
     assertEquals(f.value, None)
 
     // cancelling after scheduled for execution, but before execution

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskFlatMapSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskFlatMapSuite.scala
@@ -28,6 +28,7 @@ import scala.util.{Failure, Success, Try}
 
 object TaskFlatMapSuite extends BaseTestSuite {
   test("runAsync flatMap loop is not cancelable if autoCancelableRunLoops=false") { implicit s =>
+    implicit val opts = Task.defaultOptions.disableAutoCancelableRunLoops
     val maxCount = Platform.recommendedBatchSize * 4
 
     def loop(count: AtomicInt): Task[Unit] =
@@ -36,8 +37,7 @@ object TaskFlatMapSuite extends BaseTestSuite {
 
     val atomic = Atomic(0)
     val f = loop(atomic)
-      .executeWithOptions(_.disableAutoCancelableRunLoops)
-      .runAsync
+      .runAsyncOpt
 
     f.cancel(); s.tick()
     assertEquals(atomic.get, maxCount)
@@ -54,7 +54,7 @@ object TaskFlatMapSuite extends BaseTestSuite {
 
     val atomic = Atomic(0)
     val f = loop(atomic)
-      .autoCancelable
+      .executeWithOptions(_.enableAutoCancelableRunLoops)
       .runAsync
 
     assertEquals(atomic.get, expected)
@@ -79,7 +79,7 @@ object TaskFlatMapSuite extends BaseTestSuite {
     var result = Option.empty[Try[Unit]]
 
     val c = loop(atomic)
-      .autoCancelable
+      .executeWithOptions(_.enableAutoCancelableRunLoops)
       .runAsync(new Callback[Unit] {
         def onSuccess(value: Unit): Unit =
           result = Some(Success(value))

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskGatherUnorderedSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskGatherUnorderedSuite.scala
@@ -121,6 +121,8 @@ object TaskGatherUnorderedSuite extends BaseTestSuite {
   }
 
   test("Task.gatherUnordered should log errors if multiple errors happen") { implicit s =>
+    implicit val opts = Task.defaultOptions.disableAutoCancelableRunLoops
+
     val ex = DummyException("dummy1")
     var errorsThrow = 0
     val task1 = Task.raiseError[Int](ex).executeAsync
@@ -129,7 +131,7 @@ object TaskGatherUnorderedSuite extends BaseTestSuite {
       .doOnFinish { x => if (x.isDefined) errorsThrow += 1; Task.unit }
 
     val gather = Task.gatherUnordered(Seq(task1, task2))
-    val result = gather.runAsync
+    val result = gather.runAsyncOpt
     s.tick()
 
     assertEquals(result.value, Some(Failure(ex)))

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskMapBothSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskMapBothSuite.scala
@@ -111,9 +111,11 @@ object TaskMapBothSuite extends BaseTestSuite {
     val err2 = new RuntimeException("Error 2")
     val t2 = Task.defer(Task.raiseError[Int](err2)).executeAsync
 
-    val fb = Task.mapBoth(t1, t2)(_ + _).runAsync
-    s.tick()
+    val fb = Task.mapBoth(t1, t2)(_ + _)
+      .executeWithOptions(_.disableAutoCancelableRunLoops)
+      .runAsync
 
+    s.tick()
     fb.value match {
       case Some(Failure(`err1`)) =>
         assertEquals(s.state.lastReportedError, err2)

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskMemoizeOnSuccessSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskMemoizeOnSuccessSuite.scala
@@ -477,13 +477,13 @@ object TaskMemoizeOnSuccessSuite extends BaseTestSuite {
 
     third.cancel()
     s.tick()
-    assert(s.state.tasks.isEmpty, "tasks.isEmpty")
+    assert(s.state.tasks.nonEmpty, "tasks.nonEmpty")
 
     s.tick(1.second)
-    assertEquals(first.value, None)
-    assertEquals(second.value, None)
+    assertEquals(first.value, Some(Success(2)))
+    assertEquals(second.value, Some(Success(2)))
     assertEquals(third.value, None)
-    assertEquals(effect, 0)
+    assertEquals(effect, 1)
   }
 
   test("Task.memoizeOnSuccess should be cancellable (callback #1)") { implicit s =>
@@ -508,13 +508,13 @@ object TaskMemoizeOnSuccessSuite extends BaseTestSuite {
 
     c3.cancel()
     s.tick()
-    assert(s.state.tasks.isEmpty, "tasks.isEmpty")
+    assert(s.state.tasks.nonEmpty, "tasks.nonEmpty")
 
     s.tick(1.second)
-    assertEquals(first.future.value, None)
-    assertEquals(second.future.value, None)
+    assertEquals(first.future.value, Some(Success(2)))
+    assertEquals(second.future.value, Some(Success(2)))
     assertEquals(third.future.value, None)
-    assertEquals(effect, 0)
+    assertEquals(effect, 1)
   }
 
   test("Task.memoizeOnSuccess should be cancellable (callback #2)") { implicit s =>
@@ -539,16 +539,16 @@ object TaskMemoizeOnSuccessSuite extends BaseTestSuite {
 
     c3.cancel()
     s.tick()
-    assert(s.state.tasks.isEmpty, "tasks.isEmpty")
+    assert(s.state.tasks.nonEmpty, "tasks.nonEmpty")
 
     s.tick(1.second)
-    assertEquals(first.future.value, None)
-    assertEquals(second.future.value, None)
+    assertEquals(first.future.value, Some(Success(2)))
+    assertEquals(second.future.value, Some(Success(2)))
     assertEquals(third.future.value, None)
-    assertEquals(effect, 0)
+    assertEquals(effect, 1)
   }
 
-  test("Task.memoizeOnSuccess should not be re-executable after cancel") { implicit s =>
+  test("Task.memoizeOnSuccess should not be cancelable") { implicit s =>
     var effect = 0
     val task = Task.evalAsync { effect += 1; effect }.delayExecution(1.second).map(_ + 1).memoizeOnSuccess
     val first = task.runAsync
@@ -560,7 +560,7 @@ object TaskMemoizeOnSuccessSuite extends BaseTestSuite {
     first.cancel()
 
     s.tick()
-    assert(s.state.tasks.isEmpty, "tasks.isEmpty")
+    assert(s.state.tasks.nonEmpty, "tasks.nonEmpty")
     assertEquals(first.value, None)
     assertEquals(second.value, None)
     assertEquals(effect, 0)
@@ -569,29 +569,12 @@ object TaskMemoizeOnSuccessSuite extends BaseTestSuite {
     val third = task.runAsync
     val fourth = task.runAsync
 
-    s.tick()
-    assertEquals(third.value, None)
-    assertEquals(fourth.value, None)
-    assert(s.state.tasks.isEmpty, "tasks.isEmpty")
-  }
-
-  test("Task.memoizeOnSuccess should be uninterruptible if the source is") { implicit s =>
-    val task = Task.evalAsync(1).delayExecution(1.second).uncancelable.memoizeOnSuccess
-    val f = task.runAsync
-
-    s.tick()
-    assertEquals(f.value, None)
-
-    f.cancel()
-    assertEquals(f.value, None)
-    assert(s.state.tasks.nonEmpty, "tasks.nonEmpty")
-
     s.tick(1.second)
-    assertEquals(f.value, Some(Success(1)))
+    assertEquals(first.value, None)
+    assertEquals(second.value, Some(Success(2)))
+    assertEquals(third.value, Some(Success(2)))
+    assertEquals(fourth.value, Some(Success(2)))
     assert(s.state.tasks.isEmpty, "tasks.isEmpty")
-
-    val f2 = task.runAsync
-    assertEquals(f2.value, Some(Success(1)))
   }
 
   test("Task.evalAsync(error).memoizeOnSuccess can register multiple listeners") { implicit s =>

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskWanderUnorderedSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskWanderUnorderedSuite.scala
@@ -129,6 +129,8 @@ object TaskWanderUnorderedSuite extends BaseTestSuite {
   }
 
   test("Task.wanderUnordered should log errors if multiple errors happen") { implicit s =>
+    implicit val opts = Task.defaultOptions.disableAutoCancelableRunLoops
+
     val ex = DummyException("dummy1")
     var errorsThrow = 0
     val gather = Task.wanderUnordered(Seq(0, 0)) { _ =>
@@ -137,7 +139,7 @@ object TaskWanderUnorderedSuite extends BaseTestSuite {
         .doOnFinish { x => if (x.isDefined) errorsThrow += 1; Task.unit }
     }
 
-    val result = gather.runAsync
+    val result = gather.runAsyncOpt
     s.tick()
 
     assertEquals(result.value, Some(Failure(ex)))

--- a/monix-execution/js/src/main/scala/monix/execution/internal/Platform.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/internal/Platform.scala
@@ -55,7 +55,7 @@ private[monix] object Platform {
     * Auto cancelable run loops are set to `false` if Monix
     * is running on top of Scala.js.
     */
-  final val autoCancelableRunLoops: Boolean = false
+  final val autoCancelableRunLoops: Boolean = true
 
   /**
     * Local context propagation is set to `false` if Monix

--- a/monix-execution/js/src/test/scala/monix/execution/internal/PlatformSuite.scala
+++ b/monix-execution/js/src/test/scala/monix/execution/internal/PlatformSuite.scala
@@ -30,7 +30,7 @@ object PlatformSuite extends SimpleTestSuite {
   }
 
   test("autoCancelableRunLoops") {
-    assert(!Platform.autoCancelableRunLoops)
+    assert(Platform.autoCancelableRunLoops)
   }
 
   test("localContextPropagation") {

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/Platform.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/Platform.scala
@@ -65,17 +65,27 @@ private[monix] object Platform {
       .getOrElse(1024)
   }
 
-  /** Default value for auto cancelable loops is set to
-    * false. On top of the JVM the default can be overridden by
-    * setting the following system property:
+  /** Default value for auto cancelable loops, set to `false`.
     *
-    *  - `monix.environment.autoCancelableRunLoops`
-    *    (`true`, `yes` or `1` for enabling)
+    * On top of the JVM the default can be overridden by setting the following
+    * system property:
+    *
+    * `monix.environment.autoCancelableRunLoops`
+    *
+    * You can set the following values:
+    *
+    *  - `true`, `yes` or `1` for enabling (the default)
+    *  - `no`, `false` or `0` for disabling
+    *
+    * NOTE: this values was `false` by default prior to the Monix 3.0.0
+    * release. This changed along with the release of Cats-Effect 1.0.0
+    * which now recommends for this default to be `true` due to the design
+    * of its type classes.
     */
   val autoCancelableRunLoops: Boolean =
     Option(System.getProperty("monix.environment.autoCancelableRunLoops", ""))
       .map(_.toLowerCase)
-      .exists(v => v == "yes" || v == "true" || v == "1")
+      .forall(v => v != "no" && v != "false" && v != "0")
 
   /**
     * Default value for local context propagation loops is set to

--- a/monix-execution/jvm/src/test/scala/monix/execution/internal/PlatformSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/internal/PlatformSuite.scala
@@ -30,7 +30,7 @@ object PlatformSuite extends SimpleTestSuite {
   }
 
   test("autoCancelableRunLoops") {
-    assert(!Platform.autoCancelableRunLoops)
+    assert(Platform.autoCancelableRunLoops)
   }
 
   test("localContextPropagation") {

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/MapTaskConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/MapTaskConcurrencySuite.scala
@@ -19,13 +19,12 @@ package monix.reactive.internal.operators
 
 import monix.eval.Task
 import monix.execution.Cancelable
-import monix.execution.cancelables.BooleanCancelable
 import monix.reactive.{BaseConcurrencySuite, Observable}
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future, Promise}
 
 object MapTaskConcurrencySuite extends BaseConcurrencySuite {
-  val cancelTimeout = 3.minutes
+  val cancelTimeout = 30.seconds
   val cancelIterations = 1000
 
   test("mapTask should work for synchronous children") { implicit s =>
@@ -76,49 +75,6 @@ object MapTaskConcurrencySuite extends BaseConcurrencySuite {
         c.cancel()
       }
       Await.result(isCancelled, cancelTimeout)
-    }
-  }
-
-  test(s"mapTask should be cancellable, test 2, count $cancelIterations (issue #468)") { implicit s =>
-    def one(p: Promise[Unit])(x: Long): Task[Long] =
-      Task.cancelable0 { (sc, cb) =>
-        val ref = BooleanCancelable(() => p.trySuccess(()))
-        sc.executeAsync(() => if (!ref.isCanceled) cb.onSuccess(x))
-        ref
-      }
-
-    for (_ <- 0 until cancelIterations) {
-      val p = Promise[Unit]()
-      val c = Observable.range(0, Long.MaxValue)
-        .executeAsync
-        .uncancelable
-        .doOnError(p.tryFailure)
-        .doOnComplete(() => p.trySuccess(new IllegalStateException("complete")))
-        .doOnEarlyStop(() => p.trySuccess(()))
-        .mapTask(one(p))
-        .subscribe()
-
-      // Creating race condition
-      s.executeAsync(() => c.cancel())
-      Await.result(p.future, cancelTimeout)
-    }
-  }
-
-  test(s"mapTask should be cancellable, test 3, count $cancelIterations (issue #468)") { implicit s =>
-    for (_ <- 0 until cancelIterations) {
-      val p = Promise[Unit]()
-      val c = Observable.range(0, Long.MaxValue)
-        .executeAsync
-        .uncancelable
-        .doOnError(p.tryFailure)
-        .doOnComplete(() => p.trySuccess(new IllegalStateException("complete")))
-        .doOnEarlyStop(() => p.trySuccess(()))
-        .mapTask(x => Task.evalAsync(x))
-        .subscribe()
-
-      // Creating race condition
-      s.executeAsync(() => c.cancel())
-      Await.result(p.future, cancelTimeout)
     }
   }
 }

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/ScanTaskConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/ScanTaskConcurrencySuite.scala
@@ -19,13 +19,13 @@ package monix.reactive.internal.operators
 
 import monix.eval.Task
 import monix.execution.Cancelable
-import monix.execution.cancelables.BooleanCancelable
 import monix.reactive.{BaseConcurrencySuite, Observable}
+
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future, Promise}
 
 object ScanTaskConcurrencySuite extends BaseConcurrencySuite {
-  val cancelTimeout = 3.minutes
+  val cancelTimeout = 30.seconds
   val cancelIterations = 1000
 
   test("scanTask should work for synchronous children") { implicit s =>
@@ -76,47 +76,6 @@ object ScanTaskConcurrencySuite extends BaseConcurrencySuite {
         c.cancel()
       }
       Await.result(isCancelled, cancelTimeout)
-    }
-  }
-
-  test(s"scanTask should be cancellable, test 2, count $cancelIterations (issue #468)") { implicit s =>
-    def one(p: Promise[Unit])(acc: Long, x: Long): Task[Long] =
-      Task.cancelable0 { (sc, cb) =>
-        val ref = BooleanCancelable(() => p.trySuccess(()))
-        sc.executeAsync(() => if (!ref.isCanceled) cb.onSuccess(x))
-        ref
-      }
-
-    for (_ <- 0 until cancelIterations) {
-      val p = Promise[Unit]()
-      val c = Observable.range(0, Long.MaxValue)
-        .uncancelable
-        .doOnError(p.tryFailure)
-        .doOnComplete(() => p.trySuccess(new IllegalStateException("complete")))
-        .doOnEarlyStop(() => p.trySuccess(()))
-        .scanTask(Task.now(0L))(one(p))
-        .subscribe()
-
-      // Creating race condition
-      s.executeAsync(() => c.cancel())
-      Await.result(p.future, cancelTimeout)
-    }
-  }
-
-  test(s"scanTask should be cancellable, test 3, count $cancelIterations (issue #468)") { implicit s =>
-    for (_ <- 0 until cancelIterations) {
-      val p = Promise[Unit]()
-      val c = Observable.range(0, Long.MaxValue)
-        .uncancelable
-        .doOnError(p.tryFailure)
-        .doOnComplete(() => p.trySuccess(new IllegalStateException("complete")))
-        .doOnEarlyStop(() => p.trySuccess(()))
-        .scanTask(Task.now(0L))((_, x) => Task.evalAsync(x))
-        .subscribe()
-
-      // Creating race condition
-      s.executeAsync(() => c.cancel())
-      Await.result(p.future, cancelTimeout)
     }
   }
 }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -2884,15 +2884,19 @@ abstract class Observable[+A] extends Serializable { self =>
     * that upon execution will signal the first generated element of the
     * source observable. Returns an `Option` because the source can be empty.
     */
-  final def runAsyncGetFirst(implicit s: Scheduler): CancelableFuture[Option[A]] =
-    firstOptionL.runAsync
+  final def runAsyncGetFirst(implicit s: Scheduler): CancelableFuture[Option[A]] = {
+    implicit val opts = Task.defaultOptions.disableAutoCancelableRunLoops
+    firstOptionL.runAsyncOpt
+  }
 
   /** Creates a new [[monix.execution.CancelableFuture CancelableFuture]]
     * that upon execution will signal the last generated element of the
     * source observable. Returns an `Option` because the source can be empty.
     */
-  final def runAsyncGetLast(implicit s: Scheduler): CancelableFuture[Option[A]] =
-    lastOptionL.runAsync
+  final def runAsyncGetLast(implicit s: Scheduler): CancelableFuture[Option[A]] = {
+    implicit val opts = Task.defaultOptions.disableAutoCancelableRunLoops
+    lastOptionL.runAsyncOpt
+  }
 
   /** Returns a [[monix.eval.Task Task]] that upon execution
     * will signal the last generated element of the source observable.

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapTaskSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapTaskSuite.scala
@@ -470,7 +470,8 @@ object MapTaskSuite extends BaseOperatorSuite {
 
     s.tick(1.second)
     assert(s.state.tasks.isEmpty, "state.tasks.isEmpty")
-    assertEquals(sumAfterMapFuture, 3)
+    assertEquals(sumAfterMapTask, 2)
+    assertEquals(sumAfterMapFuture, 0)
 
     s.tick(1.hour)
     assertEquals(f.value, None)


### PR DESCRIPTION
This is a second proposal, as a competitor to #721. In this one I'm not touching `Task.Options`.

Unfortunately I realized that the implementation in #721 has flaws due to Task's internals and I can't expose `Resource` without making the internal `Context` mutable.

PR changes:

1. `Task` becomes auto-cancelable by default
2. The `autoCancelable` helper is gone
3. `Task#memoize` and `memoizeOnSuccess` are now uncancelable: it was a mistake to leave the possibility for any of the consumers to cancel the source
4. Ditto for `Fiber#join` ... cancelling it no longer cancels the source, only `Fiber#cancel` does, this following a similar change in Cats-Effect
5. Optimized `executeWithOptions` to be based on `ContextSwitch` and to no longer do any asynchrony
