### PR TITLE
Fix #780: improve fixed rate scheduling on JS

### DIFF
--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/ReferenceScheduler.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/ReferenceScheduler.scala
@@ -57,12 +57,13 @@ trait ReferenceScheduler extends Scheduler {
   override def scheduleAtFixedRate(initialDelay: Long, period: Long, unit: TimeUnit, r: Runnable): Cancelable = {
     val sub = OrderedCancelable()
 
-    def loop(initialDelayMs: Long, periodMs: Long): Unit =
+    def loop(initialDelayMs: Long, periodMs: Long): Unit = {
+      // Measuring the duration of the task + possible scheduler lag
+      val startedAtMillis = clockMonotonic(MILLISECONDS) + initialDelayMs
+
       if (!sub.isCanceled) {
         sub := scheduleOnce(initialDelayMs, MILLISECONDS, new Runnable {
           def run(): Unit = {
-            // Measuring the duration of the task
-            val startedAtMillis = clockMonotonic(MILLISECONDS)
             r.run()
 
             val delay = {
@@ -76,6 +77,7 @@ trait ReferenceScheduler extends Scheduler {
           }
         })
       }
+    }
 
     val initialMs = MILLISECONDS.convert(initialDelay, unit)
     val periodMs = MILLISECONDS.convert(period, unit)

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/TestScheduler.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/TestScheduler.scala
@@ -392,7 +392,6 @@ object TestScheduler {
 
     val newID = state.lastID + 1
     SingleAssignCancelable()
-
     val task = Task(newID, r, state.clock + delay)
     val cancelable = new Cancelable {
       def cancel(): Unit = cancelTask(task)

--- a/monix-execution/shared/src/test/scala/monix/execution/schedulers/ReferenceSchedulerSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/schedulers/ReferenceSchedulerSuite.scala
@@ -39,6 +39,11 @@ object ReferenceSchedulerSuite extends SimpleTestSuite {
       underlying.scheduleOnce(initialDelay, unit, r)
   }
 
+  class DummyTimeScheduler extends DummyScheduler() {
+    override def clockRealTime(unit: TimeUnit): Long = underlying.clockRealTime(unit)
+    override def clockMonotonic(unit: TimeUnit): Long = underlying.clockMonotonic(unit)
+  }
+
   test("clockRealTime") {
     val s = new DummyScheduler
     val ws = s.withExecutionModel(SynchronousExecution)
@@ -73,7 +78,7 @@ object ReferenceSchedulerSuite extends SimpleTestSuite {
   }
 
   test("schedule at fixed rate") {
-    val s = new DummyScheduler
+    val s = new DummyTimeScheduler
     val ws = s.withExecutionModel(SynchronousExecution)
 
     var effect = 0


### PR DESCRIPTION
This is a simple fix that seems to give most consistency. The idea is basically to add scheduling lag time to task execution time. Test is a bit non-deterministic (and I don't know how Travis would accept these), but change seems to reduce the accumulated error by a factor of magnitude in this simple scenario.