### PR TITLE
TrampolineScheduler — change internal stack to a queue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ addCommandAlias("ci-all",     ";ci-jvm ;ci-js ;mimaReportBinaryIssues ;unidoc")
 addCommandAlias("ci-js",      s";clean ;coreJS/test:compile ;${allProjects.filter(_ != "java").map(_ + "JS/test").mkString(" ;")}")
 addCommandAlias("ci-jvm",     s";clean ;coreJVM/test:compile ;${allProjects.map(_ + "JVM/test").mkString(" ;")} ;mimaReportBinaryIssues")
 addCommandAlias("ci-jvm-all", s";ci-jvm ;unidoc")
-addCommandAlias("release",    ";project monix ;+clean ;+package ;+publishSigned ;sonatypeReleaseAll")
+addCommandAlias("release",    ";project monix ;+clean ;+package ;+publishSigned")
 
 val catsVersion = "1.4.0"
 val catsEffectVersion = "1.0.0"

--- a/monix-eval/jvm/src/main/scala/monix/eval/internal/TaskRunSyncUnsafe.scala
+++ b/monix-eval/jvm/src/main/scala/monix/eval/internal/TaskRunSyncUnsafe.scala
@@ -24,7 +24,7 @@ import monix.eval.Task.{Async, Context, Error, Eval, FlatMap, Map, Now, Suspend}
 import monix.eval.internal.TaskRunLoop._
 import monix.eval.Task
 import monix.execution.{Callback, Scheduler}
-import monix.execution.internal.collection.ArrayStack
+import monix.execution.internal.collection.ChunkedArrayStack
 import scala.util.control.NonFatal
 
 import scala.concurrent.blocking
@@ -46,7 +46,7 @@ private[eval] object TaskRunSyncUnsafe {
       current match {
         case FlatMap(fa, bindNext) =>
           if (bFirst ne null) {
-            if (bRest eq null) bRest = new ArrayStack()
+            if (bRest eq null) bRest = ChunkedArrayStack()
             bRest.push(bFirst)
           }
           /*_*/bFirst = bindNext/*_*/
@@ -67,7 +67,7 @@ private[eval] object TaskRunSyncUnsafe {
 
         case bindNext @ Map(fa, _, _) =>
           if (bFirst ne null) {
-            if (bRest eq null) bRest = new ArrayStack()
+            if (bRest eq null) bRest = ChunkedArrayStack()
             bRest.push(bFirst)
           }
           bFirst = bindNext

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/CoevalRunLoop.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/CoevalRunLoop.scala
@@ -19,13 +19,13 @@ package monix.eval.internal
 
 import monix.eval.Coeval
 import monix.eval.Coeval.{Always, Eager, Error, FlatMap, Map, Now, Suspend}
-import monix.execution.internal.collection.ArrayStack
+import monix.execution.internal.collection.ChunkedArrayStack
 import scala.util.control.NonFatal
 
 private[eval] object CoevalRunLoop {
   private type Current = Coeval[Any]
   private type Bind = Any => Coeval[Any]
-  private type CallStack = ArrayStack[Bind]
+  private type CallStack = ChunkedArrayStack[Bind]
 
   /** Trampoline for lazy evaluation. */
   def start[A](source: Coeval[A]): Eager[A] = {
@@ -40,7 +40,7 @@ private[eval] object CoevalRunLoop {
       current match {
         case FlatMap(fa, bindNext) =>
           if (bFirst ne null) {
-            if (bRest eq null) bRest = new ArrayStack()
+            if (bRest eq null) bRest = ChunkedArrayStack()
             bRest.push(bFirst)
           }
           bFirst = bindNext.asInstanceOf[Bind]
@@ -61,7 +61,7 @@ private[eval] object CoevalRunLoop {
 
         case bindNext @ Map(fa, _, _) =>
           if (bFirst ne null) {
-            if (bRest eq null) bRest = new ArrayStack()
+            if (bRest eq null) bRest = ChunkedArrayStack()
             bRest.push(bFirst)
           }
           bFirst = bindNext.asInstanceOf[Bind]

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRunLoop.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRunLoop.scala
@@ -21,7 +21,7 @@ import cats.effect.CancelToken
 import monix.eval.Task.{Async, Context, ContextSwitch, Error, Eval, FlatMap, Map, Now, Suspend}
 import monix.execution.Callback
 import monix.eval.Task
-import monix.execution.internal.collection.ArrayStack
+import monix.execution.internal.collection.ChunkedArrayStack
 import monix.execution.misc.Local
 import monix.execution.{CancelableFuture, ExecutionModel, Scheduler}
 import scala.concurrent.Promise
@@ -31,7 +31,7 @@ import scala.util.control.NonFatal
 private[eval] object TaskRunLoop {
   type Current = Task[Any]
   type Bind = Any => Task[Any]
-  type CallStack = ArrayStack[Bind]
+  type CallStack = ChunkedArrayStack[Bind]
 
   /** Starts or resumes evaluation of the run-loop from where it left
     * off. This is the complete run-loop.
@@ -66,7 +66,7 @@ private[eval] object TaskRunLoop {
         current match {
           case FlatMap(fa, bindNext) =>
             if (bFirstRef ne null) {
-              if (bRestRef eq null) bRestRef = new ArrayStack()
+              if (bRestRef eq null) bRestRef = ChunkedArrayStack()
               bRestRef.push(bFirstRef)
             }
             bFirstRef = bindNext.asInstanceOf[Bind]
@@ -87,7 +87,7 @@ private[eval] object TaskRunLoop {
 
           case bindNext @ Map(fa, _, _) =>
             if (bFirstRef ne null) {
-              if (bRestRef eq null) bRestRef = new ArrayStack()
+              if (bRestRef eq null) bRestRef = ChunkedArrayStack()
               bRestRef.push(bFirstRef)
             }
             bFirstRef = bindNext.asInstanceOf[Bind]
@@ -223,7 +223,7 @@ private[eval] object TaskRunLoop {
         current match {
           case FlatMap(fa, bindNext) =>
             if (bFirst ne null) {
-              if (bRest eq null) bRest = new ArrayStack()
+              if (bRest eq null) bRest = ChunkedArrayStack()
               bRest.push(bFirst)
             }
             bFirst = bindNext.asInstanceOf[Bind]
@@ -244,7 +244,7 @@ private[eval] object TaskRunLoop {
 
           case bindNext @ Map(fa, _, _) =>
             if (bFirst ne null) {
-              if (bRest eq null) bRest = new ArrayStack()
+              if (bRest eq null) bRest = ChunkedArrayStack()
               bRest.push(bFirst)
             }
             bFirst = bindNext.asInstanceOf[Bind]
@@ -335,7 +335,7 @@ private[eval] object TaskRunLoop {
         current match {
           case FlatMap(fa, bindNext) =>
             if (bFirst ne null) {
-              if (bRest eq null) bRest = new ArrayStack()
+              if (bRest eq null) bRest = ChunkedArrayStack()
               bRest.push(bFirst)
             }
             /*_*/bFirst = bindNext/*_*/
@@ -357,7 +357,7 @@ private[eval] object TaskRunLoop {
 
           case bindNext @ Map(fa, _, _) =>
             if (bFirst ne null) {
-              if (bRest eq null) bRest = new ArrayStack()
+              if (bRest eq null) bRest = ChunkedArrayStack()
               bRest.push(bFirst)
             }
             bFirst = bindNext
@@ -451,7 +451,7 @@ private[eval] object TaskRunLoop {
         current match {
           case FlatMap(fa, bindNext) =>
             if (bFirst ne null) {
-              if (bRest eq null) bRest = new ArrayStack()
+              if (bRest eq null) bRest = ChunkedArrayStack()
               bRest.push(bFirst)
             }
             /*_*/bFirst = bindNext/*_*/
@@ -473,7 +473,7 @@ private[eval] object TaskRunLoop {
 
           case bindNext @ Map(fa, _, _) =>
             if (bFirst ne null) {
-              if (bRest eq null) bRest = new ArrayStack()
+              if (bRest eq null) bRest = ChunkedArrayStack()
               bRest.push(bFirst)
             }
             bFirst = bindNext

--- a/monix-execution/js/src/main/scala/monix/execution/internal/collection/JSArrayQueue.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/internal/collection/JSArrayQueue.scala
@@ -26,7 +26,7 @@ import scala.scalajs.js
   *
   * Inspired by: http://code.stephenmorley.org/javascript/queues/
   */
-private[monix] final class ArrayQueue[A] private
+private[monix] final class JSArrayQueue[A] private
   (_size: Int, triggerEx: Int => Throwable = null)
   extends EvictingQueue[A] {
 
@@ -127,10 +127,10 @@ private[monix] final class ArrayQueue[A] private
   }
 }
 
-private[monix] object ArrayQueue {
-  def unbounded[A]: ArrayQueue[A] =
-    new ArrayQueue[A](0)
+private[monix] object JSArrayQueue {
+  def unbounded[A]: JSArrayQueue[A] =
+    new JSArrayQueue[A](0)
 
-  def bounded[A](bufferSize: Int, triggerEx: Int => Throwable = null): ArrayQueue[A] =
-    new ArrayQueue[A](bufferSize, triggerEx)
+  def bounded[A](bufferSize: Int, triggerEx: Int => Throwable = null): JSArrayQueue[A] =
+    new JSArrayQueue[A](bufferSize, triggerEx)
 }

--- a/monix-execution/js/src/main/scala/monix/execution/internal/collection/queues/ConcurrentQueueBuilders.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/internal/collection/queues/ConcurrentQueueBuilders.scala
@@ -18,7 +18,7 @@
 package monix.execution.internal.collection.queues
 
 import monix.execution.{BufferCapacity, ChannelType}
-import monix.execution.internal.collection.{ArrayQueue, ConcurrentQueue}
+import monix.execution.internal.collection.{JSArrayQueue, ConcurrentQueue}
 
 private[internal] trait ConcurrentQueueBuilders {
   /**
@@ -26,7 +26,7 @@ private[internal] trait ConcurrentQueueBuilders {
     */
   def apply[A](capacity: BufferCapacity, channelType: ChannelType): ConcurrentQueue[A] =
     capacity match {
-      case BufferCapacity.Bounded(c) => ArrayQueue.bounded[A](c)
-      case BufferCapacity.Unbounded(_) => ArrayQueue.unbounded[A]
+      case BufferCapacity.Bounded(c) => JSArrayQueue.bounded[A](c)
+      case BufferCapacity.Unbounded(_) => JSArrayQueue.unbounded[A]
     }
 }

--- a/monix-execution/js/src/test/scala/monix/execution/internal/collection/JSArrayQueueSuite.scala
+++ b/monix-execution/js/src/test/scala/monix/execution/internal/collection/JSArrayQueueSuite.scala
@@ -19,11 +19,11 @@ package monix.execution.internal.collection
 
 import minitest.SimpleTestSuite
 
-object ArrayQueueSuite extends SimpleTestSuite {
+object JSArrayQueueSuite extends SimpleTestSuite {
   test("unbounded") {
-    val q = ArrayQueue.unbounded[Int]
+    val q = JSArrayQueue.unbounded[Int]
 
-    for (i <- 0 until 100) q.offer(1)
+    for (_ <- 0 until 100) q.offer(1)
     assertEquals(q.length, 100)
 
     var sum = 0

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/collection/ChunkedArrayQueue.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/collection/ChunkedArrayQueue.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.execution.internal
+package collection
+
+private[monix] final class ChunkedArrayQueue[A] private (
+  initialTailArray: Array[AnyRef],
+  initialTailIndex: Int,
+  initialHeadArray: Array[AnyRef],
+  initialHeadIndex: Int,
+  chunkSize: Int)
+  extends Serializable { self =>
+
+  assert(chunkSize > 1, "chunkSize > 1")
+
+  private[this] val modulo = chunkSize - 1
+  private[this] var tailArray = initialTailArray
+  private[this] var tailIndex = initialTailIndex
+  private[this] var headArray = initialHeadArray
+  private[this] var headIndex = initialHeadIndex
+
+  /**
+    * Returns `true` if the queue is empty, `false` otherwise.
+    */
+  def isEmpty: Boolean = {
+    (headArray eq tailArray) && headIndex == tailIndex
+  }
+
+  /**
+    * Enqueues an item on the queue.
+    */
+  def enqueue(a: A): Unit = {
+    tailArray(tailIndex) = a.asInstanceOf[AnyRef]
+    tailIndex += 1
+
+    if (tailIndex == modulo) {
+      val newArray = new Array[AnyRef](chunkSize)
+      tailArray(tailIndex) = newArray
+      tailArray = newArray
+      tailIndex = 0
+    }
+  }
+
+  /** Pushes an entire iterator on the stack. */
+  def enqueueAll(cursor: Iterator[A]): Unit = {
+    while (cursor.hasNext) enqueue(cursor.next())
+  }
+
+  /** Pushes an entire sequence on the stack. */
+  def enqueueAll(seq: Iterable[A]): Unit = {
+    enqueueAll(seq.iterator)
+  }
+
+  /** Pushes an entire sequence on the stack. */
+  def enqueueAll(stack: ChunkedArrayQueue[A]): Unit =
+    enqueueAll(stack.iterator)
+
+  /**
+    * Pops an item from the queue, FIFO order.
+    */
+  def dequeue(): A = {
+    if ((headArray ne tailArray) || headIndex < tailIndex) {
+      val result = headArray(headIndex).asInstanceOf[A]
+      headIndex += 1
+
+      if (headIndex == modulo) {
+        headArray = headArray(modulo).asInstanceOf[Array[AnyRef]]
+        headIndex = 0
+      }
+      result
+    } else {
+      null.asInstanceOf[A]
+    }
+  }
+
+  /** Builds an iterator out of this queue. */
+  def iterator: Iterator[A] =
+    new Iterator[A] {
+      private[this] var headArray = self.headArray
+      private[this] var headIndex = self.headIndex
+      private[this] val tailArray = self.tailArray
+      private[this] val tailIndex = self.tailIndex
+
+      def hasNext: Boolean = {
+        (headArray ne tailArray) || headIndex < tailIndex
+      }
+
+      def next(): A = {
+        val result = headArray(headIndex).asInstanceOf[A]
+        headIndex += 1
+
+        if (headIndex == modulo) {
+          headArray = headArray(modulo).asInstanceOf[Array[AnyRef]]
+          headIndex = 0
+        }
+        result
+      }
+    }
+}
+
+private[monix] object ChunkedArrayQueue {
+  /**
+    * Builds a new [[ChunkedArrayQueue]].
+    */
+  def apply[A](chunkSize: Int = 8): ChunkedArrayQueue[A] = {
+    val arr = new Array[AnyRef](chunkSize)
+    new ChunkedArrayQueue[A](arr, 0, arr, 0, chunkSize)
+  }
+}

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/collection/ChunkedArrayStack.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/collection/ChunkedArrayStack.scala
@@ -22,18 +22,17 @@ package collection
   *
   * INTERNAL API.
   */
-private[monix] final class ArrayStack[A] private (
+private[monix] final class ChunkedArrayStack[A] private (
   initialArray: Array[AnyRef],
   chunkSize: Int,
   initialIndex: Int)
   extends Serializable { self =>
 
+  assert(chunkSize > 1, "chunkSize > 1")
+
   private[this] val modulo = chunkSize - 1
   private[this] var array = initialArray
   private[this] var index = initialIndex
-
-  def this(chunkSize: Int) = this(new Array[AnyRef](chunkSize), chunkSize, 0)
-  def this() = this(8)
 
   /** Returns `true` if the stack is empty. */
   def isEmpty: Boolean =
@@ -63,7 +62,7 @@ private[monix] final class ArrayStack[A] private (
   }
 
   /** Pushes an entire sequence on the stack. */
-  def pushAll(stack: ArrayStack[A]): Unit = {
+  def pushAll(stack: ChunkedArrayStack[A]): Unit = {
     pushAll(stack.iteratorReversed)
   }
 
@@ -107,4 +106,12 @@ private[monix] final class ArrayStack[A] private (
         result
       }
     }
+}
+
+private[monix] object ChunkedArrayStack {
+  /**
+    * Builds a new [[ChunkedArrayStack]] object.
+    */
+  def apply[A](chunkSize: Int = 8): ChunkedArrayStack[A] =
+    new ChunkedArrayStack[A](new Array[AnyRef](chunkSize), chunkSize, 0)
 }

--- a/monix-execution/shared/src/test/scala/monix/execution/internal/collection/ChunkedArrayQueueSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/internal/collection/ChunkedArrayQueueSuite.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.execution.internal.collection
+
+import minitest.SimpleTestSuite
+import scala.collection.immutable.Queue
+
+object ChunkedArrayQueueSuite extends SimpleTestSuite {
+  test("enqueue and dequeue 8 items") {
+    val queue = ChunkedArrayQueue[Int](chunkSize = 8)
+    var times = 0
+
+    while (times < 10) {
+      assert(queue.isEmpty, "queue.isEmpty")
+      for (i <- 0 until 8) queue.enqueue(i)
+
+      var list = List.empty[Int]
+      while (!queue.isEmpty) {
+        assert(!queue.isEmpty, "!queue.isEmpty")
+        list = queue.dequeue() :: list
+      }
+
+      assertEquals(list, (0 until 8).reverse.toList)
+      assertEquals(queue.dequeue().asInstanceOf[AnyRef], null)
+      assert(queue.isEmpty, "queue.isEmpty")
+
+      times += 1
+    }
+  }
+
+  test("enqueue and dequeue 100 items") {
+    val queue = ChunkedArrayQueue[Int](chunkSize = 8)
+    var times = 0
+
+    while (times < 10) {
+      assert(queue.isEmpty, "queue.isEmpty")
+      for (i <- 0 until 100) queue.enqueue(i)
+
+      var list = List.empty[Int]
+      while (!queue.isEmpty) {
+        assert(!queue.isEmpty, "!queue.isEmpty")
+        list = queue.dequeue() :: list
+      }
+
+      assertEquals(list, (0 until 100).reverse.toList)
+      assertEquals(queue.dequeue().asInstanceOf[AnyRef], null)
+      assert(queue.isEmpty, "queue.isEmpty")
+
+      times += 1
+    }
+  }
+
+  test("enqueue/dequeue on each step") {
+    val queue = ChunkedArrayQueue[AnyRef](chunkSize = 8)
+
+    for (i <- 0 until 100) {
+      queue.enqueue(i.asInstanceOf[AnyRef])
+      assertEquals(queue.dequeue().asInstanceOf[Int], i)
+      assertEquals(queue.dequeue(), null)
+    }
+  }
+
+  test("enqueueAll(queue)") {
+    val queue = ChunkedArrayQueue[Int](chunkSize = 8)
+    val queue2 = ChunkedArrayQueue[Int](chunkSize = 8)
+
+    for (i <- 0 until 100) queue2.enqueue(i)
+    queue.enqueueAll(queue2)
+
+    var list = Queue.empty[Int]
+    while (!queue.isEmpty) {
+      assert(!queue.isEmpty)
+      list = list.enqueue(queue.dequeue())
+    }
+
+    assertEquals(list, (0 until 100).toList)
+    assertEquals(queue.dequeue().asInstanceOf[AnyRef], null)
+    assert(queue.isEmpty, "queue.isEmpty")
+    assert(!queue2.isEmpty, "!stack2.isEmpty")
+  }
+
+  test("enqueueAll(iterable)") {
+    val queue = ChunkedArrayQueue[Int](chunkSize = 8)
+    val expected = (0 until 100).toList
+    queue.enqueueAll(expected)
+
+    var list = Queue.empty[Int]
+    while (!queue.isEmpty) {
+      assert(!queue.isEmpty)
+      list = list.enqueue(queue.dequeue())
+    }
+
+    assertEquals(list, expected)
+    assertEquals(queue.dequeue().asInstanceOf[AnyRef], null)
+    assert(queue.isEmpty, "queue.isEmpty")
+  }
+
+  test("iterator") {
+    val queue = ChunkedArrayQueue[Int](chunkSize = 8)
+    val expected = (0 until 100).toList
+    for (i <- expected) queue.enqueue(i)
+
+    assertEquals(queue.dequeue(), 0)
+    assertEquals(queue.dequeue(), 1)
+    assertEquals(queue.iterator.toList, expected.drop(2))
+  }
+}

--- a/monix-execution/shared/src/test/scala/monix/execution/internal/collection/ChunkedArrayStackSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/internal/collection/ChunkedArrayStackSuite.scala
@@ -19,9 +19,9 @@ package monix.execution.internal.collection
 
 import minitest.SimpleTestSuite
 
-object ArrayStackSuite extends SimpleTestSuite {
+object ChunkedArrayStackSuite extends SimpleTestSuite {
   test("push and pop 8 items") {
-    val stack = new ArrayStack[Int]()
+    val stack = ChunkedArrayStack[Int](chunkSize = 8)
     var times = 0
 
     while (times < 10) {
@@ -43,7 +43,7 @@ object ArrayStackSuite extends SimpleTestSuite {
   }
 
   test("push and pop 100 items") {
-    val stack = new ArrayStack[Int]()
+    val stack = ChunkedArrayStack[Int](chunkSize = 8)
     var times = 0
 
     while (times < 10) {
@@ -65,8 +65,8 @@ object ArrayStackSuite extends SimpleTestSuite {
   }
 
   test("pushAll(stack)") {
-    val stack = new ArrayStack[Int]()
-    val stack2 = new ArrayStack[Int]()
+    val stack = ChunkedArrayStack[Int](chunkSize = 8)
+    val stack2 = ChunkedArrayStack[Int](chunkSize = 8)
 
     for (i <- 0 until 100) stack2.push(i)
     stack.pushAll(stack2)
@@ -84,7 +84,7 @@ object ArrayStackSuite extends SimpleTestSuite {
   }
 
   test("pushAll(iterable)") {
-    val stack = new ArrayStack[Int]()
+    val stack = ChunkedArrayStack[Int](chunkSize = 8)
     val expected = (0 until 100).toList
     stack.pushAll(expected)
 
@@ -100,7 +100,7 @@ object ArrayStackSuite extends SimpleTestSuite {
   }
 
   test("iterator") {
-    val stack = new ArrayStack[Int]()
+    val stack = ChunkedArrayStack[Int](chunkSize = 8)
     val expected = (0 until 100).toList
     for (i <- expected) stack.push(i)
     assertEquals(stack.iteratorReversed.toList, expected.reverse)

--- a/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/AbstractBackPressuredBufferedSubscriber.scala
+++ b/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/AbstractBackPressuredBufferedSubscriber.scala
@@ -19,7 +19,7 @@ package monix.reactive.observers.buffers
 
 import monix.execution.Ack
 import monix.execution.Ack.{Continue, Stop}
-import monix.execution.internal.collection.ArrayQueue
+import monix.execution.internal.collection.JSArrayQueue
 import monix.execution.internal.math.nextPowerOf2
 import scala.util.control.NonFatal
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
@@ -46,7 +46,7 @@ private[observers] abstract class AbstractBackPressuredBufferedSubscriber[A,R]
   private[this] var isLoopActive = false
   private[this] var backPressured: Promise[Ack] = null
   private[this] var lastIterationAck: Future[Ack] = Continue
-  protected val queue = ArrayQueue.unbounded[A]
+  protected val queue = JSArrayQueue.unbounded[A]
 
   final def onNext(elem: A): Future[Ack] = {
     if (upstreamIsComplete || downstreamIsComplete)

--- a/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/SyncBufferedSubscriber.scala
+++ b/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/SyncBufferedSubscriber.scala
@@ -19,7 +19,7 @@ package monix.reactive.observers.buffers
 
 import monix.execution.Ack
 import monix.execution.Ack.{Continue, Stop}
-import monix.execution.internal.collection.{ArrayQueue, _}
+import monix.execution.internal.collection.{JSArrayQueue, _}
 import scala.util.control.NonFatal
 import monix.execution.exceptions.BufferOverflowException
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
@@ -244,7 +244,7 @@ private[monix] object SyncBufferedSubscriber {
     * overflow strategy.
     */
   def unbounded[A](underlying: Subscriber[A]): Subscriber.Sync[A] = {
-    val buffer = ArrayQueue.unbounded[A]
+    val buffer = JSArrayQueue.unbounded[A]
     new SyncBufferedSubscriber[A](underlying, buffer, null)
   }
 
@@ -255,7 +255,7 @@ private[monix] object SyncBufferedSubscriber {
     */
   def bounded[A](underlying: Subscriber[A], bufferSize: Int): Subscriber.Sync[A] = {
     require(bufferSize > 1, "bufferSize must be strictly higher than 1")
-    val buffer = ArrayQueue.bounded[A](bufferSize, _ => {
+    val buffer = JSArrayQueue.bounded[A](bufferSize, _ => {
       BufferOverflowException(
         s"Downstream observer is too slow, buffer over capacity with a " +
         s"specified buffer size of $bufferSize")
@@ -271,7 +271,7 @@ private[monix] object SyncBufferedSubscriber {
     */
   def dropNew[A](underlying: Subscriber[A], bufferSize: Int): Subscriber.Sync[A] = {
     require(bufferSize > 1, "bufferSize must be strictly higher than 1")
-    val buffer = ArrayQueue.bounded[A](bufferSize)
+    val buffer = JSArrayQueue.bounded[A](bufferSize)
     new SyncBufferedSubscriber[A](underlying, buffer, null)
   }
 
@@ -282,7 +282,7 @@ private[monix] object SyncBufferedSubscriber {
     */
   def dropNewAndSignal[A](underlying: Subscriber[A], bufferSize: Int, onOverflow: Long => Option[A]): Subscriber.Sync[A] = {
     require(bufferSize > 1, "bufferSize must be strictly higher than 1")
-    val buffer = ArrayQueue.bounded[A](bufferSize)
+    val buffer = JSArrayQueue.bounded[A](bufferSize)
     new SyncBufferedSubscriber[A](underlying, buffer, onOverflow)
   }
 

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantBuffer.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantBuffer.scala
@@ -20,7 +20,7 @@ package internal
 
 import cats.effect.Sync
 import cats.syntax.all._
-import monix.execution.internal.collection.ArrayStack
+import monix.execution.internal.collection.ChunkedArrayStack
 import monix.tail.Iterant.{Concat, Halt, Last, Next, NextBatch, NextCursor, Scope, Suspend}
 import monix.tail.batches.Batch
 
@@ -63,7 +63,7 @@ private[tail] object IterantBuffer {
     extends Iterant.Visitor[F, A, F[Iterant[F, B]]] { loop =>
 
     private[this] val buffer = new Buffer[A](count, skip)
-    private[this] val stack  = new ArrayStack[F[Iterant[F, A]]]()
+    private[this] val stack  = ChunkedArrayStack[F[Iterant[F, A]]]()
 
     def visit(ref: Next[F, A]): F[Iterant[F, B]] = {
       val seq = buffer.push(ref.item)

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantCompleteL.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantCompleteL.scala
@@ -19,7 +19,7 @@ package monix.tail.internal
 
 import cats.effect.Sync
 import cats.syntax.all._
-import monix.execution.internal.collection.ArrayStack
+import monix.execution.internal.collection.ChunkedArrayStack
 import monix.tail.Iterant
 import monix.tail.Iterant.{Concat, Halt, Last, Next, NextBatch, NextCursor, Scope, Suspend}
 import monix.tail.batches.BatchCursor
@@ -39,10 +39,10 @@ private[tail] object IterantCompleteL {
 
     //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
     // Used in visit(Concat)
-    private[this] var stackRef: ArrayStack[F[Iterant[F, A]]] = _
+    private[this] var stackRef: ChunkedArrayStack[F[Iterant[F, A]]] = _
 
     private def stackPush(item: F[Iterant[F, A]]): Unit = {
-      if (stackRef == null) stackRef = new ArrayStack()
+      if (stackRef == null) stackRef = ChunkedArrayStack()
       stackRef.push(item)
     }
 

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFoldLeftL.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFoldLeftL.scala
@@ -19,7 +19,7 @@ package monix.tail.internal
 
 import cats.effect.Sync
 import cats.syntax.all._
-import monix.execution.internal.collection.ArrayStack
+import monix.execution.internal.collection.ChunkedArrayStack
 import monix.tail.Iterant
 import monix.tail.Iterant.{Concat, Halt, Last, Next, NextBatch, NextCursor, Scope, Suspend}
 
@@ -64,10 +64,10 @@ private[tail] object IterantFoldLeftL {
 
     //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
     // Used in visit(Concat)
-    private[this] var stackRef: ArrayStack[F[Iterant[F, A]]] = _
+    private[this] var stackRef: ChunkedArrayStack[F[Iterant[F, A]]] = _
 
     private def stackPush(item: F[Iterant[F, A]]): Unit = {
-      if (stackRef == null) stackRef = new ArrayStack()
+      if (stackRef == null) stackRef = ChunkedArrayStack()
       stackRef.push(item)
     }
 

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFoldRightL.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFoldRightL.scala
@@ -19,7 +19,7 @@ package monix.tail.internal
 
 import cats.effect.Sync
 import cats.syntax.all._
-import monix.execution.internal.collection.ArrayStack
+import monix.execution.internal.collection.ChunkedArrayStack
 import monix.tail.Iterant
 import monix.tail.Iterant.{Halt, Last, Next, NextBatch, NextCursor, Scope, Suspend}
 
@@ -38,10 +38,10 @@ private[tail] object IterantFoldRightL {
 
     //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
     // Used in visit(Concat)
-    private[this] var stackRef: ArrayStack[F[Iterant[F, A]]] = _
+    private[this] var stackRef: ChunkedArrayStack[F[Iterant[F, A]]] = _
 
     private def stackPush(item: F[Iterant[F, A]]): Unit = {
-      if (stackRef == null) stackRef = new ArrayStack()
+      if (stackRef == null) stackRef = ChunkedArrayStack()
       stackRef.push(item)
     }
 

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFoldWhileLeftL.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFoldWhileLeftL.scala
@@ -20,7 +20,7 @@ package internal
 
 import cats.effect.Sync
 import cats.syntax.all._
-import monix.execution.internal.collection.ArrayStack
+import monix.execution.internal.collection.ChunkedArrayStack
 import monix.tail.Iterant.{Concat, Halt, Last, Next, NextBatch, NextCursor, Suspend, Scope}
 import monix.tail.batches.BatchCursor
 
@@ -63,10 +63,10 @@ private[tail] object IterantFoldWhileLeftL {
 
     //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
     // Used in visit(Concat)
-    private[this] var stackRef: ArrayStack[F[Iterant[F, A]]] = _
+    private[this] var stackRef: ChunkedArrayStack[F[Iterant[F, A]]] = _
 
     private def stackPush(item: F[Iterant[F, A]]): Unit = {
-      if (stackRef == null) stackRef = new ArrayStack()
+      if (stackRef == null) stackRef = ChunkedArrayStack()
       stackRef.push(item)
     }
 
@@ -161,10 +161,10 @@ private[tail] object IterantFoldWhileLeftL {
 
     //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
     // Used in visit(Concat)
-    private[this] var stackRef: ArrayStack[F[Iterant[F, A]]] = _
+    private[this] var stackRef: ChunkedArrayStack[F[Iterant[F, A]]] = _
 
     private def stackPush(item: F[Iterant[F, A]]): Unit = {
-      if (stackRef == null) stackRef = new ArrayStack()
+      if (stackRef == null) stackRef = ChunkedArrayStack()
       stackRef.push(item)
     }
 

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantHeadOptionL.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantHeadOptionL.scala
@@ -19,7 +19,7 @@ package monix.tail.internal
 
 import cats.effect.Sync
 import cats.syntax.all._
-import monix.execution.internal.collection.ArrayStack
+import monix.execution.internal.collection.ChunkedArrayStack
 import monix.tail.Iterant
 import monix.tail.Iterant.{Concat, Halt, Last, Next, NextBatch, NextCursor, Scope, Suspend}
 import monix.tail.batches.BatchCursor
@@ -44,10 +44,10 @@ private[tail] object IterantHeadOptionL {
 
     //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
     // Used in visit(Concat)
-    private[this] var stackRef: ArrayStack[F[Iterant[F, A]]] = _
+    private[this] var stackRef: ChunkedArrayStack[F[Iterant[F, A]]] = _
 
     private def stackPush(item: F[Iterant[F, A]]): Unit = {
-      if (stackRef == null) stackRef = new ArrayStack()
+      if (stackRef == null) stackRef = ChunkedArrayStack()
       stackRef.push(item)
     }
 

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantInterleave.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantInterleave.scala
@@ -19,7 +19,7 @@ package monix.tail.internal
 
 import cats.effect.Sync
 import cats.syntax.all._
-import monix.execution.internal.collection.ArrayStack
+import monix.execution.internal.collection.ChunkedArrayStack
 import monix.tail.Iterant
 import monix.tail.Iterant.{Concat, Halt, Last, Next, NextBatch, NextCursor, Scope, Suspend}
 
@@ -40,11 +40,11 @@ private[tail] object IterantInterleave {
     //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
     // Used by Concat:
 
-    private[this] var _lhStack: ArrayStack[F[Iterant[F, A]]] = _
-    private[this] var _rhStack: ArrayStack[F[Iterant[F, A]]] = _
+    private[this] var _lhStack: ChunkedArrayStack[F[Iterant[F, A]]] = _
+    private[this] var _rhStack: ChunkedArrayStack[F[Iterant[F, A]]] = _
 
     private def lhStackPush(ref: F[Iterant[F, A]]): Unit = {
-      if (_lhStack == null) _lhStack = new ArrayStack()
+      if (_lhStack == null) _lhStack = ChunkedArrayStack()
       _lhStack.push(ref)
     }
 
@@ -53,7 +53,7 @@ private[tail] object IterantInterleave {
       else _lhStack.pop()
 
     private def rhStackPush(ref: F[Iterant[F, A]]): Unit = {
-      if (_rhStack == null) _rhStack = new ArrayStack()
+      if (_rhStack == null) _rhStack = ChunkedArrayStack()
       _rhStack.push(ref)
     }
 

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantIntersperse.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantIntersperse.scala
@@ -23,7 +23,7 @@ import cats.effect.Sync
 import cats.syntax.functor._
 import scala.util.control.NonFatal
 
-import monix.execution.internal.collection.ArrayStack
+import monix.execution.internal.collection.ChunkedArrayStack
 import monix.tail.Iterant
 import monix.tail.Iterant._
 import monix.tail.batches.BatchCursor
@@ -39,7 +39,7 @@ private[tail] object IterantIntersperse {
     extends (Iterant[F, A] => Iterant[F, A])
   {
     private[this] var prepend = false
-    private[this] val stack = new ArrayStack[F[Iterant[F, A]]]()
+    private[this] val stack = ChunkedArrayStack[F[Iterant[F, A]]]()
 
     def apply(source: Iterant[F, A]): Iterant[F, A] = {
       try source match {

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantReduce.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantReduce.scala
@@ -20,7 +20,7 @@ package internal
 
 import cats.effect.Sync
 import cats.syntax.all._
-import monix.execution.internal.collection.ArrayStack
+import monix.execution.internal.collection.ChunkedArrayStack
 import monix.tail.Iterant.{Concat, Halt, Last, Next, NextBatch, NextCursor, Scope, Suspend}
 
 
@@ -40,10 +40,10 @@ private[tail] object IterantReduce {
 
     //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
     // Used in visit(Concat)
-    private[this] var stackRef: ArrayStack[F[Iterant[F, A]]] = _
+    private[this] var stackRef: ChunkedArrayStack[F[Iterant[F, A]]] = _
 
     private def stackPush(item: F[Iterant[F, A]]): Unit = {
-      if (stackRef == null) stackRef = new ArrayStack()
+      if (stackRef == null) stackRef = ChunkedArrayStack()
       stackRef.push(item)
     }
 

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantRepeat.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantRepeat.scala
@@ -20,7 +20,7 @@ package monix.tail.internal
 import cats.effect.Sync
 import cats.syntax.all._
 import monix.execution.internal.Platform
-import monix.execution.internal.collection.ArrayStack
+import monix.execution.internal.collection.ChunkedArrayStack
 import monix.tail.Iterant
 import monix.tail.Iterant.{Concat, Halt, Last, Next, NextBatch, NextCursor, Scope, Suspend}
 import monix.tail.batches.{BatchCursor, GenericBatch, GenericCursor}
@@ -57,7 +57,7 @@ private[tail] object IterantRepeat {
     extends Iterant.Visitor[F, A, Iterant[F, A]] {
 
     private[this] var isEmpty = true
-    private[this] var stack: ArrayStack[F[Iterant[F, A]]] = _
+    private[this] var stack: ChunkedArrayStack[F[Iterant[F, A]]] = _
 
     def visit(ref: Next[F, A]): Iterant[F, A] = {
       if (isEmpty) isEmpty = false
@@ -83,7 +83,7 @@ private[tail] object IterantRepeat {
       Suspend[F, A](ref.rest.map(this))
 
     def visit(ref: Concat[F, A]): Iterant[F, A] = {
-      if (stack == null) stack = new ArrayStack()
+      if (stack == null) stack = ChunkedArrayStack()
       stack.push(ref.rh)
       Suspend(ref.lh.map(this))
     }

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantScan.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantScan.scala
@@ -20,7 +20,7 @@ package internal
 
 import cats.effect.Sync
 import cats.syntax.all._
-import monix.execution.internal.collection.ArrayStack
+import monix.execution.internal.collection.ChunkedArrayStack
 
 import scala.util.control.NonFatal
 import monix.tail.Iterant.{Concat, Halt, Last, Next, NextBatch, NextCursor, Scope, Suspend}
@@ -45,10 +45,10 @@ private[tail] object IterantScan {
     extends Iterant.Visitor[F, A, Iterant[F, S]] {
 
     private[this] var state = initial
-    private[this] var stackRef: ArrayStack[F[Iterant[F, A]]] = _
+    private[this] var stackRef: ChunkedArrayStack[F[Iterant[F, A]]] = _
 
     private def stackPush(item: F[Iterant[F, A]]): Unit = {
-      if (stackRef == null) stackRef = new ArrayStack()
+      if (stackRef == null) stackRef = ChunkedArrayStack()
       stackRef.push(item)
     }
 

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantScanEval.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantScanEval.scala
@@ -19,7 +19,7 @@ package monix.tail.internal
 
 import cats.effect.Sync
 import cats.syntax.all._
-import monix.execution.internal.collection.ArrayStack
+import monix.execution.internal.collection.ChunkedArrayStack
 import monix.tail.Iterant
 import monix.tail.Iterant._
 
@@ -39,10 +39,10 @@ private[tail] object IterantScanEval {
     extends Iterant.Visitor[F, A, Iterant[F, S]] {
 
     private[this] var state: S = seed
-    private[this] var stackRef: ArrayStack[F[Iterant[F, A]]] = _
+    private[this] var stackRef: ChunkedArrayStack[F[Iterant[F, A]]] = _
 
     private def stackPush(item: F[Iterant[F, A]]): Unit = {
-      if (stackRef == null) stackRef = new ArrayStack()
+      if (stackRef == null) stackRef = ChunkedArrayStack()
       stackRef.push(item)
     }
 

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantSwitchIfEmpty.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantSwitchIfEmpty.scala
@@ -19,7 +19,7 @@ package monix.tail.internal
 
 import cats.syntax.functor._
 import cats.effect.Sync
-import monix.execution.internal.collection.ArrayStack
+import monix.execution.internal.collection.ChunkedArrayStack
 import monix.tail.Iterant
 import monix.tail.Iterant._
 
@@ -48,13 +48,13 @@ private[tail] object IterantSwitchIfEmpty {
     extends Iterant.Visitor[F, A, Iterant[F, A]] { self =>
 
     private[this] var isEmpty = true
-    private[this] var stackRef: ArrayStack[F[Iterant[F, A]]] = _
+    private[this] var stackRef: ChunkedArrayStack[F[Iterant[F, A]]] = _
 
     private[this] def isStackEmpty: Boolean =
       stackRef == null || stackRef.isEmpty
 
     private def stackPush(item: F[Iterant[F, A]]): Unit = {
-      if (stackRef == null) stackRef = new ArrayStack()
+      if (stackRef == null) stackRef = ChunkedArrayStack()
       stackRef.push(item)
     }
 

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantTakeLast.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantTakeLast.scala
@@ -19,7 +19,7 @@ package monix.tail.internal
 
 import cats.effect.Sync
 import cats.syntax.all._
-import monix.execution.internal.collection.{ArrayStack, DropHeadOnOverflowQueue}
+import monix.execution.internal.collection.{ChunkedArrayStack, DropHeadOnOverflowQueue}
 import monix.tail.Iterant
 import monix.tail.Iterant.{Concat, Halt, Last, Next, NextBatch, NextCursor, Scope, Suspend}
 import monix.tail.batches.BatchCursor
@@ -39,10 +39,10 @@ private[tail] object IterantTakeLast {
     extends Iterant.Visitor[F, A, Iterant[F, A]] { loop =>
 
     private val buffer = DropHeadOnOverflowQueue.boxed[A](n)
-    private[this] var stackRef: ArrayStack[F[Iterant[F, A]]] = _
+    private[this] var stackRef: ChunkedArrayStack[F[Iterant[F, A]]] = _
 
     private def stackPush(item: F[Iterant[F, A]]): Unit = {
-      if (stackRef == null) stackRef = new ArrayStack()
+      if (stackRef == null) stackRef = ChunkedArrayStack()
       stackRef.push(item)
     }
 

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantToReactivePublisher.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantToReactivePublisher.scala
@@ -24,7 +24,7 @@ import monix.execution.atomic.Atomic
 import monix.execution.atomic.PaddingStrategy.LeftRight128
 import monix.execution.cancelables.SingleAssignCancelable
 import monix.execution.internal.Platform
-import monix.execution.internal.collection.ArrayStack
+import monix.execution.internal.collection.ChunkedArrayStack
 import monix.execution.rstreams.Subscription
 import monix.execution.{Cancelable, UncaughtExceptionReporter}
 import monix.tail.Iterant
@@ -160,10 +160,10 @@ private[tail] object IterantToReactivePublisher {
 
       //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
       // Used in visit(Concat)
-      private[this] var _stack: ArrayStack[F[Iterant[F, A]]] = _
+      private[this] var _stack: ChunkedArrayStack[F[Iterant[F, A]]] = _
 
       private def stackPush(item: F[Iterant[F, A]]): Unit = {
-        if (_stack == null) _stack = new ArrayStack()
+        if (_stack == null) _stack = ChunkedArrayStack()
         _stack.push(item)
       }
 

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantZipMap.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantZipMap.scala
@@ -21,7 +21,7 @@ import cats.effect.Sync
 import cats.syntax.all._
 import cats.{Applicative, Parallel}
 import monix.execution.internal.{ParallelApplicative, Platform}
-import monix.execution.internal.collection.ArrayStack
+import monix.execution.internal.collection.ChunkedArrayStack
 import monix.tail.Iterant
 import monix.tail.Iterant.{Concat, Halt, Last, Next, NextBatch, NextCursor, Scope, Suspend}
 import monix.tail.batches.{Batch, BatchCursor}
@@ -58,11 +58,11 @@ private[tail] object IterantZipMap {
     //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
     // Used by Concat:
 
-    private[this] var _lhStack: ArrayStack[F[Iterant[F, A]]] = _
-    private[this] var _rhStack: ArrayStack[F[Iterant[F, B]]] = _
+    private[this] var _lhStack: ChunkedArrayStack[F[Iterant[F, A]]] = _
+    private[this] var _rhStack: ChunkedArrayStack[F[Iterant[F, B]]] = _
 
     private def lhStackPush(ref: F[Iterant[F, A]]): Unit = {
-      if (_lhStack == null) _lhStack = new ArrayStack()
+      if (_lhStack == null) _lhStack = ChunkedArrayStack()
       _lhStack.push(ref)
     }
 
@@ -71,7 +71,7 @@ private[tail] object IterantZipMap {
       else _lhStack.pop()
 
     private def rhStackPush(ref: F[Iterant[F, B]]): Unit = {
-      if (_rhStack == null) _rhStack = new ArrayStack()
+      if (_rhStack == null) _rhStack = ChunkedArrayStack()
       _rhStack.push(ref)
     }
 
@@ -121,7 +121,7 @@ private[tail] object IterantZipMap {
         rhRef = rh
         apply(lh)
       }
-      
+
       def visit(ref: Next[F, A]): Iterant[F, C] =
         rhNextLoop.visit(ref, rhRef)
 

--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -348,6 +348,8 @@ object MimaFilters {
     exclude[MissingClassProblem]("monix.eval.instances.ParallelApplicative"),
     exclude[MissingClassProblem]("monix.reactive.internal.operators.DelaySubscriptionByTimespanObservable"),
     exclude[MissingClassProblem]("monix.reactive.internal.operators.DelaySubscriptionWithTriggerObservable"),
-    exclude[MissingClassProblem]("monix.execution.internal.collection.ArrayStack")
+    exclude[MissingClassProblem]("monix.execution.internal.collection.ArrayStack"),
+    exclude[IncompatibleMethTypeProblem]("monix.eval.internal.TaskRunLoop.findErrorHandler"),
+    exclude[IncompatibleMethTypeProblem]("monix.eval.internal.TaskRunLoop.popNextBind")
   )
 }

--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -347,6 +347,7 @@ object MimaFilters {
     exclude[IncompatibleResultTypeProblem]("monix.eval.instances.CatsEffectForTask.runAsync"),
     exclude[MissingClassProblem]("monix.eval.instances.ParallelApplicative"),
     exclude[MissingClassProblem]("monix.reactive.internal.operators.DelaySubscriptionByTimespanObservable"),
-    exclude[MissingClassProblem]("monix.reactive.internal.operators.DelaySubscriptionWithTriggerObservable")
+    exclude[MissingClassProblem]("monix.reactive.internal.operators.DelaySubscriptionWithTriggerObservable"),
+    exclude[MissingClassProblem]("monix.execution.internal.collection.ArrayStack")
   )
 }


### PR DESCRIPTION
The implementation of TrampolineScheduler changed to use an internal stack, instead of a queue, on top of JavaScript.

This is less than ideal, plus it apparently broke some tests for Outwatch, see: https://github.com/OutWatch/outwatch/pull/242

This PR changes the `Trampoline` implementation to use a plain queue. We implement our own chunked array queue for performance reasons, because the one in Scala is built via a linked list.

---

Published test version: `3.0.0-RC2-379831b`