### PR TITLE
Make MVar fork on async `take`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,11 @@ matrix:
       env: COMMAND=ci-js COVERAGE=
     # Scala 2.12, JVM
     - jdk: oraclejdk8
-      scala: 2.12.4
+      scala: 2.12.7
       env: COMMAND=ci-jvm-all COVERAGE=coverage
     # Scala 2.12, JavaScript
     - jdk: oraclejdk8
-      scala: 2.12.4
+      scala: 2.12.7
       env: COMMAND=ci-js COVERAGE=
 
 env:

--- a/monix-catnap/jvm/src/test/scala/monix/catnap/CatsEffectIssue380Suite.scala
+++ b/monix-catnap/jvm/src/test/scala/monix/catnap/CatsEffectIssue380Suite.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.catnap
+
+import java.util.concurrent.Executors
+
+import minitest.SimpleTestSuite
+import cats.effect.IO
+import cats.implicits._
+import monix.execution.Scheduler
+import monix.execution.atomic.Atomic
+import scala.concurrent.{CancellationException, ExecutionContext}
+import scala.concurrent.duration._
+
+object CatsEffectIssue380Suite extends SimpleTestSuite {
+  test("MVar does not block on put — typelevel/cats-effect#380") {
+    val service = Executors.newSingleThreadScheduledExecutor()
+    implicit val ec = ExecutionContext.global
+    implicit val cs = IO.contextShift(ec)
+    implicit val timer = IO.timer(ec, service)
+
+    try {
+      for (_ <- 0 until 10) {
+        val cancelLoop = Atomic(false)
+        val unit = IO {
+          if (cancelLoop.get()) throw new CancellationException
+        }
+
+        try {
+          val task = for {
+            mv <- MVar[IO].empty[Unit]()
+            _  <- (mv.take *> unit.foreverM).start
+            _  <- timer.sleep(100.millis)
+            _  <- mv.put(())
+          } yield ()
+
+          val dt = 10.seconds
+          assert(task.unsafeRunTimed(dt).nonEmpty, s"timed-out after $dt")
+        } finally {
+          cancelLoop := true
+        }
+      }
+    } finally {
+      service.shutdown()
+    }
+  }
+}

--- a/monix-catnap/shared/src/main/scala/monix/catnap/MVar.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/MVar.scala
@@ -18,7 +18,7 @@
 package monix.catnap
 
 import cats.effect.concurrent.{MVar => CatsMVar}
-import cats.effect.{Async, Concurrent, Sync}
+import cats.effect.{Async, Concurrent, ContextShift}
 import monix.catnap.internals.AsyncUtils
 import monix.execution.atomic.PaddingStrategy
 import monix.execution.atomic.PaddingStrategy.NoPadding
@@ -153,14 +153,14 @@ object MVar {
     *
     * @see [[of]] and [[empty]]
     */
-  def apply[F[_]](implicit F: Concurrent[F] OrElse Async[F]): ApplyBuilders[F] =
+  def apply[F[_]](implicit F: Concurrent[F] OrElse Async[F], cs: ContextShift[F]): ApplyBuilders[F] =
     new ApplyBuilders[F](F)
 
   /**
     * Builds an [[MVar]] instance with an `initial` value.
     */
   def of[F[_], A](initial: A, ps: PaddingStrategy = NoPadding)
-    (implicit F: Concurrent[F] OrElse Async[F]): F[MVar[F, A]] = {
+    (implicit F: Concurrent[F] OrElse Async[F], cs: ContextShift[F]): F[MVar[F, A]] = {
 
     F.fold(
       implicit F => F.delay(new MVar(new ConcurrentImpl(Some(initial), ps))),
@@ -172,7 +172,7 @@ object MVar {
     * Builds an empty [[MVar]] instance.
     */
   def empty[F[_], A](ps: PaddingStrategy = NoPadding)
-    (implicit F: Concurrent[F] OrElse Async[F]): F[MVar[F, A]] = {
+    (implicit F: Concurrent[F] OrElse Async[F], cs: ContextShift[F]): F[MVar[F, A]] = {
 
     F.fold(
       implicit F => F.delay(new MVar(new ConcurrentImpl(None, ps))),
@@ -189,25 +189,24 @@ object MVar {
       *
       * @see documentation for [[MVar.of]]
       */
-    def of[A](a: A, ps: PaddingStrategy = NoPadding): F[MVar[F, A]] =
-      MVar.of(a, ps)(F)
+    def of[A](a: A, ps: PaddingStrategy = NoPadding)(implicit cs: ContextShift[F]): F[MVar[F, A]] =
+      MVar.of(a, ps)(F, cs)
 
     /**
       * Builds an empty `MVar`.
       *
       * @see documentation for [[MVar.empty]]
       */
-    def empty[A](ps: PaddingStrategy = NoPadding): F[MVar[F, A]] =
-      MVar.empty(ps)(F)
+    def empty[A](ps: PaddingStrategy = NoPadding)(implicit cs: ContextShift[F]): F[MVar[F, A]] =
+      MVar.empty(ps)(F, cs)
   }
 
 
   private trait Impl[F[_], A] { self: GenericVar[A, F[Unit]] =>
-    def F: Sync[F]
+    implicit def F: Async[F]
+    implicit def cs: ContextShift[F]
 
-    def put(a: A): F[Unit]
-    def take: F[A]
-    def read: F[A]
+    protected def create[T](k: (Either[Throwable, T] => Unit) => F[Unit]): F[T]
 
     final def isEmpty: F[Boolean] =
       F.delay(unsafeIsEmpty())
@@ -217,37 +216,62 @@ object MVar {
       F.delay(unsafeTryTake())
     final def tryRead: F[Option[A]] =
       F.delay(unsafeTryRead())
+
+    final def put(a: A): F[Unit] =
+      F.suspend {
+        if (unsafeTryPut(a))
+          F.unit
+        else
+          F.flatMap(AsyncUtils.cancelable[F, Unit](unsafePut(a, _)))(bindFork)
+      }
+
+    final def take: F[A] =
+      F.suspend[A] {
+        unsafeTryTake() match {
+          case Some(a) => F.pure(a)
+          case None =>
+            F.flatMap(AsyncUtils.cancelable[F, A](unsafeTake))(
+              bindForkA.asInstanceOf[A => F[A]])
+        }
+      }
+
+    final def read: F[A] =
+      AsyncUtils.cancelable { cb => unsafeRead(cb) }
+
+    private[this] val bindFork: (Unit => F[Unit]) = {
+      val shift = cs.shift
+      _ => shift
+    }
+
+    private[this] val bindForkA: (Any => F[Any]) = {
+      val shift = cs.shift
+      x => F.map(shift)(_ => x)
+    }
   }
 
-  private final class AsyncImpl[F[_], A](initial: Option[A], ps: PaddingStrategy)
-    (implicit val F: Async[F])
+  private final class AsyncImpl[F[_], A](
+    initial: Option[A],
+    ps: PaddingStrategy)
+    (implicit val F: Async[F], val cs: ContextShift[F])
     extends GenericVar[A, F[Unit]](initial, ps) with Impl[F, A] {
 
+    protected def create[T](k: (Either[Throwable, T] => Unit) => F[Unit]): F[T] =
+      AsyncUtils.cancelable(k)
     override protected def makeCancelable(f: Id => Unit, id: Id): F[Unit] =
       F.delay(f(id))
     override protected def emptyCancelable: F[Unit] =
       F.unit
-    def put(a: A): F[Unit] =
-      AsyncUtils.cancelable { cb => unsafePut(a, cb) }
-    def take: F[A] =
-      AsyncUtils.cancelable { cb => unsafeTake(cb) }
-    def read: F[A] =
-      AsyncUtils.cancelable { cb => unsafeRead(cb) }
   }
 
   private final class ConcurrentImpl[F[_], A](initial: Option[A], ps: PaddingStrategy)
-    (implicit val F: Concurrent[F])
+    (implicit val F: Concurrent[F], val cs: ContextShift[F])
     extends GenericVar[A, F[Unit]](initial, ps) with Impl[F, A] {
 
+    protected def create[T](k: (Either[Throwable, T] => Unit) => F[Unit]): F[T] =
+      F.cancelable(k)
     override protected def makeCancelable(f: Id => Unit, id: Id): F[Unit] =
       F.delay(f(id))
     override protected def emptyCancelable: F[Unit] =
       F.unit
-    def put(a: A): F[Unit] =
-      F.cancelable { cb => unsafePut(a, cb) }
-    def take: F[A] =
-      F.cancelable { cb => unsafeTake(cb) }
-    def read: F[A] =
-      F.cancelable { cb => unsafeRead(cb) }
   }
 }

--- a/monix-catnap/shared/src/test/scala/monix/catnap/CircuitBreakerSuite.scala
+++ b/monix-catnap/shared/src/test/scala/monix/catnap/CircuitBreakerSuite.scala
@@ -33,7 +33,7 @@ object CircuitBreakerSuite extends TestSuite[TestScheduler] {
     assert(env.state.tasks.isEmpty, "There should be no tasks left!")
 
   implicit def timer(implicit ec: TestScheduler) =
-    ec.timer[IO]
+    ec.timerLiftIO[IO]
 
   implicit def contextShift(implicit ec: TestScheduler) =
     ec.contextShift[IO]

--- a/monix-catnap/shared/src/test/scala/monix/catnap/MVarConcurrentSuite.scala
+++ b/monix-catnap/shared/src/test/scala/monix/catnap/MVarConcurrentSuite.scala
@@ -28,18 +28,18 @@ import scala.concurrent.duration._
 
 object MVarConcurrentSuite extends BaseMVarSuite {
   def init[A](a: A): IO[MVar[IO, A]] =
-    MVar[IO](OrElse.primary(IO.ioConcurrentEffect)).of(a)
+    MVar[IO](OrElse.primary(IO.ioConcurrentEffect), cs).of(a)
 
   def empty[A]: IO[MVar[IO, A]] =
-    MVar[IO](OrElse.primary(IO.ioConcurrentEffect)).empty[A]()
+    MVar[IO](OrElse.primary(IO.ioConcurrentEffect), cs).empty[A]()
 }
 
 object MVarAsyncSuite extends BaseMVarSuite {
   def init[A](a: A): IO[MVar[IO, A]] =
-    MVar[IO](OrElse.secondary(IO.ioEffect)).of(a)
+    MVar[IO](OrElse.secondary(IO.ioEffect), cs).of(a)
 
   def empty[A]: IO[MVar[IO, A]] =
-    MVar[IO](OrElse.secondary(IO.ioEffect)).empty[A]()
+    MVar[IO](OrElse.secondary(IO.ioEffect), cs).empty[A]()
 }
 
 abstract class BaseMVarSuite extends SimpleTestSuite {

--- a/monix-eval/shared/src/main/scala/monix/eval/TaskApp.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/TaskApp.scala
@@ -85,10 +85,10 @@ trait TaskApp {
   final def main(args: Array[String]): Unit = {
     val self = this
     val app = new IOApp {
-      override lazy val timer: Timer[IO] =
-        scheduler.timer[IO]
-      override lazy val contextShift: ContextShift[IO] =
-        scheduler.contextShift[IO]
+      override implicit lazy val contextShift: ContextShift[IO] =
+        scheduler.contextShift[IO](IO.ioEffect)
+      override implicit lazy val timer: Timer[IO] =
+        scheduler.timerLiftIO[IO](IO.ioEffect)
       def run(args: List[String]): IO[ExitCode] =
         self.run(args).toIO
     }

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskConversionsSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskConversionsSuite.scala
@@ -179,7 +179,7 @@ object TaskConversionsSuite extends BaseTestSuite {
   }
 
   test("Task.fromIO is cancelable") { implicit s =>
-    val timer = s.timer[IO]
+    val timer = s.timerLiftIO[IO]
     val io = timer.sleep(10.seconds)
     val f = Task.fromIO(io).runToFuture
 

--- a/monix-execution/shared/src/test/scala/monix/execution/schedulers/ReferenceSchedulerSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/schedulers/ReferenceSchedulerSuite.scala
@@ -158,7 +158,7 @@ object ReferenceSchedulerSuite extends SimpleTestSuite {
 
   test("timer.sleep") {
     val s = new DummyScheduler
-    val timer = s.timer[IO]
+    val timer = s.timerLiftIO[IO]
 
     val f = timer.sleep(10.seconds).unsafeToFuture()
     assertEquals(f.value, None)

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -1408,7 +1408,7 @@ abstract class Observable[+A] extends Serializable { self =>
     *   import scala.concurrent.duration._
     *   import monix.execution.Scheduler.Implicits.global
     *   // Needed for IO.sleep
-    *   implicit val timer = global.timer[IO]
+    *   implicit val timer = global.timerLiftIO[IO]
     *
     *   Observable.range(0, 100)
     *     .delayExecution(1.second)
@@ -1460,7 +1460,7 @@ abstract class Observable[+A] extends Serializable { self =>
     *   import scala.concurrent.duration._
     *   import monix.execution.Scheduler.Implicits.global
     *   // Needed for IO.sleep
-    *   implicit val timer = global.timer[IO]
+    *   implicit val timer = global.timerLiftIO[IO]
     *
     *   Observable.range(0, 10)
     *     .doOnSubscribeF(IO.sleep(1.second))
@@ -1506,7 +1506,7 @@ abstract class Observable[+A] extends Serializable { self =>
     *   import scala.concurrent.duration._
     *   import monix.execution.Scheduler.Implicits.global
     *   // Needed for IO.sleep
-    *   implicit val timer = global.timer[IO]
+    *   implicit val timer = global.timerLiftIO[IO]
     *
     *   Observable.range(0, 100)
     *     .doAfterSubscribeF(IO.sleep(1.second))
@@ -2083,7 +2083,7 @@ abstract class Observable[+A] extends Serializable { self =>
     *   import scala.concurrent.duration._
     *   import monix.execution.Scheduler.Implicits.global
     *   // Needed for IO.sleep
-    *   implicit val timer = global.timer[IO]
+    *   implicit val timer = global.timerLiftIO[IO]
     *
     *   Observable.range(0, 100).mapEvalF { x =>
     *     IO.sleep(1.second) *> IO(x)
@@ -4725,7 +4725,7 @@ object Observable extends ObservableDeprecatedBuilders {
     *    import monix.execution.Scheduler.global
     *
     *    // Needed for IO.sleep
-    *    implicit val timer = global.timer[IO]
+    *    implicit val timer = global.timerLiftIO[IO]
     *    val task = IO.sleep(5.seconds) *> IO(println("Hello!"))
     *
     *    Observable.fromTaskLike(task)

--- a/monix-tail/shared/src/test/scala/monix/tail/IntervalIntervalSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IntervalIntervalSuite.scala
@@ -54,7 +54,7 @@ object IntervalIntervalSuite extends BaseTestSuite {
   }
 
   test("Iterant[IO].intervalWithFixedDelay(1.second, 2.seconds)") { s =>
-    implicit val timer = s.timer[IO]
+    implicit val timer = s.timerLiftIO[IO]
 
     var effect = 0
     val lst = Iterant[IO].intervalWithFixedDelay(1.second, 2.seconds)
@@ -108,7 +108,7 @@ object IntervalIntervalSuite extends BaseTestSuite {
   }
 
   test("Iterant[IO].intervalWithFixedDelay(2.seconds)") { s =>
-    implicit val timer = s.timer[IO]
+    implicit val timer = s.timerLiftIO[IO]
 
     var effect = 0
     val lst = Iterant[IO].intervalWithFixedDelay(2.seconds)
@@ -155,7 +155,7 @@ object IntervalIntervalSuite extends BaseTestSuite {
   }
 
   test("Iterant[IO].intervalAtFixedRate(1.second)") { s =>
-    implicit val timer = s.timer[IO]
+    implicit val timer = s.timerLiftIO[IO]
 
     var effect = 0
     val lst = Iterant[IO].intervalAtFixedRate(1.second)
@@ -203,7 +203,7 @@ object IntervalIntervalSuite extends BaseTestSuite {
   }
 
   test("Iterant[IO].intervalAtFixedRate(2.seconds, 1.second)") { s =>
-    implicit val timer = s.timer[IO]
+    implicit val timer = s.timerLiftIO[IO]
 
     var effect = 0
     val lst = Iterant[IO].intervalAtFixedRate(2.seconds, 1.second)
@@ -252,7 +252,7 @@ object IntervalIntervalSuite extends BaseTestSuite {
   }
 
   test("Iterant[IO].intervalAtFixedRate accounts for time it takes task to finish") { s =>
-    implicit val timer = s.timer[IO]
+    implicit val timer = s.timerLiftIO[IO]
 
     var effect = 0
     val lst = Iterant[IO].intervalAtFixedRate(1.second)


### PR DESCRIPTION
Related to: https://github.com/typelevel/cats-effect/issues/380

If async `take` doesn't fork, then its bind continuation can block `put` indefinitely.