### PR TITLE
Add FunctorFilter instances for Iterant&Observable

### DIFF
--- a/monix-reactive/shared/src/test/scala/monix/reactive/TypeClassLawsForObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/TypeClassLawsForObservableSuite.scala
@@ -18,8 +18,9 @@
 package monix.reactive
 
 import cats.effect.laws.discipline.BracketTests
-import cats.laws.discipline.{AlternativeTests, ApplyTests, CoflatMapTests, MonoidKTests, NonEmptyParallelTests}
+import cats.laws.discipline.{AlternativeTests, ApplyTests, CoflatMapTests, FunctorFilterTests, MonoidKTests, NonEmptyParallelTests}
 import monix.reactive.observables.CombineObservable
+import cats.laws.discipline.arbitrary.catsLawsArbitraryForPartialFunction
 
 object TypeClassLawsForObservableSuite extends BaseLawsTestSuite {
   checkAllAsync("Bracket[Observable, Throwable]") { implicit ec =>
@@ -48,5 +49,9 @@ object TypeClassLawsForObservableSuite extends BaseLawsTestSuite {
 
   checkAllAsync("NonEmptyParallel[Observable, CombineObservable.Type]") { implicit ec =>
     NonEmptyParallelTests[Observable, CombineObservable.Type].nonEmptyParallel[Int, Int]
+  }
+
+  checkAllAsync("FunctorFilter[Observable]") { implicit ec =>
+    FunctorFilterTests[Observable].functorFilter[Int, Int, Int]
   }
 }

--- a/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
@@ -21,7 +21,7 @@ import java.io.PrintStream
 
 import cats.arrow.FunctionK
 import cats.effect.{Async, Effect, Sync, _}
-import cats.{Applicative, CoflatMap, Defer, Eq, Functor, MonadError, Monoid, MonoidK, Order, Parallel, StackSafeMonad}
+import cats.{Applicative, CoflatMap, Defer, Eq, Functor, FunctorFilter, MonadError, Monoid, MonoidK, Order, Parallel, StackSafeMonad}
 
 import scala.util.control.NonFatal
 import monix.execution.internal.Platform.recommendedBatchSize
@@ -2640,7 +2640,8 @@ private[tail] trait IterantInstances {
       with MonadError[Iterant[F, ?], Throwable]
       with Defer[Iterant[F, ?]]
       with MonoidK[Iterant[F, ?]]
-      with CoflatMap[Iterant[F, ?]] {
+      with CoflatMap[Iterant[F, ?]]
+      with FunctorFilter[Iterant[F, ?]] {
 
     override def pure[A](a: A): Iterant[F, A] =
       Iterant.pure(a)
@@ -2692,5 +2693,16 @@ private[tail] trait IterantInstances {
 
     override def recoverWith[A](fa: Iterant[F, A])(pf: PartialFunction[Throwable, Iterant[F, A]]): Iterant[F, A] =
       fa.onErrorRecoverWith(pf)
+
+    override def functor: Functor[Iterant[F, ?]] = this
+
+    override def mapFilter[A, B](fa: Iterant[F, A])(f: A => Option[B]): Iterant[F, B] =
+      fa.map(f).collect { case Some(b) => b }
+
+    override def collect[A, B](fa: Iterant[F, A])(f: PartialFunction[A, B]): Iterant[F, B] =
+      fa.collect(f)
+
+    override def filter[A](fa: Iterant[F, A])(f: A => Boolean): Iterant[F, A] =
+      fa.filter(f)
   }
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/TypeClassLawsForIterantCoevalSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/TypeClassLawsForIterantCoevalSuite.scala
@@ -19,7 +19,8 @@ package monix.tail
 
 import cats.Eq
 import cats.data.EitherT
-import cats.laws.discipline.{CoflatMapTests, DeferTests, MonadErrorTests, MonoidKTests, SemigroupalTests}
+import cats.laws.discipline.{CoflatMapTests, DeferTests, FunctorFilterTests, MonadErrorTests, MonoidKTests, SemigroupalTests}
+import cats.laws.discipline.arbitrary.catsLawsArbitraryForPartialFunction
 import monix.eval.Coeval
 
 object TypeClassLawsForIterantCoevalSuite extends BaseLawsSuite {
@@ -46,7 +47,11 @@ object TypeClassLawsForIterantCoevalSuite extends BaseLawsSuite {
     MonoidKTests[F].monoidK[Int]
   }
 
-  checkAllAsync("CoflatMap[Iterant[IO]]") { implicit ec =>
+  checkAllAsync("CoflatMap[Iterant[Coeval]]") { implicit ec =>
     CoflatMapTests[F].coflatMap[Int, Int, Int]
+  }
+
+  checkAllAsync("FunctorFilter[Iterant[Coeval]]") { implicit ec =>
+    FunctorFilterTests[F].functorFilter[Int, Int, Int]
   }
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/TypeClassLawsForIterantIOSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/TypeClassLawsForIterantIOSuite.scala
@@ -20,8 +20,8 @@ package monix.tail
 import cats.Eq
 import cats.data.EitherT
 import cats.effect.IO
-import cats.effect.laws.discipline.AsyncTests
-import cats.laws.discipline.{CoflatMapTests, DeferTests, MonadErrorTests, MonoidKTests, SemigroupalTests}
+import cats.laws.discipline.{CoflatMapTests, DeferTests, FunctorFilterTests, MonadErrorTests, MonoidKTests, SemigroupalTests}
+import cats.laws.discipline.arbitrary.catsLawsArbitraryForPartialFunction
 import monix.execution.schedulers.TestScheduler
 
 object TypeClassLawsForIterantIOSuite extends BaseLawsSuite {
@@ -52,5 +52,9 @@ object TypeClassLawsForIterantIOSuite extends BaseLawsSuite {
 
   checkAllAsync("CoflatMap[Iterant[IO]]") { implicit ec =>
     CoflatMapTests[F].coflatMap[Int, Int, Int]
+  }
+
+  checkAllAsync("FunctorFilter[Iterant[IO]]") { implicit ec =>
+    FunctorFilterTests[F].functorFilter[Int, Int, Int]
   }
 }

--- a/monix-tail/shared/src/test/scala/monix/tail/TypeClassLawsForIterantTaskSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/TypeClassLawsForIterantTaskSuite.scala
@@ -19,7 +19,8 @@ package monix.tail
 
 import cats.Eq
 import cats.data.EitherT
-import cats.laws.discipline.{CoflatMapTests, DeferTests, MonadErrorTests, MonoidKTests, SemigroupalTests}
+import cats.laws.discipline.{CoflatMapTests, DeferTests, FunctorFilterTests, MonadErrorTests, MonoidKTests, SemigroupalTests}
+import cats.laws.discipline.arbitrary.catsLawsArbitraryForPartialFunction
 import monix.eval.Task
 import monix.execution.schedulers.TestScheduler
 
@@ -49,7 +50,12 @@ object TypeClassLawsForIterantTaskSuite extends BaseLawsSuite {
     MonoidKTests[F].monoidK[Int]
   }
 
-  checkAllAsync("CoflatMap[Iterant[IO]]") { implicit ec =>
+  checkAllAsync("CoflatMap[Iterant[Task]]") { implicit ec =>
     CoflatMapTests[F].coflatMap[Int, Int, Int]
+  }
+
+
+  checkAllAsync("FunctorFilter[Iterant[Task]]") { implicit ec =>
+    FunctorFilterTests[F].functorFilter[Int, Int, Int]
   }
 }


### PR DESCRIPTION
There's a new typeclass abstracting over `filter` and `collect` in cats [since 1.3.0](https://github.com/typelevel/cats/releases/tag/v1.3.0). Since we have streams that support these operations, might as well have the instances :)