### PR TITLE
Fix handling start/end of Long range in RangeObservable

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -48,3 +48,6 @@ https://github.com/lmnet
 
 Yohann Bredoux
 https://github.com/ybr
+
+Kacper Gunia
+https://github.com/cakper

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RangeObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RangeObservable.scala
@@ -35,7 +35,7 @@ private[reactive] final class RangeObservable(from: Long, until: Long, step: Lon
 
   def unsafeSubscribeFn(subscriber: Subscriber[Long]): Cancelable = {
     val s = subscriber.scheduler
-    if (!isInRange(from, until, step)) {
+    if (!isRangeValid(from, until, step)) {
       subscriber.onComplete()
       Cancelable.empty
     } else {
@@ -53,7 +53,7 @@ private[reactive] final class RangeObservable(from: Long, until: Long, step: Lon
     val ack = downstream.onNext(from)
     val nextFrom = from+step
 
-    if (!isInRange(nextFrom, until, step))
+    if (!isNextInRange(from, nextFrom, until, step))
       downstream.onComplete()
     else {
       val nextIndex =
@@ -85,9 +85,11 @@ private[reactive] final class RangeObservable(from: Long, until: Long, step: Lon
     }
   }
 
-  private def isInRange(x: Long, until: Long, step: Long): Boolean = {
-    (step > 0 && x < until) || (step < 0 && x > until)
+  private def isRangeValid(from: Long, until: Long, step: Long): Boolean = {
+    (step > 0 && from < until) || (step < 0 && from > until)
+  }
+
+  private def isNextInRange(from: Long, nextFrom: Long, until: Long, step: Long): Boolean = {
+    (step > 0 && nextFrom < until && nextFrom > from) || (step < 0 && nextFrom > until && nextFrom < from)
   }
 }
-
-

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/RangeObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/RangeObservableSuite.scala
@@ -18,7 +18,7 @@
 package monix.reactive.internal.builders
 
 import minitest.TestSuite
-import monix.execution.Ack.Continue
+import monix.execution.Ack.{Continue, Stop}
 import monix.execution.FutureUtils.extensions._
 import monix.execution.internal.Platform
 import monix.execution.schedulers.TestScheduler
@@ -137,5 +137,57 @@ object RangeObservableSuite extends TestSuite[TestScheduler] {
 
     assertEquals(received, s.executionModel.recommendedBatchSize * 2)
     assertEquals(wasCompleted, 0)
+  }
+
+  test("should complete when Long.MaxValue is reached") { implicit s =>
+    var wasCompleted = false
+    var elements = List.empty[Long]
+
+    val from = Long.MaxValue - 3
+    val until = Long.MaxValue
+
+    Observable
+      .range(from, until, 2)
+      .unsafeSubscribeFn(new Observer[Long] {
+        def onNext(elem: Long) = {
+          if (elem < from) Stop
+          else {
+            elements = elem :: elements
+            Continue
+          }
+        }
+
+        def onComplete(): Unit = wasCompleted = true
+        def onError(ex: Throwable): Unit = ()
+      })
+
+    assertEquals(elements, List(from + 2, from))
+    assertEquals(wasCompleted, true)
+  }
+
+  test("should complete when Long.MinValue is reached") { implicit s =>
+    var wasCompleted = false
+    var elements = List.empty[Long]
+
+    val from = Long.MinValue + 3
+    val until = Long.MinValue
+
+    Observable
+      .range(from, until, -2)
+      .unsafeSubscribeFn(new Observer[Long] {
+        def onNext(elem: Long) = {
+          if (elem > from) Stop
+          else {
+            elements = elem :: elements
+            Continue
+          }
+        }
+
+        def onComplete(): Unit = wasCompleted = true
+        def onError(ex: Throwable): Unit = ()
+      })
+
+    assertEquals(elements, List(from - 2, from))
+    assertEquals(wasCompleted, true)
   }
 }


### PR DESCRIPTION
Hello,

I've encountered a problem with `RangeObservable` that doesn't correctly handle start/end of Long range - current behaviour is that it overflows Long and continues emitting elements.

Problem happens both in Monix 2/3 and would be nice to have it fixed in 2 branch as at the moment I'm using a workaround (use case is that I need to scan whole Long range).