### PR TITLE
Use globally accessible (rather than local) source paths in JS source maps (#781)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -295,7 +295,17 @@ lazy val javaExtensionsSettings = sharedSettings ++ testSettings ++ Seq(
 )
 
 lazy val scalaJSSettings = Seq(
-  coverageExcludedFiles := ".*"
+  coverageExcludedFiles := ".*",
+
+  // Use globally accessible (rather than local) source paths in JS source maps
+  scalacOptions += {
+    val tagOrHash =
+      if (isSnapshot.value) git.gitHeadCommit.value.get
+      else s"v${git.baseVersion.value}"
+    val l = (baseDirectory in LocalRootProject).value.toURI.toString
+    val g = s"https://raw.githubusercontent.com/monix/monix/$tagOrHash/"
+    s"-P:scalajs:mapSourceURI:$l->$g"
+  }
 )
 
 lazy val cmdlineProfile =


### PR DESCRIPTION
@alexandru Please see what you think of this. I have not previously encountered the [sbt-git](https://github.com/sbt/sbt-git) plugin that the Monix build is using. I am also not sure of your versioning policies and preferences, but I have attempted to do something reasonably sensible along the lines of the Cats project as a first attempt at a PR.

I have tested this change (by running `sbt package` for the `monix` project) in three scenarios:

1. When the HEAD of the local build repository is tagged with a version string. In this case, source maps reference appropriate tagged content on GitHub. e.g. `https://raw.githubusercontent.com/monix/monix/v3.0.0-RC2/...`

2. When there are uncommitted changes in the local build repository (in which case, `isSnapshot` appears to be `true`). In this scenario, source maps reference the SHA hash of the most recent commit. i.e. `https://raw.githubusercontent.com/monix/monix/<sha-hash>/...`

3. When there are committed but untagged changes. In this case, `isSnapshot` appears to be false, and the source maps reference the most recent tag that sbt-git was able to find.

Scenario (1) is probably all that most Monix users will care about, with (2) and (3) being of relevance to Monix developers.

It seems to me that the behaviour in scenario (3) is not ideal – it would probably be better to map to GitHub paths containing the SHA hash of the current commit. However, it is not clear to me whether it is the `isSnapshot` logic that is incorrect here – perhaps `isSnapshot` should be true in this instance? This will depend upon your definition of snapshot for the Monix project.

Finally, the behaviour of scenario (2) is also debatable. Maybe local paths should be preserved in this situation? Again, though, I’m unsure whether `isSnapshot` is acting correctly here – are we really building a snapshot if we are building from uncommitted changes? Given my lack of familiarity with sbt-git and your project policies, I am not sure how best to detect this situation.

Thus, I suspect this PR will need further work, and that it would make more sense for a regular Monix contributor to run with that given the policy questions involved. Still, perhaps this PR will be somewhat helpful as a starting point.