### PR TITLE
Fix issue typelevel/cats-effect#403

### DIFF
--- a/monix-catnap/shared/src/main/scala/monix/catnap/Semaphore.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/Semaphore.scala
@@ -56,6 +56,15 @@ import scala.concurrent.Promise
   *     _ <- tasks.toList.parSequence
   *   } yield ()
   * }}}
+  *
+  * ==Credits==
+  *
+  * `Semaphore` is now implementing `cats.effect.Semaphore`, deprecating
+  * the old Monix `TaskSemaphore`.
+  *
+  * The changes to the interface and some implementation details are
+  * inspired by the implementation in Cats-Effect, which was ported
+  * from FS2.
   */
 final class Semaphore[F[_]] private (provisioned: Long, ps: PaddingStrategy)
   (implicit F: Concurrent[F] OrElse Async[F], cs: ContextShift[F])

--- a/monix-catnap/shared/src/main/scala/monix/catnap/cancelables/AssignableCancelableF.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/cancelables/AssignableCancelableF.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.catnap.cancelables
+
+import monix.catnap.CancelableF
+
+/** Represents a class of cancelable references that can hold
+  * an internal reference to another cancelable (and thus has to
+  * support the assignment operator).
+  *
+  * On assignment, if this cancelable is already
+  * canceled, then no assignment should happen and the update
+  * reference should be canceled as well.
+  */
+trait AssignableCancelableF[F[_]] extends CancelableF[F] {
+  def set(ref: CancelableF[F]): F[Unit]
+}
+
+object AssignableCancelableF {
+  /**
+    * Represents [[AssignableCancelableF]] instances that are also
+    * [[BooleanCancelableF]].
+    */
+  trait Bool[F[_]] extends AssignableCancelableF[F] with BooleanCancelableF[F]
+
+  /**
+    * Interface for [[AssignableCancelableF]] types that can be
+    * assigned multiple times.
+    */
+  trait Multi[F[_]] extends Bool[F]
+}

--- a/monix-catnap/shared/src/main/scala/monix/catnap/cancelables/AssignableCancelableF.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/cancelables/AssignableCancelableF.scala
@@ -15,9 +15,13 @@
  * limitations under the License.
  */
 
-package monix.catnap.cancelables
+package monix.catnap
+package cancelables
 
+import cats.Applicative
+import cats.effect.CancelToken
 import monix.catnap.CancelableF
+import monix.catnap.CancelableF.Empty
 
 /** Represents a class of cancelable references that can hold
   * an internal reference to another cancelable (and thus has to
@@ -28,7 +32,18 @@ import monix.catnap.CancelableF
   * reference should be canceled as well.
   */
 trait AssignableCancelableF[F[_]] extends CancelableF[F] {
-  def set(ref: CancelableF[F]): F[Unit]
+  /**
+    * Sets the underlying reference to the given [[CancelableF]] reference.
+    *
+    * Contract:
+    *
+    *  - the given reference gets canceled in case the assignable was
+    *    already canceled
+    *  - this operation might throw an error if the contract of the
+    *    implementation doesn't allow for calling `set` multiple times
+    *    (e.g. [[SingleAssignCancelableF]])
+    */
+  def set(cancelable: CancelableF[F]): F[Unit]
 }
 
 object AssignableCancelableF {
@@ -43,4 +58,27 @@ object AssignableCancelableF {
     * assigned multiple times.
     */
   trait Multi[F[_]] extends Bool[F]
+
+  /**
+    * Builds an [[AssignableCancelableF]] instance that's already canceled.
+    */
+  def alreadyCanceled[F[_]](implicit F: Applicative[F]): Bool[F] with Empty[F] =
+    new Bool[F] with Empty[F] {
+      def set(ref: CancelableF[F]): F[Unit] = ref.cancel
+      def isCanceled: F[Boolean] = F.pure(true)
+      def cancel: CancelToken[F] = F.unit
+    }
+
+  /**
+    * Represents an [[AssignableCancelableF]] with no internal state and that
+    * doesn't do anything, either on assignment or on cancelation.
+    *
+    * It's a no-op.
+    */
+  def dummy[F[_]](implicit F: Applicative[F]): Multi[F] =
+    new Multi[F] {
+      def set(ref: CancelableF[F]): F[Unit] = F.unit
+      def isCanceled: F[Boolean] = F.pure(false)
+      def cancel: CancelToken[F] = F.unit
+    }
 }

--- a/monix-catnap/shared/src/main/scala/monix/catnap/cancelables/SingleAssignCancelableF.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/cancelables/SingleAssignCancelableF.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.catnap.cancelables
+
+import cats.effect.{CancelToken, Sync}
+import monix.catnap.CancelableF
+import monix.execution.annotations.UnsafeBecauseImpure
+import monix.execution.atomic.Atomic
+import scala.annotation.tailrec
+
+/** Represents a [[monix.catnap.CancelableF]] that can be assigned only
+  * once to another cancelable reference.
+  *
+  * If the assignment happens after this cancelable has been canceled, then on
+  * assignment the reference will get canceled too. If the assignment already
+  * happened, then a second assignment will raise an error.
+  *
+  * Useful in case you need a forward reference.
+  */
+final class SingleAssignCancelableF[F[_]] private (extra: CancelableF[F])(implicit F: Sync[F])
+  extends AssignableCancelableF.Bool[F] {
+
+  import SingleAssignCancelableF._
+  private[this] val state = Atomic(Empty : State[F])
+
+  val isCanceled: F[Boolean] =
+    F.delay(state.get() match {
+      case IsCanceled | IsEmptyCanceled => true
+      case _ => false
+    })
+
+  val cancel: CancelToken[F] = {
+    @tailrec def loop(): F[Unit] =
+      state.get() match {
+        case IsCanceled | IsEmptyCanceled => F.unit
+        case current @ IsActive(s) =>
+          if (state.compareAndSet(current, IsCanceled))
+            F.guarantee(s.cancel)(extra.cancel)
+          else
+            loop()
+        case Empty =>
+          if (state.compareAndSet(Empty, IsEmptyCanceled))
+            extra.cancel
+          else
+            loop()
+      }
+    F.suspend(loop())
+  }
+
+  def set(ref: CancelableF[F]): F[Unit] =
+    F.suspend(unsafeLoop(ref))
+
+  @tailrec
+  private def unsafeLoop(ref: CancelableF[F]): F[Unit] = {
+    if (state.compareAndSet(Empty, IsActive(ref)))
+      F.unit
+    else state.get() match {
+      case IsEmptyCanceled =>
+        if (state.compareAndSet(IsEmptyCanceled, IsCanceled))
+          ref.cancel
+        else
+          unsafeLoop(ref)
+
+      case IsCanceled | IsActive(_) =>
+        F.flatMap(ref.cancel)(_ => raiseError)
+      case Empty =>
+        unsafeLoop(ref)
+    }
+  }
+
+  private def raiseError: F[Unit] = F.raiseError {
+    new IllegalStateException(
+      "Cannot assign to SingleAssignmentCancelableF " +
+      "as it was already assigned once")
+  }
+}
+
+object SingleAssignCancelableF {
+  /**
+    * Builder for [[SingleAssignCancelableF]].
+    */
+  def apply[F[_]](implicit F: Sync[F]): F[SingleAssignCancelableF[F]] =
+    plusOne(CancelableF.empty)
+
+  /**
+    * Builder for [[SingleAssignCancelableF]] that takes an extra reference,
+    * to be canceled on [[SingleAssignCancelableF.cancel cancel]]
+    * along with whatever underlying reference we have.
+    */
+  def plusOne[F[_]](extra: CancelableF[F])(implicit F: Sync[F]): F[SingleAssignCancelableF[F]] =
+    F.delay(unsafePlusOne(extra))
+
+  /**
+    * Unsafe version of [[apply]]
+    *
+    * Breaks referential transparency. Prefer the safe version.
+    */
+  @UnsafeBecauseImpure
+  def unsafeApply[F[_]](implicit F: Sync[F]): SingleAssignCancelableF[F] =
+    unsafePlusOne(CancelableF.empty)
+
+  /**
+    * Unsafe version of [[plusOne]]
+    *
+    * Breaks referential transparency. Prefer the safe version.
+    */
+  @UnsafeBecauseImpure
+  def unsafePlusOne[F[_]](extra: CancelableF[F])(implicit F: Sync[F]): SingleAssignCancelableF[F] =
+    new SingleAssignCancelableF[F](extra)
+
+  private sealed trait State[+F[_]]
+  private case object Empty extends State[Nothing]
+  private case class  IsActive[F[_]](s: CancelableF[F]) extends State[F]
+  private case object IsCanceled extends State[Nothing]
+  private case object IsEmptyCanceled extends State[Nothing]
+}

--- a/monix-catnap/shared/src/test/scala/monix/catnap/SemaphoreSuite.scala
+++ b/monix-catnap/shared/src/test/scala/monix/catnap/SemaphoreSuite.scala
@@ -17,12 +17,11 @@
 
 package monix.catnap
 
-import cats.implicits._
 import cats.effect.{ContextShift, IO}
+import cats.implicits._
 import minitest.TestSuite
-import monix.execution.internal.{AttemptCallback, Platform}
+import monix.execution.internal.Platform
 import monix.execution.schedulers.TestScheduler
-
 import scala.concurrent.{ExecutionContext, Promise}
 import scala.util.{Random, Success}
 
@@ -182,6 +181,72 @@ object SemaphoreSuite extends TestSuite[TestScheduler] {
       }
     }
     task.unsafeToFuture()
+  }
+
+  test("withPermitN has FIFO priority") { implicit s =>
+    val sem = Semaphore.unsafe[IO](provisioned = 0)
+
+    val f1 = sem.withPermitN(3)(IO(1 + 1)).unsafeToFuture()
+    assertEquals(f1.value, None)
+    val f2 = sem.withPermitN(4)(IO(1 + 1)).unsafeToFuture()
+    assertEquals(f2.value, None)
+
+    sem.releaseN(2).unsafeRunAsyncAndForget(); s.tick()
+    assertEquals(f1.value, None)
+    assertEquals(f2.value, None)
+
+    sem.releaseN(1).unsafeRunAsyncAndForget(); s.tick()
+    assertEquals(f1.value, Some(Success(2)))
+    assertEquals(f2.value, None)
+
+    sem.releaseN(1).unsafeRunAsyncAndForget(); s.tick()
+    assertEquals(f2.value, Some(Success(2)))
+  }
+
+  test("withPermitN is cancelable (1)") { implicit s =>
+    val sem = Semaphore.unsafe[IO](provisioned = 0)
+    assertEquals(sem.count.unsafeRunSync(), 0)
+
+    val p1 = Promise[Int]()
+    val cancel = sem.withPermitN(3)(IO(1 + 1)).unsafeRunCancelable(r => p1.complete(r.toTry))
+    val f2 = sem.withPermitN(3)(IO(1 + 1)).unsafeToFuture()
+
+    assertEquals(p1.future.value, None)
+    assertEquals(f2.value, None)
+    assertEquals(sem.count.unsafeRunSync(), -6)
+
+    cancel.unsafeRunAsyncAndForget(); s.tick()
+    assertEquals(sem.count.unsafeRunSync(), -3)
+
+    sem.releaseN(3).unsafeRunAsyncAndForget()
+    s.tick()
+
+    assertEquals(p1.future.value, None)
+    assertEquals(f2.value, Some(Success(2)))
+  }
+
+  test("withPermitN is cancelable (2)") { implicit s =>
+    val sem = Semaphore.unsafe[IO](provisioned = 1)
+
+    val p1 = Promise[Int]()
+    val cancel = sem.withPermitN(3)(IO(1 + 1)).unsafeRunCancelable(r => p1.complete(r.toTry))
+    val f2 = sem.withPermitN(3)(IO(1 + 1)).unsafeToFuture()
+    assertEquals(sem.count.unsafeRunSync(), -5)
+
+    sem.releaseN(1).unsafeRunAsyncAndForget()
+    assertEquals(sem.count.unsafeRunSync(), -4)
+
+    assertEquals(p1.future.value, None)
+    assertEquals(f2.value, None)
+
+    cancel.unsafeRunAsyncAndForget(); s.tick()
+    assertEquals(sem.count.unsafeRunSync(), -1)
+
+    sem.releaseN(1).unsafeRunAsyncAndForget()
+    s.tick()
+
+    assertEquals(p1.future.value, None)
+    assertEquals(f2.value, Some(Success(2)))
   }
 
   def repeatTest(n: Int)(f: => IO[Unit]): IO[Unit] =

--- a/monix-catnap/shared/src/test/scala/monix/catnap/SemaphoreSuite.scala
+++ b/monix-catnap/shared/src/test/scala/monix/catnap/SemaphoreSuite.scala
@@ -77,8 +77,8 @@ object SemaphoreSuite extends TestSuite[TestScheduler] {
     // Executing Futures on the global scheduler!
     import scala.concurrent.ExecutionContext.Implicits.global
 
-    val semaphore = Semaphore.unsafe[IO](provisioned = 4)
-    val count = if (Platform.isJVM) 100000 else 1000
+    val semaphore = Semaphore.unsafe[IO](provisioned = 20)
+    val count = if (Platform.isJVM) 10000 else 1000
 
     val futures = for (i <- 0 until count) yield
       semaphore.withPermit(IO.shift *> IO(i))

--- a/monix-catnap/shared/src/test/scala/monix/catnap/cancelables/AssignableCancelableFSuite.scala
+++ b/monix-catnap/shared/src/test/scala/monix/catnap/cancelables/AssignableCancelableFSuite.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.catnap.cancelables
+
+import cats.effect.IO
+import minitest.SimpleTestSuite
+import monix.catnap.CancelableF
+
+object AssignableCancelableFSuite extends SimpleTestSuite {
+  test("alreadyCanceled") {
+    val ac = AssignableCancelableF.alreadyCanceled[IO]
+    var effect = 0
+
+    assertEquals(ac.isCanceled.unsafeRunSync(), true)
+    ac.set(CancelableF.wrap(IO { effect += 1 })).unsafeRunSync()
+    assertEquals(effect, 1)
+
+    ac.cancel.unsafeRunSync()
+    assertEquals(effect, 1)
+    ac.set(CancelableF.wrap(IO { effect += 1 })).unsafeRunSync()
+    assertEquals(effect, 2)
+  }
+
+  test("dummy") {
+    val ac = AssignableCancelableF.dummy[IO]
+    var effect = 0
+
+    assertEquals(ac.isCanceled.unsafeRunSync(), false)
+    ac.set(CancelableF.wrap(IO { effect += 1 })).unsafeRunSync()
+    assertEquals(effect, 0)
+
+    ac.cancel.unsafeRunSync()
+    assertEquals(effect, 0)
+    ac.set(CancelableF.wrap(IO { effect += 1 })).unsafeRunSync()
+    assertEquals(effect, 0)
+
+    assertEquals(ac.isCanceled.unsafeRunSync(), false)
+  }
+}

--- a/monix-catnap/shared/src/test/scala/monix/catnap/cancelables/SingleAssignCancelableFSuite.scala
+++ b/monix-catnap/shared/src/test/scala/monix/catnap/cancelables/SingleAssignCancelableFSuite.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.catnap
+package cancelables
+
+import cats.effect.IO
+import minitest.SimpleTestSuite
+import monix.execution.exceptions.DummyException
+
+object SingleAssignCancelableFSuite extends SimpleTestSuite {
+  test("cancel") {
+    var effect = 0
+    val s = SingleAssignCancelableF[IO].unsafeRunSync()
+    val b = BooleanCancelableF.unsafeApply(IO { effect += 1 })
+
+    s.set(b).unsafeRunSync()
+    assert(!s.isCanceled.unsafeRunSync(), "!s.isCanceled")
+
+    s.cancel.unsafeRunSync()
+    assert(s.isCanceled.unsafeRunSync(), "s.isCanceled")
+    assert(b.isCanceled.unsafeRunSync())
+    assert(effect == 1)
+
+    s.cancel.unsafeRunSync()
+    assert(effect == 1)
+  }
+
+  test("cancel (plus one)") {
+    var effect = 0
+    val extra = BooleanCancelableF.unsafeApply(IO { effect += 1 })
+    val b = BooleanCancelableF.unsafeApply(IO { effect += 2 })
+
+    val s = SingleAssignCancelableF.plusOne(extra).unsafeRunSync()
+    s.set(b).unsafeRunSync()
+
+    s.cancel.unsafeRunSync()
+    assert(s.isCanceled.unsafeRunSync())
+    assert(b.isCanceled.unsafeRunSync())
+    assert(extra.isCanceled.unsafeRunSync())
+    assert(effect == 3)
+
+    s.cancel.unsafeRunSync()
+    assert(effect == 3)
+  }
+
+  test("cancel on single assignment") {
+    val s = SingleAssignCancelableF[IO].unsafeRunSync()
+    s.cancel.unsafeRunSync()
+    assert(s.isCanceled.unsafeRunSync())
+
+    var effect = 0
+    val b = BooleanCancelableF.unsafeApply(IO { effect += 1 })
+    s.set(b).unsafeRunSync()
+
+    assert(b.isCanceled.unsafeRunSync())
+    assert(effect == 1)
+
+    s.cancel.unsafeRunSync()
+    assert(effect == 1)
+  }
+
+  test("cancel on single assignment (plus one)") {
+    var effect = 0
+    val extra = BooleanCancelableF.unsafeApply(IO { effect += 1 })
+    val s = SingleAssignCancelableF.plusOne(extra).unsafeRunSync()
+
+    s.cancel.unsafeRunSync()
+    assert(s.isCanceled.unsafeRunSync(), "s.isCanceled")
+    assert(extra.isCanceled.unsafeRunSync(), "extra.isCanceled")
+    assert(effect == 1)
+
+    val b = BooleanCancelableF.unsafeApply(IO { effect += 1 })
+    s.set(b).unsafeRunSync()
+
+    assert(b.isCanceled.unsafeRunSync())
+    assert(effect == 2)
+
+    s.cancel.unsafeRunSync()
+    assert(effect == 2)
+  }
+
+  test("throw exception on multi assignment") {
+    val s = SingleAssignCancelableF[IO].unsafeRunSync()
+    val b1 = CancelableF.empty[IO]
+    s.set(b1).unsafeRunSync()
+
+    intercept[IllegalStateException] {
+      s.set(CancelableF.empty[IO]).unsafeRunSync()
+    }
+  }
+
+  test("throw exception on multi assignment when canceled") {
+    val s = SingleAssignCancelableF[IO].unsafeRunSync()
+    s.cancel.unsafeRunSync()
+
+    val b1 = CancelableF.empty[IO]
+    s.set(b1).unsafeRunSync()
+
+    intercept[IllegalStateException] {
+      s.set(CancelableF.empty[IO]).unsafeRunSync()
+    }
+  }
+
+  test("cancel when both reference and `extra` throw") {
+    var effect = 0
+    val dummy1 = DummyException("dummy1")
+
+    val extra = CancelableF.unsafeApply[IO](IO { effect += 1; throw dummy1 })
+    val s = SingleAssignCancelableF.plusOne(extra).unsafeRunSync()
+
+    val dummy2 = DummyException("dummy2")
+    val b = CancelableF.unsafeApply[IO](IO { effect += 1; throw dummy2 })
+    s.set(b).unsafeRunSync()
+
+    intercept[DummyException] {
+      s.cancel.unsafeRunSync()
+    }
+
+    assertEquals(effect, 2)
+  }
+}

--- a/monix-execution/js/src/main/scala/monix/execution/internal/Platform.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/internal/Platform.scala
@@ -97,8 +97,7 @@ private[monix] object Platform {
       case nonEmpty =>
         first match {
           case CompositeException(errors) =>
-            val list = errors.toList
-            CompositeException(list ::: nonEmpty)
+            CompositeException(errors ::: nonEmpty)
           case _ =>
             CompositeException(first :: nonEmpty)
         }

--- a/monix-execution/shared/src/main/scala/monix/execution/exceptions/CompositeException.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/exceptions/CompositeException.scala
@@ -40,9 +40,9 @@ final class CompositeException(val errors: Seq[Throwable])
 object CompositeException extends AbstractFunction1[Seq[Throwable], CompositeException] {
   /** Builder for [[CompositeException]]. */
   def apply(errors: Seq[Throwable]): CompositeException =
-    new CompositeException(errors)
+    new CompositeException(errors.toList)
 
   /** For pattern matching [[CompositeException]] references. */
-  def unapply(ref: CompositeException): Option[Seq[Throwable]] =
-    Some(ref.errors)
+  def unapply(ref: CompositeException): Option[List[Throwable]] =
+    Some(ref.errors.toList)
 }


### PR DESCRIPTION
Related: https://github.com/typelevel/cats-effect/pull/403

Also added `AssignableCancelableF` and `SingleAssignCancelableF`, used in the initial implementation, which was later optimized to do without. 