### PR TITLE
Avoid buffer size overflow in MapAsyncParallelSubscription

### DIFF
--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapAsyncParallelObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapAsyncParallelObservable.scala
@@ -77,7 +77,11 @@ private[reactive] final class MapAsyncParallelObservable[A,B]
     // used as an overflow strategy, meaning that when the buffer
     // is full then the data source gets frozen
     private[this] val buffer = {
-      val strategy = BackPressure(parallelism + Platform.recommendedBatchSize)
+      val bufferSize = {
+        val size = parallelism + Platform.recommendedBatchSize //can overflow
+        if (size < 0) Int.MaxValue else size
+      }
+      val strategy = BackPressure(bufferSize)
       BufferedSubscriber[B](out, strategy)
     }
 

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapAsyncParallelSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapAsyncParallelSuite.scala
@@ -145,9 +145,8 @@ object MapAsyncParallelSuite extends BaseOperatorSuite {
   }
 
   test("should work for any positive parallelism") { implicit s =>
-    implicit lazy val arbInt: Arbitrary[Int] = Arbitrary(
-      Gen.chooseNum(1, Int.MaxValue)
-    )
+    implicit val positiveInt: Arbitrary[Int] = Arbitrary(Gen.chooseNum(1, Int.MaxValue))
+
     check2 { (list: List[Int], parallelism: Int) =>
       val result: Future[List[Int]] =
         Observable


### PR DESCRIPTION
Targetting `series/2.x` - this no longer seems to be the case in 3.x.

When parallelism was sufficiently high in `.mapAsync`, it could overflow after internal `Platform.recommendedBatchSize` addition.