### PR TITLE
Acquire lock per subscription instead of observable-wide lock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,11 @@ matrix:
       env: COMMAND=ci-js COVERAGE=
     # Scala 2.12, JVM
     - jdk: oraclejdk8
-      scala: 2.12.7
+      scala: 2.12.8
       env: COMMAND=ci-jvm-all COVERAGE=coverage
     # Scala 2.12, JavaScript
     - jdk: oraclejdk8
-      scala: 2.12.7
+      scala: 2.12.8
       env: COMMAND=ci-js COVERAGE=
 
 env:

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ addCommandAlias("ci-jvm-all", s";ci-jvm ;unidoc")
 addCommandAlias("release",    ";project monix ;+clean ;+package ;+publishSigned")
 
 val catsVersion = "1.4.0"
-val catsEffectVersion = "1.0.0"
+val catsEffectVersion = "1.1.0"
 val catsEffectLawsVersion = catsEffectVersion
 val jcToolsVersion = "2.1.2"
 val reactiveStreamsVersion = "1.0.2"

--- a/build.sbt
+++ b/build.sbt
@@ -54,8 +54,8 @@ lazy val warnUnusedImport = Seq(
 
 lazy val sharedSettings = warnUnusedImport ++ Seq(
   organization := "io.monix",
-  scalaVersion := "2.12.7",
-  crossScalaVersions := Seq("2.11.12", "2.12.7"),
+  scalaVersion := "2.12.8",
+  crossScalaVersions := Seq("2.11.12", "2.12.8"),
 
   scalacOptions ++= Seq(
     // warnings

--- a/build.sbt
+++ b/build.sbt
@@ -42,14 +42,14 @@ lazy val doNotPublishArtifact = Seq(
 lazy val warnUnusedImport = Seq(
   scalacOptions ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, 10)) =>
-        Seq()
-      case Some((2, n)) if n >= 11 =>
+      case Some((2, 11)) =>
         Seq("-Ywarn-unused-import")
+      case _ =>
+        Seq("-Ywarn-unused:imports")
     }
   },
-  scalacOptions in (Compile, console) ~= {_.filterNot("-Ywarn-unused-import" == _)},
-  scalacOptions in Test ~= {_.filterNot("-Ywarn-unused-import" == _)}
+  scalacOptions in (Compile, console) --= Seq("-Ywarn-unused-import", "-Ywarn-unused:imports"),
+  scalacOptions in Test --= Seq("-Ywarn-unused-import", "-Ywarn-unused:imports")
 )
 
 lazy val sharedSettings = warnUnusedImport ++ Seq(
@@ -66,11 +66,19 @@ lazy val sharedSettings = warnUnusedImport ++ Seq(
     "-language:higherKinds",
     "-language:implicitConversions",
     "-language:experimental.macros",
-    // possibly deprecated options
-    "-Ywarn-inaccessible",
-    // absolutely necessary for Iterant
-    "-Ypartial-unification"
   ),
+
+  scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, v)) if v <= 12 =>
+      Seq(
+        // possibly deprecated options
+        "-Ywarn-inaccessible",
+        // absolutely necessary for Iterant
+        "-Ypartial-unification",
+      )
+    case _ =>
+      Seq.empty
+  }),
 
   // Force building with Java 8
   initialize := {
@@ -102,26 +110,28 @@ lazy val sharedSettings = warnUnusedImport ++ Seq(
   }),
 
   // Linter
+  scalacOptions ++= Seq(
+    // Turns all warnings into errors ;-)
+    "-Xfatal-warnings",
+    // Enables linter options
+    "-Xlint:adapted-args", // warn if an argument list is modified to match the receiver
+    "-Xlint:nullary-unit", // warn when nullary methods return Unit
+    "-Xlint:nullary-override", // warn when non-nullary `def f()' overrides nullary `def f'
+    "-Xlint:infer-any", // warn when a type argument is inferred to be `Any`
+    "-Xlint:missing-interpolator", // a string literal appears to be missing an interpolator id
+    "-Xlint:doc-detached", // a ScalaDoc comment appears to be detached from its element
+    "-Xlint:private-shadow", // a private field (or class parameter) shadows a superclass field
+    "-Xlint:type-parameter-shadow", // a local type parameter shadows a type already in scope
+    "-Xlint:poly-implicit-overload", // parameterized overloaded implicit methods are not visible as view bounds
+    "-Xlint:option-implicit", // Option.apply used implicit view
+    "-Xlint:delayedinit-select", // Selecting member of DelayedInit
+    "-Xlint:package-object-classes", // Class or object defined in package object
+  ),
   scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, majorVersion)) if majorVersion >= 11 =>
+    case Some((2, majorVersion)) if majorVersion <= 12 =>
       Seq(
-        // Turns all warnings into errors ;-)
-        "-Xfatal-warnings",
-        // Enables linter options
-        "-Xlint:adapted-args", // warn if an argument list is modified to match the receiver
-        "-Xlint:nullary-unit", // warn when nullary methods return Unit
         "-Xlint:inaccessible", // warn about inaccessible types in method signatures
-        "-Xlint:nullary-override", // warn when non-nullary `def f()' overrides nullary `def f'
-        "-Xlint:infer-any", // warn when a type argument is inferred to be `Any`
-        "-Xlint:missing-interpolator", // a string literal appears to be missing an interpolator id
-        "-Xlint:doc-detached", // a ScalaDoc comment appears to be detached from its element
-        "-Xlint:private-shadow", // a private field (or class parameter) shadows a superclass field
-        "-Xlint:type-parameter-shadow", // a local type parameter shadows a type already in scope
-        "-Xlint:poly-implicit-overload", // parameterized overloaded implicit methods are not visible as view bounds
-        "-Xlint:option-implicit", // Option.apply used implicit view
-        "-Xlint:delayedinit-select", // Selecting member of DelayedInit
         "-Xlint:by-name-right-associative", // By-name parameter of right associative operator
-        "-Xlint:package-object-classes", // Class or object defined in package object
         "-Xlint:unsound-match" // Pattern match may not be typesafe
       )
     case _ =>
@@ -269,8 +279,8 @@ lazy val unidocSettings = Seq(
 
   scalacOptions in (ScalaUnidoc, unidoc) +=
     "-Xfatal-warnings",
-  scalacOptions in (ScalaUnidoc, unidoc) -=
-    "-Ywarn-unused-import",
+  scalacOptions in (ScalaUnidoc, unidoc) --=
+    Seq("-Ywarn-unused-import", "-Ywarn-unused:imports"),
   scalacOptions in (ScalaUnidoc, unidoc) ++=
     Opts.doc.title(s"Monix"),
   scalacOptions in (ScalaUnidoc, unidoc) ++=

--- a/monix-catnap/shared/src/main/scala/monix/catnap/ConcurrentQueue.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/ConcurrentQueue.scala
@@ -197,6 +197,8 @@ final class ConcurrentQueue[F[_], A] private (
     */
   @UnsafeProtocol
   def tryPoll: F[Option[A]] = tryPollRef
+  private[this] val tryPollRef =
+    F.delay(Option(tryPollUnsafe()))
 
   /** Fetches a value from the queue, or if the queue is empty it awaits
     * asynchronously until a value is made available.
@@ -354,10 +356,6 @@ final class ConcurrentQueue[F[_], A] private (
   private[this] val pollMap: A => A = a => a
   private[this] val offerTest: Boolean => Boolean = x => x
   private[this] val offerMap: Boolean => Unit = _ => ()
-
-  /** Cached implementation for [[tryPoll]]. */
-  private[this] val tryPollRef =
-    F.delay(Option(tryPollUnsafe()))
 
   private def toSeq(buffer: ArrayBuffer[A]): Seq[A] =
     buffer.toArray[Any].toSeq.asInstanceOf[Seq[A]]

--- a/monix-eval/jvm/src/test/scala/monix/eval/TaskLocalJVMSuite.scala
+++ b/monix-eval/jvm/src/test/scala/monix/eval/TaskLocalJVMSuite.scala
@@ -123,4 +123,20 @@ object TaskLocalJVMSuite extends SimpleTestSuite {
     val r = task.runSyncUnsafeOpt(Duration.Inf)
     assertEquals(r, 100)
   }
+
+  test("local state is encapsulated by Task run loop") {
+    import monix.execution.Scheduler.Implicits.global
+    implicit val opts = Task.defaultOptions.enableLocalContextPropagation
+    val local = TaskLocal(0).memoize
+
+    val task = for {
+      l <- local
+      x <- l.read
+      _ <- l.write(x + 1)
+    } yield x
+
+    for (_ <- 1 to 10) task.runSyncUnsafeOpt()
+    val r = task.runSyncUnsafeOpt()
+    assertEquals(r, 0)
+  }
 }

--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -27,6 +27,7 @@ import monix.execution._
 import monix.execution.annotations.{UnsafeBecauseBlocking, UnsafeBecauseImpure}
 import monix.execution.internal.Platform.fusionMaxStackDepth
 import monix.execution.internal.{Newtype1, Platform}
+import monix.execution.misc.Local
 import monix.execution.schedulers.{CanBlock, TracingScheduler, TrampolinedRunnable}
 
 import scala.annotation.unchecked.{uncheckedVariance => uV}
@@ -577,7 +578,9 @@ sealed abstract class Task[+A] extends Serializable {
     */
   @UnsafeBecauseImpure
   def runToFutureOpt(implicit s: Scheduler, opts: Options): CancelableFuture[A] =
-    TaskRunLoop.startFuture(this, s, opts)
+    Local.bindCurrentIf(opts.localContextPropagation) {
+      TaskRunLoop.startFuture(this, s, opts)
+    }
 
   /** Triggers the asynchronous execution, with a provided callback
     * that's going to be called at some point in the future with
@@ -697,7 +700,9 @@ sealed abstract class Task[+A] extends Serializable {
     */
   @UnsafeBecauseImpure
   def runAsyncOpt(cb: Either[Throwable, A] => Unit)(implicit s: Scheduler, opts: Options): Cancelable =
-    UnsafeCancelUtils.taskToCancelable(runAsyncOptF(cb)(s, opts))
+    Local.bindCurrentIf(opts.localContextPropagation) {
+      UnsafeCancelUtils.taskToCancelable(runAsyncOptF(cb)(s, opts))
+    }
 
   /** Triggers the asynchronous execution, returning a `Task[Unit]`
     * (aliased to `CancelToken[Task]` in Cats-Effect) which can
@@ -795,7 +800,9 @@ sealed abstract class Task[+A] extends Serializable {
     */
   @UnsafeBecauseImpure
   def runAsyncOptF(cb: Either[Throwable, A] => Unit)(implicit s: Scheduler, opts: Options): CancelToken[Task] =
-    TaskRunLoop.startLight(this, s, opts, Callback.fromAttempt(cb))
+    Local.bindCurrentIf(opts.localContextPropagation) {
+      TaskRunLoop.startLight(this, s, opts, Callback.fromAttempt(cb))
+    }
 
   /** Triggers the asynchronous execution of the source task
     * in a "fire and forget" fashion.
@@ -914,7 +921,9 @@ sealed abstract class Task[+A] extends Serializable {
   @UnsafeBecauseImpure
   def runAsyncUncancelableOpt(cb: Either[Throwable, A] => Unit)
     (implicit s: Scheduler, opts: Task.Options): Unit =
-    TaskRunLoop.startLight(this, s, opts, Callback.fromAttempt(cb), isCancelable = false)
+    Local.bindCurrentIf(opts.localContextPropagation) {
+      TaskRunLoop.startLight(this, s, opts, Callback.fromAttempt(cb), isCancelable = false)
+    }
 
   /** Executes the source until completion, or until the first async
     * boundary, whichever comes first.
@@ -975,7 +984,9 @@ sealed abstract class Task[+A] extends Serializable {
     */
   @UnsafeBecauseImpure
   final def runSyncStepOpt(implicit s: Scheduler, opts: Options): Either[Task[A], A] =
-    TaskRunLoop.startStep(this, s, opts)
+    Local.bindCurrentIf(opts.localContextPropagation) {
+      TaskRunLoop.startStep(this, s, opts)
+    }
 
   /** Evaluates the source task synchronously and returns the result
     * immediately or blocks the underlying thread until the result is
@@ -1070,7 +1081,9 @@ sealed abstract class Task[+A] extends Serializable {
   final def runSyncUnsafeOpt(timeout: Duration = Duration.Inf)
     (implicit s: Scheduler, opts: Options, permit: CanBlock): A = {
     /*_*/
-    TaskRunSyncUnsafe(this, timeout, s, opts)
+    Local.bindCurrentIf(opts.localContextPropagation) {
+      TaskRunSyncUnsafe(this, timeout, s, opts)
+    }
     /*_*/
   }
 

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDeprecated.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDeprecated.scala
@@ -263,7 +263,7 @@ private[eval] object TaskDeprecated {
     /**
       * DEPRECATED — subsumed by [[Task.start start]].
       *
-      * To be consistent with cats-effect 1.0.0, `start` now
+      * To be consistent with cats-effect 1.1.0, `start` now
       * enforces an asynchronous boundary, being exactly the same
       * as `fork` from 3.0.0-RC1
       */

--- a/monix-execution/js/src/main/scala/monix/execution/internal/Platform.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/internal/Platform.scala
@@ -43,6 +43,7 @@ private[monix] object Platform {
     *
     * It's always a power of 2, because then for
     * applying the modulo operation we can just do:
+    *
     * {{{
     *   val modulus = Platform.recommendedBatchSize - 1
     *   // ...
@@ -50,6 +51,13 @@ private[monix] object Platform {
     * }}}
     */
   final val recommendedBatchSize: Int = 512
+
+  /** Recommended chunk size in unbounded buffer implementations that are chunked,
+    * or in chunked streams.
+    *
+    * Should be a power of 2.
+    */
+  final val recommendedBufferChunkSize: Int = 128
 
   /**
     * Auto cancelable run loops are set to `false` if Monix

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/Platform.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/Platform.scala
@@ -78,7 +78,7 @@ private[monix] object Platform {
     *  - `no`, `false` or `0` for disabling
     *
     * NOTE: this values was `false` by default prior to the Monix 3.0.0
-    * release. This changed along with the release of Cats-Effect 1.0.0
+    * release. This changed along with the release of Cats-Effect 1.1.0
     * which now recommends for this default to be `true` due to the design
     * of its type classes.
     */

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/FromCircularQueue.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/FromCircularQueue.scala
@@ -31,6 +31,9 @@ private[internal] abstract class FromCircularQueue[A](queue: ConcurrentCircularA
   def fenceOffer(): Unit
   def fencePoll(): Unit
 
+  final def isEmpty: Boolean =
+    queue.isEmpty
+
   final def offer(elem: A): Int =
     if (queue.offer(elem)) 0 else 1
 

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/FromJavaQueue.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/FromJavaQueue.scala
@@ -27,6 +27,9 @@ private[internal] class FromJavaQueue[A](queue: util.Queue[A])
   final def fenceOffer(): Unit = ()
   final def fencePoll(): Unit = ()
 
+  final def isEmpty: Boolean =
+    queue.isEmpty
+
   final def offer(elem: A): Int =
     if (queue.offer(elem)) 0 else 1
 

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/FromMessagePassingQueue.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/FromMessagePassingQueue.scala
@@ -31,6 +31,8 @@ private[internal] abstract class FromMessagePassingQueue[A](queue: MessagePassin
   def fenceOffer(): Unit
   def fencePoll(): Unit
 
+  final def isEmpty: Boolean =
+    queue.isEmpty
   final def offer(elem: A): Int =
     if (queue.offer(elem)) 0 else 1
   final def poll(): A =

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/LowLevelConcurrentQueueBuilders.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/LowLevelConcurrentQueueBuilders.scala
@@ -69,7 +69,8 @@ private[internal] trait LowLevelConcurrentQueueBuilders {
     * Builds an bounded `ConcurrentQueue` reference.
     */
   private def unbounded[A](chunkSize: Option[Int], ct: ChannelType, fenced: Boolean): LowLevelConcurrentQueue[A] = {
-    val chunk = chunkSize.getOrElse(Platform.recommendedBatchSize)
+    val chunk = chunkSize.getOrElse(Platform.recommendedBufferChunkSize)
+
     if (UnsafeAccess.IS_OPENJDK_COMPATIBLE) {
       // Support for memory fences in Unsafe is only available in Java 8+
       if (UnsafeAccess.HAS_JAVA8_INTRINSICS || !fenced) {

--- a/monix-execution/shared/src/main/scala/monix/execution/ChannelType.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/ChannelType.scala
@@ -92,8 +92,15 @@ object ChannelType {
     * Enumeration for describing the type of the producer, with two
     * possible values:
     *
-    *  - [[MultiProducer]]
+    *  - [[MultiProducer]] (default)
     *  - [[SingleProducer]]
+    *
+    * This is often used to optimize the underlying buffer used.
+    * The multi-producer option is the safe default and specifies
+    * that multiple producers (threads, actors, etc) can push events
+    * concurrently, whereas the single-producer option specifies that
+    * a single producer can (sequentially) push events and can be used
+    * as an (unsafe) optimization.
     */
   sealed abstract class ProducerSide(val value: String)
     extends Serializable

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/collection/ChunkedArrayQueue.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/collection/ChunkedArrayQueue.scala
@@ -76,6 +76,7 @@ private[monix] final class ChunkedArrayQueue[A] private (
   def dequeue(): A = {
     if ((headArray ne tailArray) || headIndex < tailIndex) {
       val result = headArray(headIndex).asInstanceOf[A]
+      headArray(headIndex) = null
       headIndex += 1
 
       if (headIndex == modulo) {

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/collection/LowLevelConcurrentQueue.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/collection/LowLevelConcurrentQueue.scala
@@ -18,6 +18,7 @@
 package monix.execution.internal.collection
 
 private[monix] trait LowLevelConcurrentQueue[A] extends Serializable {
+  def isEmpty: Boolean
   def offer(a: A): Int
   def poll(): A
   def drainToBuffer(buffer: scala.collection.mutable.Buffer[A], limit: Int): Int

--- a/monix-execution/shared/src/main/scala/monix/execution/misc/Local.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/misc/Local.scala
@@ -76,6 +76,9 @@ object Local {
   def bindClear[R](f: => R): R =
     macro Macros.localLetClear
 
+  private[monix] def bindCurrentIf[R](b: => Boolean)(f: => R): R =
+    macro Macros.localLetCurrentIf
+
   /** Convert a closure `() => R` into another closure of the same
     * type whose [[Local.Context]] is saved when calling closed
     * and restored upon invocation.
@@ -145,6 +148,15 @@ object Local {
        $Local.setContext($Map.empty)
        try { $f } finally { $Local.setContext($saved) }
        """)
+    }
+
+    def localLetCurrentIf(b: Tree)(f: Tree): Tree = {
+      val Local = symbolOf[Local[_]].companion
+      resetTree(
+        q"""
+           if (!$b) { $f }
+           else ${localLet(q"$Local.getContext()")(f)}
+         """)
     }
   }
 }

--- a/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/BuildersImpl.scala
+++ b/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/BuildersImpl.scala
@@ -17,12 +17,14 @@
 
 package monix.reactive.observers.buffers
 
+import monix.execution.ChannelType
+import monix.execution.ChannelType.MultiProducer
 import monix.reactive.OverflowStrategy
 import monix.reactive.OverflowStrategy._
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
 
 private[observers] trait BuildersImpl { self: BufferedSubscriber.type =>
-  def apply[A](subscriber: Subscriber[A], bufferPolicy: OverflowStrategy[A]): Subscriber[A] = {
+  def apply[A](subscriber: Subscriber[A], bufferPolicy: OverflowStrategy[A], producerType: ChannelType.ProducerSide = MultiProducer): Subscriber[A] = {
     bufferPolicy match {
       case Unbounded =>
         SyncBufferedSubscriber.unbounded(subscriber)
@@ -48,7 +50,7 @@ private[observers] trait BuildersImpl { self: BufferedSubscriber.type =>
     }
   }
 
-  def synchronous[A](subscriber: Subscriber[A], bufferPolicy: OverflowStrategy.Synchronous[A]): Subscriber.Sync[A] = {
+  def synchronous[A](subscriber: Subscriber[A], bufferPolicy: OverflowStrategy.Synchronous[A], producerType: ChannelType.ProducerSide = MultiProducer): Subscriber.Sync[A] = {
     bufferPolicy match {
       case Unbounded =>
         SyncBufferedSubscriber.unbounded(subscriber)
@@ -72,6 +74,6 @@ private[observers] trait BuildersImpl { self: BufferedSubscriber.type =>
     }
   }
 
-  def batched[A](underlying: Subscriber[List[A]], bufferSize: Int): Subscriber[A] =
+  def batched[A](underlying: Subscriber[List[A]], bufferSize: Int, producerType: ChannelType.ProducerSide = MultiProducer): Subscriber[A] =
     BatchedBufferedSubscriber(underlying, bufferSize)
 }

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/AbstractBackPressuredBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/AbstractBackPressuredBufferedSubscriber.scala
@@ -17,11 +17,15 @@
 
 package monix.reactive.observers.buffers
 
-import monix.execution.Ack
+import monix.execution.{Ack, ChannelType}
 import monix.execution.Ack.{Continue, Stop}
+import monix.execution.BufferCapacity.Unbounded
+import monix.execution.ChannelType._
 import monix.execution.atomic.Atomic
 import monix.execution.atomic.PaddingStrategy.LeftRight256
-import monix.execution.internal.math
+import monix.execution.internal.collection.LowLevelConcurrentQueue
+import monix.execution.internal.{Platform, math}
+
 import scala.util.control.NonFatal
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
 
@@ -33,7 +37,7 @@ import scala.util.{Failure, Success}
   * [[BatchedBufferedSubscriber]].
   */
 private[observers] abstract class AbstractBackPressuredBufferedSubscriber[A,R]
-  (out: Subscriber[R], _bufferSize: Int)
+  (out: Subscriber[R], _bufferSize: Int, pt: ChannelType.ProducerSide)
   extends CommonBufferMembers with BufferedSubscriber[A] {
 
   require(_bufferSize > 0, "bufferSize must be a strictly positive number")
@@ -42,8 +46,12 @@ private[observers] abstract class AbstractBackPressuredBufferedSubscriber[A,R]
   private[this] val em = out.scheduler.executionModel
   implicit final val scheduler = out.scheduler
 
-  protected final val queue: ConcurrentQueue[A] =
-    ConcurrentQueue.unbounded()
+  protected final val queue: LowLevelConcurrentQueue[A] =
+    LowLevelConcurrentQueue(
+      Unbounded(Some(scala.math.min(Platform.recommendedBufferChunkSize, bufferSize))),
+      ChannelType.assemble(pt, SingleConsumer),
+      fenced = false
+    )
 
   private[this] val itemsToPush =
     Atomic.withPadding(0, LeftRight256)
@@ -64,7 +72,7 @@ private[observers] abstract class AbstractBackPressuredBufferedSubscriber[A,R]
         case Some(v) => v
       }
 
-      backPressured.get match {
+      backPressured.get() match {
         case null =>
           if (toPush < bufferSize) {
             queue.offer(elem)
@@ -180,7 +188,7 @@ private[observers] abstract class AbstractBackPressuredBufferedSubscriber[A,R]
     private final def fastLoop(prevAck: Future[Ack], lastProcessed: Int, startIndex: Int): Unit = {
       def stopStreaming(): Unit = {
         downstreamIsComplete = true
-        val bp = backPressured.get
+        val bp = backPressured.get()
         if (bp != null) bp.success(Stop)
       }
 

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/BackPressuredBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/BackPressuredBufferedSubscriber.scala
@@ -17,6 +17,7 @@
 
 package monix.reactive.observers.buffers
 
+import monix.execution.ChannelType
 import monix.reactive.observers.Subscriber
 
 /** A `BufferedSubscriber` implementation for the
@@ -24,8 +25,8 @@ import monix.reactive.observers.Subscriber
   * buffer overflow strategy.
   */
 private[observers] final class BackPressuredBufferedSubscriber[A] private
-  (out: Subscriber[A], _bufferSize: Int)
-  extends AbstractBackPressuredBufferedSubscriber[A,A](out, _bufferSize) {
+  (out: Subscriber[A], _bufferSize: Int, pt: ChannelType.ProducerSide)
+  extends AbstractBackPressuredBufferedSubscriber[A,A](out, _bufferSize, pt) {
 
   @volatile protected var p50, p51, p52, p53, p54, p55, p56, p57 = 5
   @volatile protected var q50, q51, q52, q53, q54, q55, q56, q57 = 5
@@ -38,6 +39,11 @@ private[observers] final class BackPressuredBufferedSubscriber[A] private
 }
 
 private[observers] object BackPressuredBufferedSubscriber {
-  def apply[A](underlying: Subscriber[A], bufferSize: Int): BackPressuredBufferedSubscriber[A] =
-    new BackPressuredBufferedSubscriber[A](underlying, bufferSize)
+  def apply[A](
+    underlying: Subscriber[A],
+    bufferSize: Int,
+    producerType: ChannelType.ProducerSide): BackPressuredBufferedSubscriber[A] = {
+
+    new BackPressuredBufferedSubscriber[A](underlying, bufferSize, producerType)
+  }
 }

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/BatchedBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/BatchedBufferedSubscriber.scala
@@ -17,8 +17,10 @@
 
 package monix.reactive.observers.buffers
 
+import monix.execution.ChannelType
 import monix.execution.internal.Platform
 import monix.reactive.observers.Subscriber
+
 import scala.collection.mutable.ListBuffer
 
 /** A `BufferedSubscriber` implementation for the
@@ -26,9 +28,12 @@ import scala.collection.mutable.ListBuffer
   * buffer overflowStrategy that sends events in bundles.
   */
 private[monix] final class BatchedBufferedSubscriber[A] private
-  (out: Subscriber[List[A]], _bufferSize: Int)
+  (out: Subscriber[List[A]], _bufferSize: Int, pt: ChannelType.ProducerSide)
   extends AbstractBackPressuredBufferedSubscriber[A, ListBuffer[A]](
-    subscriberBufferToList(out), _bufferSize) { self =>
+    subscriberBufferToList(out),
+    _bufferSize,
+    pt
+  ) { self =>
 
   @volatile protected var p50, p51, p52, p53, p54, p55, p56, p57 = 5
   @volatile protected var q50, q51, q52, q53, q54, q55, q56, q57 = 5
@@ -46,6 +51,9 @@ private[monix] final class BatchedBufferedSubscriber[A] private
 
 private[monix] object BatchedBufferedSubscriber {
   /** Builder for [[BatchedBufferedSubscriber]] */
-  def apply[A](underlying: Subscriber[List[A]], bufferSize: Int): BatchedBufferedSubscriber[A] =
-    new BatchedBufferedSubscriber[A](underlying, bufferSize)
+  def apply[A](
+    underlying: Subscriber[List[A]],
+    bufferSize: Int,
+    producerType: ChannelType.ProducerSide): BatchedBufferedSubscriber[A] =
+    new BatchedBufferedSubscriber[A](underlying, bufferSize, producerType)
 }

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/ConcurrentQueue.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/ConcurrentQueue.scala
@@ -42,10 +42,10 @@ private[buffers] object ConcurrentQueue {
     val maxCapacity = math.max(4, nextPowerOf2(capacity))
     if (UnsafeAccess.IS_OPENJDK_COMPATIBLE) {
       new FromMessagePassingQueue[A](
-        if (maxCapacity <= Platform.recommendedBatchSize)
+        if (maxCapacity <= Platform.recommendedBufferChunkSize)
           new MpscArrayQueue[A](maxCapacity)
         else {
-          val initialCapacity = math.min(Platform.recommendedBatchSize, maxCapacity / 2)
+          val initialCapacity = math.min(Platform.recommendedBufferChunkSize, maxCapacity / 2)
           new MpscChunkedArrayQueue[A](initialCapacity, maxCapacity)
         }
       )
@@ -58,7 +58,7 @@ private[buffers] object ConcurrentQueue {
   /** Builds an unbounded queue. */
   def unbounded[A](): ConcurrentQueue[A] = {
     if (UnsafeAccess.IS_OPENJDK_COMPATIBLE) {
-      val size = Platform.recommendedBatchSize
+      val size = Platform.recommendedBufferChunkSize
       new FromMessagePassingQueue[A](new MpscUnboundedArrayQueue[A](size))
     }
     else {

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/DropNewBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/DropNewBufferedSubscriber.scala
@@ -17,10 +17,12 @@
 
 package monix.reactive.observers.buffers
 
+import monix.eval.Coeval
 import monix.execution.Ack
 import monix.execution.Ack.{Continue, Stop}
 import monix.execution.atomic.PaddingStrategy.{LeftRight128, LeftRight256}
 import monix.execution.atomic.{Atomic, AtomicInt}
+
 import scala.util.control.NonFatal
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
 
@@ -33,7 +35,7 @@ import scala.util.{Failure, Success}
   * overflow strategies.
   */
 private[observers] final class DropNewBufferedSubscriber[A] private
-  (out: Subscriber[A], bufferSize: Int, onOverflow: Long => Option[A] = null)
+  (out: Subscriber[A], bufferSize: Int, onOverflow: Long => Coeval[Option[A]] = null)
   extends CommonBufferMembers with BufferedSubscriber[A] with Subscriber.Sync[A] {
 
   require(bufferSize > 0, "bufferSize must be a strictly positive number")
@@ -170,7 +172,7 @@ private[observers] final class DropNewBufferedSubscriber[A] private
               if (onOverflow == null || droppedCount.get == 0)
                 null.asInstanceOf[A]
               else
-                onOverflow(droppedCount.getAndSet(0)) match {
+                onOverflow(droppedCount.getAndSet(0)).value() match {
                   case Some(value) => value
                   case None => null.asInstanceOf[A]
                 }
@@ -271,7 +273,7 @@ private[observers] object DropNewBufferedSubscriber {
     * [[monix.reactive.OverflowStrategy.DropNewAndSignal DropNewAndSignal]]
     * overflowStrategy.
     */
-  def withSignal[A](underlying: Subscriber[A], bufferSize: Int, onOverflow: Long => Option[A]): DropNewBufferedSubscriber[A] =
+  def withSignal[A](underlying: Subscriber[A], bufferSize: Int, onOverflow: Long => Coeval[Option[A]]): DropNewBufferedSubscriber[A] =
     new DropNewBufferedSubscriber[A](underlying, bufferSize, onOverflow)
 }
 

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/SimpleBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/SimpleBufferedSubscriber.scala
@@ -17,12 +17,16 @@
 
 package monix.reactive.observers.buffers
 
-import monix.execution.Ack
+import monix.execution.{Ack, ChannelType}
 import monix.execution.Ack.{Continue, Stop}
+import monix.execution.BufferCapacity.{Bounded, Unbounded}
+import monix.execution.ChannelType.SingleConsumer
 import monix.execution.atomic.Atomic
 import monix.execution.atomic.PaddingStrategy.LeftRight256
 import monix.execution.exceptions.BufferOverflowException
+import monix.execution.internal.collection.LowLevelConcurrentQueue
 import monix.execution.internal.math.nextPowerOf2
+
 import scala.util.control.NonFatal
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
 
@@ -41,7 +45,7 @@ import scala.util.{Failure, Success}
   * used with care, since it can eat the whole heap memory.
   */
 private[observers] final class SimpleBufferedSubscriber[A] protected
-  (out: Subscriber[A], _qRef: ConcurrentQueue[A], capacity: Int)
+  (out: Subscriber[A], _qRef: LowLevelConcurrentQueue[A], capacity: Int)
   extends AbstractSimpleBufferedSubscriber[A](out, _qRef, capacity) {
 
   @volatile protected var p50, p51, p52, p53, p54, p55, p56, p57 = 5
@@ -49,7 +53,7 @@ private[observers] final class SimpleBufferedSubscriber[A] protected
 }
 
 private[observers] abstract class AbstractSimpleBufferedSubscriber[A] protected
-  (out: Subscriber[A], _qRef: ConcurrentQueue[A], capacity: Int)
+  (out: Subscriber[A], _qRef: LowLevelConcurrentQueue[A], capacity: Int)
   extends CommonBufferMembers with BufferedSubscriber[A] with Subscriber.Sync[A] {
 
   private[this] val queue = _qRef
@@ -65,11 +69,10 @@ private[observers] abstract class AbstractSimpleBufferedSubscriber[A] protected
         Stop
       }
       else try {
-        if (queue.offer(elem)) {
+        if (queue.offer(elem) == 0) {
           pushToConsumer()
           Continue
-        }
-        else {
+        } else {
           onError(BufferOverflowException(
             s"Downstream observer is too slow, buffer overflowed with a " +
             s"specified maximum capacity of $capacity"
@@ -249,14 +252,16 @@ private[observers] abstract class AbstractSimpleBufferedSubscriber[A] protected
 }
 
 private[observers] object SimpleBufferedSubscriber {
-  def unbounded[A](underlying: Subscriber[A]): SimpleBufferedSubscriber[A] = {
-    val queue = ConcurrentQueue.unbounded[A]()
+  def unbounded[A](underlying: Subscriber[A], chunkSizeHint: Option[Int], pt: ChannelType.ProducerSide): SimpleBufferedSubscriber[A] = {
+    val ct = ChannelType.assemble(pt, SingleConsumer)
+    val queue = LowLevelConcurrentQueue[A](Unbounded(chunkSizeHint), ct, fenced = false)
     new SimpleBufferedSubscriber[A](underlying, queue, Int.MaxValue)
   }
 
-  def overflowTriggering[A](underlying: Subscriber[A], bufferSize: Int): SimpleBufferedSubscriber[A] = {
+  def overflowTriggering[A](underlying: Subscriber[A], bufferSize: Int, pt: ChannelType.ProducerSide): SimpleBufferedSubscriber[A] = {
     val maxCapacity = math.max(4, nextPowerOf2(bufferSize))
-    val queue = ConcurrentQueue.limited[A](bufferSize)
+    val ct = ChannelType.assemble(pt, SingleConsumer)
+    val queue = LowLevelConcurrentQueue[A](Bounded(bufferSize), ct, fenced = false)
     new SimpleBufferedSubscriber[A](underlying, queue, maxCapacity)
   }
 }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -4855,10 +4855,13 @@ object Observable extends ObservableDeprecatedBuilders {
     new builders.Interleave2Observable(oa1, oa2)
 
   /** Creates an Observable that emits auto-incremented natural numbers
-    * (longs) spaced by a given time interval. Starts from 0 with no
-    * delay, after which it emits incremented numbers spaced by the
-    * `period` of time. The given `period` of time acts as a fixed
+    * (longs) spaced by a given time interval. Starts from 0 with `initialDelay`, 
+    * after which it emits incremented numbers spaced by the
+    * `delay` of time. The given `delay` of time acts as a fixed
     * delay between successive events.
+    *
+    * This version of the `intervalWithFixedDelay` allows specifying an
+    * `initialDelay` before events start being emitted.
     *
     * @param initialDelay is the delay to wait before emitting the first event
     * @param delay the time to wait between 2 successive events
@@ -4869,7 +4872,7 @@ object Observable extends ObservableDeprecatedBuilders {
   /** Creates an Observable that emits auto-incremented natural numbers
     * (longs) spaced by a given time interval. Starts from 0 with no
     * delay, after which it emits incremented numbers spaced by the
-    * `period` of time. The given `period` of time acts as a fixed
+    * `delay` of time. The given `delay` of time acts as a fixed
     * delay between successive events.
     *
     * @param delay the delay between 2 successive events
@@ -4880,7 +4883,7 @@ object Observable extends ObservableDeprecatedBuilders {
   /** Creates an Observable that emits auto-incremented natural numbers
     * (longs) spaced by a given time interval. Starts from 0 with no
     * delay, after which it emits incremented numbers spaced by the
-    * `period` of time. The given `period` of time acts as a fixed
+    * `delay` of time. The given `delay` of time acts as a fixed
     * delay between successive events.
     *
     * @param delay the delay between 2 successive events

--- a/monix-reactive/shared/src/main/scala/monix/reactive/OverflowStrategy.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/OverflowStrategy.scala
@@ -17,6 +17,7 @@
 
 package monix.reactive
 
+import monix.eval.Coeval
 import monix.execution.internal.Platform
 
 /** Represents the buffering overflowStrategy chosen for actions that
@@ -44,7 +45,7 @@ object OverflowStrategy {
     * Using this overflowStrategy implies that with a fast data source, the system's
     * memory can be exhausted and the process might blow up on lack of memory.
     */
-  case object Unbounded extends Synchronous[Nothing]
+  final case object Unbounded extends Synchronous[Nothing]
 
   /** A [[OverflowStrategy]] specifying that on reaching the maximum size,
     * the pipeline should cancel the subscription and send an `onError`
@@ -70,7 +71,7 @@ object OverflowStrategy {
   final case class BackPressure(bufferSize: Int)
     extends OverflowStrategy[Nothing] {
 
-    require(bufferSize > 1, "bufferSize should be strictly greater than 1")
+    require(bufferSize > 1, "bufferSize must be strictly greater than 1")
   }
 
   /** A [[OverflowStrategy]] specifying that on reaching the maximum size,
@@ -83,7 +84,7 @@ object OverflowStrategy {
   final case class DropNew(bufferSize: Int)
     extends Evicted[Nothing] {
 
-    require(bufferSize > 1, "bufferSize should be strictly greater than 1")
+    require(bufferSize > 1, "bufferSize must be strictly greater than 1")
   }
 
   /** A [[OverflowStrategy]] specifying that on reaching the maximum size,
@@ -103,10 +104,10 @@ object OverflowStrategy {
     *        a new message that will be sent to downstream. If it returns
     *        `None`, then no message gets sent to downstream.
     */
-  final case class DropNewAndSignal[A](bufferSize: Int, onOverflow: Long => Option[A])
+  final case class DropNewAndSignal[A](bufferSize: Int, onOverflow: Long => Coeval[Option[A]])
     extends Evicted[A] {
 
-    require(bufferSize > 1, "bufferSize should be strictly greater than 1")
+    require(bufferSize > 1, "bufferSize must be strictly greater than 1")
   }
 
   /** A [[OverflowStrategy]] specifying that on reaching the maximum size,
@@ -119,7 +120,7 @@ object OverflowStrategy {
   final case class DropOld(bufferSize: Int)
     extends Evicted[Nothing] {
 
-    require(bufferSize > 1, "bufferSize should be strictly greater than 1")
+    require(bufferSize > 1, "bufferSize must be strictly greater than 1")
   }
 
   /** A [[OverflowStrategy]] specifying that on reaching the maximum size,
@@ -139,10 +140,10 @@ object OverflowStrategy {
     *        a new message that will be sent to downstream. If it returns
     *        `None`, then no message gets sent to downstream.
     */
-  final case class DropOldAndSignal[A](bufferSize: Int, onOverflow: Long => Option[A])
+  final case class DropOldAndSignal[A](bufferSize: Int, onOverflow: Long => Coeval[Option[A]])
     extends Evicted[A] {
 
-    require(bufferSize > 1, "bufferSize should be strictly greater than 1")
+    require(bufferSize > 1, "bufferSize must be strictly greater than 1")
   }
 
   /** A [[OverflowStrategy]] specifying that on reaching the maximum size,
@@ -155,7 +156,7 @@ object OverflowStrategy {
   final case class ClearBuffer(bufferSize: Int)
     extends Evicted[Nothing] {
 
-    require(bufferSize > 1, "bufferSize should be strictly greater than 1")
+    require(bufferSize > 1, "bufferSize must be strictly greater than 1")
   }
 
   /** A [[OverflowStrategy]] specifying that on reaching the maximum size,
@@ -174,10 +175,10 @@ object OverflowStrategy {
     *        a number of messages that were dropped, a function that builds
     *        a new message that will be sent to downstream.
     */
-  final case class ClearBufferAndSignal[A](bufferSize: Int, onOverflow: Long => Option[A])
+  final case class ClearBufferAndSignal[A](bufferSize: Int, onOverflow: Long => Coeval[Option[A]])
     extends Evicted[A] {
 
-    require(bufferSize > 1, "bufferSize should be strictly greater than 1")
+    require(bufferSize > 1, "bufferSize must be strictly greater than 1")
   }
 
   /** A category of [[OverflowStrategy]] for buffers that can be used

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Pipe.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Pipe.scala
@@ -17,7 +17,9 @@
 
 package monix.reactive
 
-import monix.execution.Scheduler
+import monix.execution.ChannelType.MultiProducer
+import monix.execution.{ChannelType, Scheduler}
+
 import scala.util.control.NonFatal
 import monix.reactive.Observable.Operator
 import monix.reactive.OverflowStrategy.{Synchronous, Unbounded}
@@ -64,9 +66,27 @@ abstract class Pipe[I, +O] extends Serializable {
     * @param strategy is the [[OverflowStrategy]] used for the underlying
     *                 multi-producer/single-consumer buffer
     */
-  def concurrent(strategy: Synchronous[I])(implicit s: Scheduler): (Observer.Sync[I], Observable[O]) = {
+  def concurrent(strategy: Synchronous[I])(implicit s: Scheduler): (Observer.Sync[I], Observable[O]) =
+    concurrent(strategy, MultiProducer)
+
+
+  /** Returns an input/output pair with an input that can be
+    * used synchronously and concurrently (without back-pressure or
+    * multi-threading issues) to push signals to multiple subscribers.
+    *
+    * @param strategy is the [[OverflowStrategy]] used for the underlying
+    *                 multi-producer/single-consumer buffer
+    *
+    * @param producerType specifies the
+    *        [[monix.execution.ChannelType.ProducerSide ChannelType.ProducerSide]],
+    *        which configures the type of the producer, for performance optimization;
+    *        can be multi producer (the default) or single producer
+    */
+  def concurrent(strategy: Synchronous[I], producerType: ChannelType.ProducerSide)
+    (implicit s: Scheduler): (Observer.Sync[I], Observable[O]) = {
+
     val (in,out) = multicast(s)
-    val buffer = BufferedSubscriber.synchronous[I](Subscriber(in, s), strategy)
+    val buffer = BufferedSubscriber.synchronous[I](Subscriber(in, s), strategy, producerType)
     (buffer, out)
   }
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest2Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest2Observable.scala
@@ -31,26 +31,27 @@ private[reactive] final
 class CombineLatest2Observable[A1,A2,+R]
   (obsA1: Observable[A1], obsA2: Observable[A2])
   (f: (A1,A2) => R)
-  extends Observable[R] { self =>
+  extends Observable[R] {
 
   def unsafeSubscribeFn(out: Subscriber[R]): Cancelable = {
     import out.scheduler
 
+    val lock = new AnyRef
     var isDone = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var lastAck = Continue : Future[Ack]
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var elemA1: A1 = null.asInstanceOf[A1]
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var hasElemA1 = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var elemA2: A2 = null.asInstanceOf[A2]
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var hasElemA2 = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var completedCount = 0
 
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     def rawOnNext(a1: A1, a2: A2): Future[Ack] =
       if (isDone) Stop else {
         var streamError = true
@@ -66,7 +67,7 @@ class CombineLatest2Observable[A1,A2,+R]
         }
       }
 
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     def signalOnNext(a1: A1, a2: A2): Future[Ack] = {
       lastAck = lastAck match {
         case Continue => rawOnNext(a1,a2)
@@ -74,7 +75,7 @@ class CombineLatest2Observable[A1,A2,+R]
         case async =>
           async.flatMap {
             // async execution, we have to re-sync
-            case Continue => self.synchronized(rawOnNext(a1,a2))
+            case Continue => lock.synchronized(rawOnNext(a1,a2))
             case Stop => Stop
           }
       }
@@ -82,7 +83,7 @@ class CombineLatest2Observable[A1,A2,+R]
       lastAck
     }
 
-    def signalOnError(ex: Throwable): Unit = self.synchronized {
+    def signalOnError(ex: Throwable): Unit = lock.synchronized {
       if (!isDone) {
         isDone = true
         out.onError(ex)
@@ -90,7 +91,7 @@ class CombineLatest2Observable[A1,A2,+R]
       }
     }
 
-    def signalOnComplete(): Unit = self.synchronized  {
+    def signalOnComplete(): Unit = lock.synchronized  {
       completedCount += 1
 
       if (completedCount == 2 && !isDone) {
@@ -103,7 +104,7 @@ class CombineLatest2Observable[A1,A2,+R]
           case async =>
             async.onComplete {
               case Success(Continue) =>
-                self.synchronized {
+                lock.synchronized {
                   if (!isDone) {
                     isDone = true
                     out.onComplete()
@@ -123,7 +124,7 @@ class CombineLatest2Observable[A1,A2,+R]
     composite += obsA1.unsafeSubscribeFn(new Subscriber[A1] {
       implicit val scheduler = out.scheduler
 
-      def onNext(elem: A1): Future[Ack] = self.synchronized {
+      def onNext(elem: A1): Future[Ack] = lock.synchronized {
         if (isDone) Stop else {
           elemA1 = elem
           if (!hasElemA1) hasElemA1 = true
@@ -144,7 +145,7 @@ class CombineLatest2Observable[A1,A2,+R]
     composite += obsA2.unsafeSubscribeFn(new Subscriber[A2] {
       implicit val scheduler = out.scheduler
 
-      def onNext(elem: A2): Future[Ack] = self.synchronized {
+      def onNext(elem: A2): Future[Ack] = lock.synchronized {
         if (isDone) Stop else {
           elemA2 = elem
           if (!hasElemA2) hasElemA2 = true

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest3Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest3Observable.scala
@@ -32,30 +32,31 @@ private[reactive] final
 class CombineLatest3Observable[A1,A2,A3,+R]
   (obsA1: Observable[A1], obsA2: Observable[A2], obsA3: Observable[A3])
   (f: (A1,A2,A3) => R)
-  extends Observable[R] { self =>
+  extends Observable[R] {
 
   def unsafeSubscribeFn(out: Subscriber[R]): Cancelable = {
     import out.scheduler
 
+    val lock = new AnyRef
     var isDone = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var lastAck = Continue : Future[Ack]
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var elemA1: A1 = null.asInstanceOf[A1]
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var hasElemA1 = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var elemA2: A2 = null.asInstanceOf[A2]
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var hasElemA2 = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var elemA3: A3 = null.asInstanceOf[A3]
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var hasElemA3 = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var completedCount = 0
 
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     def rawOnNext(a1: A1, a2: A2, a3: A3): Future[Ack] =
       if (isDone) Stop else {
         var streamError = true
@@ -71,7 +72,7 @@ class CombineLatest3Observable[A1,A2,A3,+R]
         }
       }
 
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     def signalOnNext(a1: A1, a2: A2, a3: A3): Future[Ack] = {
       lastAck = lastAck match {
         case Continue => rawOnNext(a1,a2,a3)
@@ -79,7 +80,7 @@ class CombineLatest3Observable[A1,A2,A3,+R]
         case async =>
           async.flatMap {
             // async execution, we have to re-sync
-            case Continue => self.synchronized(rawOnNext(a1,a2,a3))
+            case Continue => lock.synchronized(rawOnNext(a1,a2,a3))
             case Stop => Stop
           }
       }
@@ -87,7 +88,7 @@ class CombineLatest3Observable[A1,A2,A3,+R]
       lastAck
     }
 
-    def signalOnError(ex: Throwable): Unit = self.synchronized {
+    def signalOnError(ex: Throwable): Unit = lock.synchronized {
       if (!isDone) {
         isDone = true
         out.onError(ex)
@@ -95,7 +96,7 @@ class CombineLatest3Observable[A1,A2,A3,+R]
       }
     }
 
-    def signalOnComplete(): Unit = self.synchronized  {
+    def signalOnComplete(): Unit = lock.synchronized  {
       completedCount += 1
 
       if (completedCount == 3 && !isDone) {
@@ -108,7 +109,7 @@ class CombineLatest3Observable[A1,A2,A3,+R]
           case async =>
             async.onComplete {
               case Success(Continue) =>
-                self.synchronized {
+                lock.synchronized {
                   if (!isDone) {
                     isDone = true
                     out.onComplete()
@@ -128,7 +129,7 @@ class CombineLatest3Observable[A1,A2,A3,+R]
     composite += obsA1.unsafeSubscribeFn(new Subscriber[A1] {
       implicit val scheduler = out.scheduler
 
-      def onNext(elem: A1): Future[Ack] = self.synchronized {
+      def onNext(elem: A1): Future[Ack] = lock.synchronized {
         if (isDone) Stop else {
           elemA1 = elem
           if (!hasElemA1) hasElemA1 = true
@@ -149,7 +150,7 @@ class CombineLatest3Observable[A1,A2,A3,+R]
     composite += obsA2.unsafeSubscribeFn(new Subscriber[A2] {
       implicit val scheduler = out.scheduler
 
-      def onNext(elem: A2): Future[Ack] = self.synchronized {
+      def onNext(elem: A2): Future[Ack] = lock.synchronized {
         if (isDone) Stop else {
           elemA2 = elem
           if (!hasElemA2) hasElemA2 = true
@@ -170,7 +171,7 @@ class CombineLatest3Observable[A1,A2,A3,+R]
     composite += obsA3.unsafeSubscribeFn(new Subscriber[A3] {
       implicit val scheduler = out.scheduler
 
-      def onNext(elem: A3): Future[Ack] = self.synchronized {
+      def onNext(elem: A3): Future[Ack] = lock.synchronized {
         if (isDone) Stop else {
           elemA3 = elem
           if (!hasElemA3) hasElemA3 = true

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest4Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest4Observable.scala
@@ -31,34 +31,35 @@ private[reactive] final
 class CombineLatest4Observable[A1,A2,A3,A4,+R]
   (obsA1: Observable[A1], obsA2: Observable[A2], obsA3: Observable[A3], obsA4: Observable[A4])
   (f: (A1,A2,A3,A4) => R)
-  extends Observable[R] { self =>
+  extends Observable[R] { lock =>
 
   def unsafeSubscribeFn(out: Subscriber[R]): Cancelable = {
     import out.scheduler
 
+    val lock = new AnyRef
     var isDone = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var lastAck = Continue : Future[Ack]
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var elemA1: A1 = null.asInstanceOf[A1]
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var hasElemA1 = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var elemA2: A2 = null.asInstanceOf[A2]
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var hasElemA2 = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var elemA3: A3 = null.asInstanceOf[A3]
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var hasElemA3 = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var elemA4: A4 = null.asInstanceOf[A4]
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var hasElemA4 = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var completedCount = 0
 
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     def rawOnNext(a1: A1, a2: A2, a3: A3, a4: A4): Future[Ack] =
       if (isDone) Stop else {
         var streamError = true
@@ -74,7 +75,7 @@ class CombineLatest4Observable[A1,A2,A3,A4,+R]
         }
       }
 
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     def signalOnNext(a1: A1, a2: A2, a3: A3, a4: A4): Future[Ack] = {
       lastAck = lastAck match {
         case Continue => rawOnNext(a1,a2,a3,a4)
@@ -82,7 +83,7 @@ class CombineLatest4Observable[A1,A2,A3,A4,+R]
         case async =>
           async.flatMap {
             // async execution, we have to re-sync
-            case Continue => self.synchronized(rawOnNext(a1,a2,a3,a4))
+            case Continue => lock.synchronized(rawOnNext(a1,a2,a3,a4))
             case Stop => Stop
           }
       }
@@ -90,7 +91,7 @@ class CombineLatest4Observable[A1,A2,A3,A4,+R]
       lastAck
     }
 
-    def signalOnError(ex: Throwable): Unit = self.synchronized {
+    def signalOnError(ex: Throwable): Unit = lock.synchronized {
       if (!isDone) {
         isDone = true
         out.onError(ex)
@@ -98,7 +99,7 @@ class CombineLatest4Observable[A1,A2,A3,A4,+R]
       }
     }
 
-    def signalOnComplete(): Unit = self.synchronized  {
+    def signalOnComplete(): Unit = lock.synchronized  {
       completedCount += 1
 
       if (completedCount == 4 && !isDone) {
@@ -111,7 +112,7 @@ class CombineLatest4Observable[A1,A2,A3,A4,+R]
           case async =>
             async.onComplete {
               case Success(Continue) =>
-                self.synchronized {
+                lock.synchronized {
                   if (!isDone) {
                     isDone = true
                     out.onComplete()
@@ -131,7 +132,7 @@ class CombineLatest4Observable[A1,A2,A3,A4,+R]
     composite += obsA1.unsafeSubscribeFn(new Subscriber[A1] {
       implicit val scheduler = out.scheduler
 
-      def onNext(elem: A1): Future[Ack] = self.synchronized {
+      def onNext(elem: A1): Future[Ack] = lock.synchronized {
         if (isDone) Stop else {
           elemA1 = elem
           if (!hasElemA1) hasElemA1 = true
@@ -152,7 +153,7 @@ class CombineLatest4Observable[A1,A2,A3,A4,+R]
     composite += obsA2.unsafeSubscribeFn(new Subscriber[A2] {
       implicit val scheduler = out.scheduler
 
-      def onNext(elem: A2): Future[Ack] = self.synchronized {
+      def onNext(elem: A2): Future[Ack] = lock.synchronized {
         if (isDone) Stop else {
           elemA2 = elem
           if (!hasElemA2) hasElemA2 = true
@@ -173,7 +174,7 @@ class CombineLatest4Observable[A1,A2,A3,A4,+R]
     composite += obsA3.unsafeSubscribeFn(new Subscriber[A3] {
       implicit val scheduler = out.scheduler
 
-      def onNext(elem: A3): Future[Ack] = self.synchronized {
+      def onNext(elem: A3): Future[Ack] = lock.synchronized {
         if (isDone) Stop else {
           elemA3 = elem
           if (!hasElemA3) hasElemA3 = true
@@ -194,7 +195,7 @@ class CombineLatest4Observable[A1,A2,A3,A4,+R]
     composite += obsA4.unsafeSubscribeFn(new Subscriber[A4] {
       implicit val scheduler = out.scheduler
 
-      def onNext(elem: A4): Future[Ack] = self.synchronized {
+      def onNext(elem: A4): Future[Ack] = lock.synchronized {
         if (isDone) Stop else {
           elemA4 = elem
           if (!hasElemA4) hasElemA4 = true

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest6Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest6Observable.scala
@@ -32,42 +32,43 @@ class CombineLatest6Observable[A1,A2,A3,A4,A5,A6,+R]
   (obsA1: Observable[A1], obsA2: Observable[A2], obsA3: Observable[A3],
    obsA4: Observable[A4], obsA5: Observable[A5], obsA6: Observable[A6])
   (f: (A1,A2,A3,A4,A5,A6) => R)
-  extends Observable[R] { self =>
+  extends Observable[R] {
 
   def unsafeSubscribeFn(out: Subscriber[R]): Cancelable = {
     import out.scheduler
 
+    val lock = new AnyRef
     var isDone = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var lastAck = Continue : Future[Ack]
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var elemA1: A1 = null.asInstanceOf[A1]
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var hasElemA1 = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var elemA2: A2 = null.asInstanceOf[A2]
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var hasElemA2 = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var elemA3: A3 = null.asInstanceOf[A3]
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var hasElemA3 = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var elemA4: A4 = null.asInstanceOf[A4]
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var hasElemA4 = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var elemA5: A5 = null.asInstanceOf[A5]
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var hasElemA5 = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var elemA6: A6 = null.asInstanceOf[A6]
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var hasElemA6 = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var completedCount = 0
 
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     def rawOnNext(a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6): Future[Ack] =
       if (isDone) Stop else {
         var streamError = true
@@ -83,7 +84,7 @@ class CombineLatest6Observable[A1,A2,A3,A4,A5,A6,+R]
         }
       }
 
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     def signalOnNext(a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6): Future[Ack] = {
       lastAck = lastAck match {
         case Continue => rawOnNext(a1,a2,a3,a4,a5,a6)
@@ -91,7 +92,7 @@ class CombineLatest6Observable[A1,A2,A3,A4,A5,A6,+R]
         case async =>
           async.flatMap {
             // async execution, we have to re-sync
-            case Continue => self.synchronized(rawOnNext(a1,a2,a3,a4,a5,a6))
+            case Continue => lock.synchronized(rawOnNext(a1,a2,a3,a4,a5,a6))
             case Stop => Stop
           }
       }
@@ -99,7 +100,7 @@ class CombineLatest6Observable[A1,A2,A3,A4,A5,A6,+R]
       lastAck
     }
 
-    def signalOnError(ex: Throwable): Unit = self.synchronized {
+    def signalOnError(ex: Throwable): Unit = lock.synchronized {
       if (!isDone) {
         isDone = true
         out.onError(ex)
@@ -107,7 +108,7 @@ class CombineLatest6Observable[A1,A2,A3,A4,A5,A6,+R]
       }
     }
 
-    def signalOnComplete(): Unit = self.synchronized  {
+    def signalOnComplete(): Unit = lock.synchronized  {
       completedCount += 1
 
       if (completedCount == 6 && !isDone) {
@@ -120,7 +121,7 @@ class CombineLatest6Observable[A1,A2,A3,A4,A5,A6,+R]
           case async =>
             async.onComplete {
               case Success(Continue) =>
-                self.synchronized {
+                lock.synchronized {
                   if (!isDone) {
                     isDone = true
                     out.onComplete()
@@ -140,7 +141,7 @@ class CombineLatest6Observable[A1,A2,A3,A4,A5,A6,+R]
     composite += obsA1.unsafeSubscribeFn(new Subscriber[A1] {
       implicit val scheduler = out.scheduler
 
-      def onNext(elem: A1): Future[Ack] = self.synchronized {
+      def onNext(elem: A1): Future[Ack] = lock.synchronized {
         if (isDone) Stop else {
           elemA1 = elem
           if (!hasElemA1) hasElemA1 = true
@@ -161,7 +162,7 @@ class CombineLatest6Observable[A1,A2,A3,A4,A5,A6,+R]
     composite += obsA2.unsafeSubscribeFn(new Subscriber[A2] {
       implicit val scheduler = out.scheduler
 
-      def onNext(elem: A2): Future[Ack] = self.synchronized {
+      def onNext(elem: A2): Future[Ack] = lock.synchronized {
         if (isDone) Stop else {
           elemA2 = elem
           if (!hasElemA2) hasElemA2 = true
@@ -182,7 +183,7 @@ class CombineLatest6Observable[A1,A2,A3,A4,A5,A6,+R]
     composite += obsA3.unsafeSubscribeFn(new Subscriber[A3] {
       implicit val scheduler = out.scheduler
 
-      def onNext(elem: A3): Future[Ack] = self.synchronized {
+      def onNext(elem: A3): Future[Ack] = lock.synchronized {
         if (isDone) Stop else {
           elemA3 = elem
           if (!hasElemA3) hasElemA3 = true
@@ -203,7 +204,7 @@ class CombineLatest6Observable[A1,A2,A3,A4,A5,A6,+R]
     composite += obsA4.unsafeSubscribeFn(new Subscriber[A4] {
       implicit val scheduler = out.scheduler
 
-      def onNext(elem: A4): Future[Ack] = self.synchronized {
+      def onNext(elem: A4): Future[Ack] = lock.synchronized {
         if (isDone) Stop else {
           elemA4 = elem
           if (!hasElemA4) hasElemA4 = true
@@ -224,7 +225,7 @@ class CombineLatest6Observable[A1,A2,A3,A4,A5,A6,+R]
     composite += obsA5.unsafeSubscribeFn(new Subscriber[A5] {
       implicit val scheduler = out.scheduler
 
-      def onNext(elem: A5): Future[Ack] = self.synchronized {
+      def onNext(elem: A5): Future[Ack] = lock.synchronized {
         if (isDone) Stop else {
           elemA5 = elem
           if (!hasElemA5) hasElemA5 = true
@@ -245,7 +246,7 @@ class CombineLatest6Observable[A1,A2,A3,A4,A5,A6,+R]
     composite += obsA6.unsafeSubscribeFn(new Subscriber[A6] {
       implicit val scheduler = out.scheduler
 
-      def onNext(elem: A6): Future[Ack] = self.synchronized {
+      def onNext(elem: A6): Future[Ack] = lock.synchronized {
         if (isDone) Stop else {
           elemA6 = elem
           if (!hasElemA6) hasElemA6 = true

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CreateObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CreateObservable.scala
@@ -17,7 +17,7 @@
 
 package monix.reactive.internal.builders
 
-import monix.execution.Cancelable
+import monix.execution.{Cancelable, ChannelType}
 import scala.util.control.NonFatal
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
 import monix.reactive.{Observable, OverflowStrategy}
@@ -25,11 +25,12 @@ import monix.reactive.{Observable, OverflowStrategy}
 /** Implementation for [[monix.reactive.Observable.create]]. */
 private[reactive] final class CreateObservable[+A](
   overflowStrategy: OverflowStrategy.Synchronous[A],
+  producerType: ChannelType.ProducerSide,
   f: Subscriber.Sync[A] => Cancelable)
   extends Observable[A] {
 
   def unsafeSubscribeFn(subscriber: Subscriber[A]): Cancelable = {
-    val out = BufferedSubscriber.synchronous(subscriber, overflowStrategy)
+    val out = BufferedSubscriber.synchronous(subscriber, overflowStrategy, producerType)
     try f(out) catch {
       case ex if NonFatal(ex) =>
         subscriber.scheduler.reportFailure(ex)

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Interleave2Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Interleave2Observable.scala
@@ -25,29 +25,30 @@ import monix.reactive.observers.Subscriber
 import scala.concurrent.{Future, Promise}
 
 private[reactive] final class Interleave2Observable[+A]
-  (obsA1: Observable[A], obsA2: Observable[A]) extends Observable[A] { self =>
+  (obsA1: Observable[A], obsA2: Observable[A]) extends Observable[A] {
 
   def unsafeSubscribeFn(out: Subscriber[A]): Cancelable = {
     import out.scheduler
 
-    // MUST BE synchronized by `self`
+    val lock = new AnyRef
+    // MUST BE synchronized by `lock`
     var isDone = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var downstreamAck = Continue : Future[Ack]
-    // MUST BE synchronized by `self`.
+    // MUST BE synchronized by `lock`.
     // This essentially serves as a lock for obsA1 when `select` is not assigned to it
     // pauseA1 is initialized to be `Continue`, so that obsA1 is deterministically emitted before obsA2
     var pauseA1 = Promise.successful(Continue : Ack)
     // This essentially serves as a lock for obsA2 when `select` is not assigned to it
     var pauseA2 = Promise[Ack]()
 
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var completedCount = 0
     var lastAck1 = Continue : Future[Ack]
     var lastAck2 = Continue : Future[Ack]
 
     def signalOnError(ex: Throwable): Unit =
-      self.synchronized {
+      lock.synchronized {
         if (!isDone) {
           isDone = true
           out.onError(ex)
@@ -57,7 +58,7 @@ private[reactive] final class Interleave2Observable[+A]
         }
       }
 
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     def signalOnComplete(ack: Future[Ack]): Unit = {
       val shouldComplete = !isDone && {
         completedCount += 1
@@ -66,7 +67,7 @@ private[reactive] final class Interleave2Observable[+A]
 
       if (shouldComplete)
         ack.syncOnContinue(
-          self.synchronized(if (!isDone) {
+          lock.synchronized(if (!isDone) {
             isDone = true
             out.onComplete()
           }))
@@ -77,8 +78,8 @@ private[reactive] final class Interleave2Observable[+A]
     composite += obsA1.unsafeSubscribeFn(new Subscriber[A] {
       implicit val scheduler = out.scheduler
 
-      def onNext(elem: A): Future[Ack] = self.synchronized {
-        @inline def sendSignal(a: A): Future[Ack] = self.synchronized {
+      def onNext(elem: A): Future[Ack] = lock.synchronized {
+        @inline def sendSignal(a: A): Future[Ack] = lock.synchronized {
           if (isDone) Stop else {
             downstreamAck = out.onNext(a)
             pauseA1 = Promise[Ack]()
@@ -99,7 +100,7 @@ private[reactive] final class Interleave2Observable[+A]
       def onError(ex: Throwable): Unit =
         signalOnError(ex)
 
-      def onComplete(): Unit = self.synchronized {
+      def onComplete(): Unit = lock.synchronized {
         lastAck1.syncOnContinue {
           signalOnComplete(lastAck1)
           pauseA2.trySuccess(Continue)
@@ -111,8 +112,8 @@ private[reactive] final class Interleave2Observable[+A]
     composite += obsA2.unsafeSubscribeFn(new Subscriber[A] {
       implicit val scheduler = out.scheduler
 
-      def onNext(elem: A): Future[Ack] = self.synchronized {
-        @inline def sendSignal(a: A): Future[Ack] = self.synchronized {
+      def onNext(elem: A): Future[Ack] = lock.synchronized {
+        @inline def sendSignal(a: A): Future[Ack] = lock.synchronized {
           if (isDone) Stop else {
             downstreamAck = out.onNext(a)
             pauseA2 = Promise[Ack]()
@@ -133,7 +134,7 @@ private[reactive] final class Interleave2Observable[+A]
       def onError(ex: Throwable): Unit =
         signalOnError(ex)
 
-      def onComplete(): Unit = self.synchronized {
+      def onComplete(): Unit = lock.synchronized {
         lastAck2.syncOnContinue {
           signalOnComplete(lastAck2)
           pauseA1.trySuccess(Continue)

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip2Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip2Observable.scala
@@ -31,30 +31,31 @@ private[reactive] final
 class Zip2Observable[A1,A2,+R]
   (obsA1: Observable[A1], obsA2: Observable[A2])
   (f: (A1,A2) => R)
-  extends Observable[R] { self =>
+  extends Observable[R] {
 
 
   def unsafeSubscribeFn(out: Subscriber[R]): Cancelable = {
     import out.scheduler
 
-    // MUST BE synchronized by `self`
+    val lock = new AnyRef
+    // MUST BE synchronized by `lock`
     var isDone = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var lastAck = Continue : Future[Ack]
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var elemA1: A1 = null.asInstanceOf[A1]
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var hasElemA1 = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var elemA2: A2 = null.asInstanceOf[A2]
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var hasElemA2 = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var continueP = Promise[Ack]()
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var completeWithNext = false
 
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     def rawOnNext(a1: A1, a2: A2): Future[Ack] =
       if (isDone) Stop else {
         var streamError = true
@@ -77,7 +78,7 @@ class Zip2Observable[A1,A2,+R]
         }
       }
 
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     def signalOnNext(a1: A1, a2: A2): Future[Ack] = {
       lastAck = lastAck match {
         case Continue => rawOnNext(a1,a2)
@@ -85,7 +86,7 @@ class Zip2Observable[A1,A2,+R]
         case async =>
           async.flatMap {
             // async execution, we have to re-sync
-            case Continue => self.synchronized(rawOnNext(a1,a2))
+            case Continue => lock.synchronized(rawOnNext(a1,a2))
             case Stop => Stop
           }
       }
@@ -95,7 +96,7 @@ class Zip2Observable[A1,A2,+R]
       lastAck
     }
 
-    def signalOnError(ex: Throwable): Unit = self.synchronized {
+    def signalOnError(ex: Throwable): Unit = lock.synchronized {
       if (!isDone) {
         isDone = true
         out.onError(ex)
@@ -110,7 +111,7 @@ class Zip2Observable[A1,A2,+R]
           out.onComplete()
         }
 
-      self.synchronized {
+      lock.synchronized {
         if (!hasElem) {
           lastAck match {
             case Continue => rawOnComplete()
@@ -118,7 +119,7 @@ class Zip2Observable[A1,A2,+R]
             case async =>
               async.onComplete {
                 case Success(Continue) =>
-                  self.synchronized(rawOnComplete())
+                  lock.synchronized(rawOnComplete())
                 case _ =>
                   () // do nothing
               }
@@ -137,7 +138,7 @@ class Zip2Observable[A1,A2,+R]
     composite += obsA1.unsafeSubscribeFn(new Subscriber[A1] {
       implicit val scheduler = out.scheduler
 
-      def onNext(elem: A1): Future[Ack] = self.synchronized {
+      def onNext(elem: A1): Future[Ack] = lock.synchronized {
         if (isDone) Stop else {
           elemA1 = elem
           if (!hasElemA1) hasElemA1 = true
@@ -158,7 +159,7 @@ class Zip2Observable[A1,A2,+R]
     composite += obsA2.unsafeSubscribeFn(new Subscriber[A2] {
       implicit val scheduler = out.scheduler
 
-      def onNext(elem: A2): Future[Ack] = self.synchronized {
+      def onNext(elem: A2): Future[Ack] = lock.synchronized {
         if (isDone) Stop else {
           elemA2 = elem
           if (!hasElemA2) hasElemA2 = true

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip4Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip4Observable.scala
@@ -32,37 +32,37 @@ class Zip4Observable[A1,A2,A3,A4,+R]
   (obsA1: Observable[A1], obsA2: Observable[A2], obsA3: Observable[A3], obsA4: Observable[A4])
   (f: (A1,A2,A3,A4) => R)
   extends Observable[R] {
-  self =>
 
   def unsafeSubscribeFn(out: Subscriber[R]): Cancelable = {
     import out.scheduler
 
-    // MUST BE synchronized by `self`
+    val lock = new AnyRef
+    // MUST BE synchronized by `lock`
     var isDone = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var lastAck = Continue: Future[Ack]
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var elemA1: A1 = null.asInstanceOf[A1]
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var hasElemA1 = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var elemA2: A2 = null.asInstanceOf[A2]
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var hasElemA2 = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var elemA3: A3 = null.asInstanceOf[A3]
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var hasElemA3 = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var elemA4: A4 = null.asInstanceOf[A4]
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var hasElemA4 = false
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var continueP = Promise[Ack]()
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     var completeWithNext = false
 
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     def rawOnNext(a1: A1, a2: A2, a3: A3, a4: A4): Future[Ack] =
       if (isDone) Stop
       else {
@@ -88,7 +88,7 @@ class Zip4Observable[A1,A2,A3,A4,+R]
         }
       }
 
-    // MUST BE synchronized by `self`
+    // MUST BE synchronized by `lock`
     def signalOnNext(a1: A1, a2: A2, a3: A3, a4: A4): Future[Ack] = {
       lastAck = lastAck match {
         case Continue => rawOnNext(a1, a2, a3, a4)
@@ -96,7 +96,7 @@ class Zip4Observable[A1,A2,A3,A4,+R]
         case async =>
           async.flatMap {
             // async execution, we have to re-sync
-            case Continue => self.synchronized(rawOnNext(a1, a2, a3, a4))
+            case Continue => lock.synchronized(rawOnNext(a1, a2, a3, a4))
             case Stop => Stop
           }
       }
@@ -106,7 +106,7 @@ class Zip4Observable[A1,A2,A3,A4,+R]
       lastAck
     }
 
-    def signalOnError(ex: Throwable): Unit = self.synchronized {
+    def signalOnError(ex: Throwable): Unit = lock.synchronized {
       if (!isDone) {
         isDone = true
         out.onError(ex)
@@ -120,7 +120,7 @@ class Zip4Observable[A1,A2,A3,A4,+R]
         out.onComplete()
       }
 
-    def signalOnComplete(hasElem: Boolean): Unit = self.synchronized {
+    def signalOnComplete(hasElem: Boolean): Unit = lock.synchronized {
       if (!hasElem) {
         lastAck match {
           case Continue => rawOnComplete()
@@ -128,7 +128,7 @@ class Zip4Observable[A1,A2,A3,A4,+R]
           case async =>
             async.onComplete {
               case Success(Continue) =>
-                self.synchronized(rawOnComplete())
+                lock.synchronized(rawOnComplete())
               case _ =>
                 () // do nothing
             }
@@ -146,7 +146,7 @@ class Zip4Observable[A1,A2,A3,A4,+R]
     composite += obsA1.unsafeSubscribeFn(new Subscriber[A1] {
       implicit val scheduler = out.scheduler
 
-      def onNext(elem: A1): Future[Ack] = self.synchronized {
+      def onNext(elem: A1): Future[Ack] = lock.synchronized {
         if (isDone) Stop
         else {
           elemA1 = elem
@@ -169,7 +169,7 @@ class Zip4Observable[A1,A2,A3,A4,+R]
     composite += obsA2.unsafeSubscribeFn(new Subscriber[A2] {
       implicit val scheduler = out.scheduler
 
-      def onNext(elem: A2): Future[Ack] = self.synchronized {
+      def onNext(elem: A2): Future[Ack] = lock.synchronized {
         if (isDone) Stop
         else {
           elemA2 = elem
@@ -192,7 +192,7 @@ class Zip4Observable[A1,A2,A3,A4,+R]
     composite += obsA3.unsafeSubscribeFn(new Subscriber[A3] {
       implicit val scheduler = out.scheduler
 
-      def onNext(elem: A3): Future[Ack] = self.synchronized {
+      def onNext(elem: A3): Future[Ack] = lock.synchronized {
         if (isDone) Stop
         else {
           elemA3 = elem
@@ -215,7 +215,7 @@ class Zip4Observable[A1,A2,A3,A4,+R]
     composite += obsA4.unsafeSubscribeFn(new Subscriber[A4] {
       implicit val scheduler = out.scheduler
 
-      def onNext(elem: A4): Future[Ack] = self.synchronized {
+      def onNext(elem: A4): Future[Ack] = lock.synchronized {
         if (isDone) Stop
         else {
           elemA4 = elem

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/AsyncBoundaryOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/AsyncBoundaryOperator.scala
@@ -17,6 +17,7 @@
 
 package monix.reactive.internal.operators
 
+import monix.execution.ChannelType.SingleProducer
 import monix.reactive.Observable.Operator
 import monix.reactive.OverflowStrategy
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
@@ -26,5 +27,5 @@ class AsyncBoundaryOperator[A](overflowStrategy: OverflowStrategy[A])
   extends Operator[A,A] {
 
   def apply(out: Subscriber[A]): Subscriber[A] =
-    BufferedSubscriber(out, overflowStrategy)
+    BufferedSubscriber(out, overflowStrategy, SingleProducer)
 }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferIntrospectiveObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferIntrospectiveObservable.scala
@@ -18,6 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Cancelable
+import monix.execution.ChannelType.SingleProducer
 import monix.reactive.Observable
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
 
@@ -26,5 +27,5 @@ class BufferIntrospectiveObservable[+A](source: Observable[A], maxSize: Int)
   extends Observable[List[A]] {
 
   def unsafeSubscribeFn(subscriber: Subscriber[List[A]]): Cancelable =
-    source.unsafeSubscribeFn(BufferedSubscriber.batched(subscriber, maxSize))
+    source.unsafeSubscribeFn(BufferedSubscriber.batched(subscriber, maxSize, SingleProducer))
 }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapParallelOrderedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapParallelOrderedObservable.scala
@@ -24,6 +24,7 @@ import monix.eval.Task
 import monix.execution.Ack.{Continue, Stop}
 import monix.execution.cancelables.{CompositeCancelable, SingleAssignCancelable}
 import monix.execution.AsyncSemaphore
+import monix.execution.ChannelType.MultiProducer
 import monix.execution.{Ack, Cancelable, CancelableFuture}
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
 import monix.reactive.{Observable, OverflowStrategy}
@@ -64,7 +65,7 @@ private[reactive] final class MapParallelOrderedObservable[A, B](
     // everything gets canceled at once
     private[this] val releaseTask = Task.eval(semaphore.release())
     // Buffer with the supplied  overflow strategy.
-    private[this] val buffer = BufferedSubscriber[B](out, overflowStrategy)
+    private[this] val buffer = BufferedSubscriber[B](out, overflowStrategy, MultiProducer)
 
     // Flag indicating whether a final event was called, after which
     // nothing else can happen. It's a very light protection, as

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapParallelUnorderedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapParallelUnorderedObservable.scala
@@ -20,9 +20,11 @@ package monix.reactive.internal.operators
 import monix.execution.{Ack, AsyncSemaphore, Callback, Cancelable}
 import monix.eval.Task
 import monix.execution.Ack.{Continue, Stop}
+import monix.execution.ChannelType.MultiProducer
 import monix.execution.cancelables.{CompositeCancelable, SingleAssignCancelable}
 import monix.reactive.{Observable, OverflowStrategy}
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
+
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}
@@ -75,7 +77,7 @@ private[reactive] final class MapParallelUnorderedObservable[A,B](
     // everything gets canceled at once
     private[this] val releaseTask = Task.eval(semaphore.release())
     // Buffer with the supplied  overflow strategy.
-    private[this] val buffer = BufferedSubscriber[B](out, overflowStrategy)
+    private[this] val buffer = BufferedSubscriber[B](out, overflowStrategy, MultiProducer)
 
     // Flag indicating whether a final event was called, after which
     // nothing else can happen. It's a very light protection, as

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MergeMapObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MergeMapObservable.scala
@@ -18,6 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.{Continue, Stop}
+import monix.execution.ChannelType.MultiProducer
 import monix.execution.{Ack, Cancelable}
 import monix.execution.cancelables._
 import monix.execution.exceptions.CompositeException
@@ -25,7 +26,6 @@ import monix.reactive.observers.{BufferedSubscriber, Subscriber}
 import monix.reactive.{Observable, OverflowStrategy}
 import monix.execution.atomic.Atomic
 import scala.util.control.NonFatal
-
 import scala.collection.mutable
 
 private[reactive] final class MergeMapObservable[A,B](
@@ -41,7 +41,7 @@ private[reactive] final class MergeMapObservable[A,B](
     composite += source.unsafeSubscribeFn(new Subscriber[A] {
       implicit val scheduler = downstream.scheduler
       private[this] val subscriberB: Subscriber[B] =
-        BufferedSubscriber(downstream, overflowStrategy)
+        BufferedSubscriber(downstream, overflowStrategy, MultiProducer)
 
       private[this] val upstreamIsDone = Atomic(false)
       private[this] val errors = if (delayErrors)

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ObserveOnObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ObserveOnObservable.scala
@@ -17,6 +17,7 @@
 
 package monix.reactive.internal.operators
 
+import monix.execution.ChannelType.SingleProducer
 import monix.execution.{Ack, Cancelable, Scheduler}
 import monix.reactive.{Observable, OverflowStrategy}
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
@@ -39,7 +40,7 @@ class ObserveOnObservable[+A](source: Observable[A], altS: Scheduler, os: Overfl
         def onComplete() = out.onComplete()
       }
 
-      BufferedSubscriber(ref, os)
+      BufferedSubscriber(ref, os, SingleProducer)
     }
 
     // Unfortunately we have to do double wrapping of our Subscriber,

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/rstreams/SubscriberAsReactiveSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/rstreams/SubscriberAsReactiveSubscriber.scala
@@ -19,11 +19,13 @@ package monix.reactive.internal.rstreams
 
 import monix.execution.Ack
 import monix.execution.Ack.{Continue, Stop}
+import monix.execution.ChannelType.SingleProducer
 import monix.execution.rstreams.SingleAssignSubscription
 import monix.execution.schedulers.TrampolineExecutionContext.immediate
 import monix.reactive.OverflowStrategy.Unbounded
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
 import org.reactivestreams.{Subscriber => RSubscriber, Subscription => RSubscription}
+
 import scala.concurrent.Future
 
 private[reactive] object SubscriberAsReactiveSubscriber {
@@ -35,7 +37,7 @@ private[reactive] object SubscriberAsReactiveSubscriber {
     * the call may pass asynchronous boundaries, the emitted events need to be buffered.
     * The `requestCount` constructor parameter also represents the buffer size.
     *
-    * To async an instance, [[SubscriberAsReactiveSubscriber.apply]] must be used: 
+    * To async an instance, [[SubscriberAsReactiveSubscriber.apply]] must be used:
     * {{{
     *   // uses the default requestCount of 128
     *   val subscriber = SubscriberAsReactiveSubscriber(new Observer[Int] {
@@ -151,7 +153,7 @@ private[reactive] final class AsyncSubscriberAsReactiveSubscriber[A]
 
 
   private[this] val buffer: Subscriber.Sync[A] =
-    BufferedSubscriber.synchronous(downstream, Unbounded)
+    BufferedSubscriber.synchronous(downstream, Unbounded, SingleProducer)
 
   def onSubscribe(s: RSubscription): Unit =
     subscription := s

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observers/BufferedSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observers/BufferedSubscriber.scala
@@ -17,6 +17,8 @@
 
 package monix.reactive.observers
 
+import monix.execution.ChannelType
+import monix.execution.ChannelType.MultiProducer
 import monix.reactive.OverflowStrategy
 import monix.reactive.observers.buffers.BuildersImpl
 
@@ -58,7 +60,7 @@ import monix.reactive.observers.buffers.BuildersImpl
   *    upstream data sources, or dropping events from the head or the
   *    tail of the queue, or attempting to apply back-pressure, etc...
   *
-  * See [[OverflowStrategy OverflowStrategy]] for the buffer
+  * See [[monix.reactive.OverflowStrategy OverflowStrategy]] for the buffer
   * policies available.
   */
 trait BufferedSubscriber[-A] extends Subscriber[A]
@@ -67,12 +69,18 @@ private[reactive] trait Builders {
   /** Given an [[OverflowStrategy]] wraps a [[Subscriber]] into a
     * buffered subscriber.
     */
-  def apply[A](subscriber: Subscriber[A], bufferPolicy: OverflowStrategy[A]): Subscriber[A]
+  def apply[A](
+    subscriber: Subscriber[A],
+    bufferPolicy: OverflowStrategy[A],
+    producerType: ChannelType.ProducerSide = MultiProducer): Subscriber[A]
 
   /** Given an synchronous [[OverflowStrategy overflow strategy]] wraps
     * a [[Subscriber]] into a buffered subscriber.
     */
-  def synchronous[A](subscriber: Subscriber[A], bufferPolicy: OverflowStrategy.Synchronous[A]): Subscriber.Sync[A]
+  def synchronous[A](
+    subscriber: Subscriber[A],
+    bufferPolicy: OverflowStrategy.Synchronous[A],
+    producerType: ChannelType.ProducerSide = MultiProducer): Subscriber.Sync[A]
 
   /** Builds a batched buffered subscriber.
     *
@@ -86,7 +94,10 @@ private[reactive] trait Builders {
     * So a batched buffered subscriber is implicitly delivering
     * the back-pressure overflow strategy.
     */
-  def batched[A](underlying: Subscriber[List[A]], bufferSize: Int): Subscriber[A]
+  def batched[A](
+    underlying: Subscriber[List[A]],
+    bufferSize: Int,
+    producerType: ChannelType.ProducerSide = MultiProducer): Subscriber[A]
 }
 
 object BufferedSubscriber extends Builders with BuildersImpl

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressureBatchedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressureBatchedSuite.scala
@@ -20,8 +20,10 @@ package monix.reactive.observers
 import minitest.TestSuite
 import monix.execution.Ack
 import monix.execution.Ack.{Continue, Stop}
+import monix.execution.ChannelType.MultiProducer
 import monix.execution.schedulers.TestScheduler
 import monix.execution.exceptions.DummyException
+
 import scala.concurrent.{Future, Promise}
 import scala.util.Success
 
@@ -38,6 +40,7 @@ object OverflowStrategyBackPressureBatchedSuite extends TestSuite[TestScheduler]
 
     val buffer = BufferedSubscriber.batched[Int](
       bufferSize = 5,
+      producerType = MultiProducer,
       underlying = new Subscriber[List[Int]] {
         def onNext(elem: List[Int]) = promise.future
         def onError(ex: Throwable) = throw new IllegalStateException()
@@ -98,7 +101,7 @@ object OverflowStrategyBackPressureBatchedSuite extends TestSuite[TestScheduler]
       }
     }
 
-    val buffer = BufferedSubscriber.batched[Int](underlying, 1000)
+    val buffer = BufferedSubscriber.batched[Int](underlying, 1000, MultiProducer)
     for (i <- 0 until 1000) buffer.onNext(i)
     buffer.onComplete()
 
@@ -129,7 +132,7 @@ object OverflowStrategyBackPressureBatchedSuite extends TestSuite[TestScheduler]
       }
     }
 
-    val buffer = BufferedSubscriber.batched[Int](underlying, 1000)
+    val buffer = BufferedSubscriber.batched[Int](underlying, 1000, MultiProducer)
     def loop(n: Int): Unit =
       if (n > 0)
         s.executeAsync { () => buffer.onNext(n); loop(n-1) }
@@ -166,7 +169,7 @@ object OverflowStrategyBackPressureBatchedSuite extends TestSuite[TestScheduler]
       }
     }
 
-    val buffer = BufferedSubscriber.batched[Int](underlying, 512)
+    val buffer = BufferedSubscriber.batched[Int](underlying, 512, MultiProducer)
     def loop(n: Int): Unit =
       if (n > 0)
         s.executeAsync { () => buffer.onNext(n); loop(n-1) }
@@ -191,7 +194,7 @@ object OverflowStrategyBackPressureBatchedSuite extends TestSuite[TestScheduler]
       val scheduler = s
     }
 
-    val buffer = BufferedSubscriber.batched(underlying, 5)
+    val buffer = BufferedSubscriber.batched(underlying, 5, MultiProducer)
     buffer.onError(DummyException("dummy"))
     s.tickOne()
 
@@ -210,7 +213,7 @@ object OverflowStrategyBackPressureBatchedSuite extends TestSuite[TestScheduler]
       val scheduler = s
     }
 
-    val buffer = BufferedSubscriber.batched(underlying, 5)
+    val buffer = BufferedSubscriber.batched(underlying, 5, MultiProducer)
     buffer.onNext(1)
     buffer.onError(DummyException("dummy"))
 
@@ -229,7 +232,7 @@ object OverflowStrategyBackPressureBatchedSuite extends TestSuite[TestScheduler]
       val scheduler = s
     }
 
-    val buffer = BufferedSubscriber.batched(underlying, 5)
+    val buffer = BufferedSubscriber.batched(underlying, 5, MultiProducer)
     for (i <- 0 until 20) buffer.onNext(i)
     buffer.onError(DummyException("dummy"))
 
@@ -246,7 +249,7 @@ object OverflowStrategyBackPressureBatchedSuite extends TestSuite[TestScheduler]
       def onComplete() = wasCompleted = true
     }
 
-    val buffer = BufferedSubscriber.batched(underlying, 8)
+    val buffer = BufferedSubscriber.batched(underlying, 8, MultiProducer)
     buffer.onComplete()
 
     s.tickOne()
@@ -264,7 +267,7 @@ object OverflowStrategyBackPressureBatchedSuite extends TestSuite[TestScheduler]
       def onComplete() = wasCompleted = true
     }
 
-    val buffer = BufferedSubscriber.batched(underlying, 8)
+    val buffer = BufferedSubscriber.batched(underlying, 8, MultiProducer)
     buffer.onNext(1)
     buffer.onComplete()
 

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyClearBufferAndSignalSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyClearBufferAndSignalSuite.scala
@@ -18,6 +18,7 @@
 package monix.reactive.observers
 
 import minitest.TestSuite
+import monix.eval.Coeval
 import monix.execution.Ack.{Continue, Stop}
 import monix.execution.atomic.AtomicLong
 import monix.execution.internal.{Platform, RunnableAction}
@@ -26,6 +27,7 @@ import monix.execution.{Ack, Scheduler}
 import monix.reactive.Observer
 import monix.reactive.OverflowStrategy.ClearBufferAndSignal
 import monix.execution.exceptions.DummyException
+
 import scala.concurrent.{Future, Promise}
 
 object OverflowStrategyClearBufferAndSignalSuite extends TestSuite[TestScheduler] {
@@ -39,14 +41,14 @@ object OverflowStrategyClearBufferAndSignalSuite extends TestSuite[TestScheduler
     (implicit s: Scheduler) = {
 
     BufferedSubscriber(Subscriber(underlying, s),
-      ClearBufferAndSignal(bufferSize, nr => Some(nr.toInt)))
+      ClearBufferAndSignal(bufferSize, nr => Coeval(Some(nr.toInt))))
   }
 
   def buildNewWithLog(bufferSize: Int, underlying: Observer[Int], log: AtomicLong)
     (implicit s: Scheduler) = {
 
     BufferedSubscriber[Int](Subscriber(underlying, s),
-      ClearBufferAndSignal(bufferSize, { nr => log.set(nr); None }))
+      ClearBufferAndSignal(bufferSize, nr => Coeval { log.set(nr); None }))
   }
 
   test("should not lose events, test 1") { implicit s =>
@@ -187,10 +189,10 @@ object OverflowStrategyClearBufferAndSignalSuite extends TestSuite[TestScheduler
 
     if (Platform.isJVM) {
       assertEquals(received, 28 + (2000 to 2004).sum)
-      assertEquals(log.get, 2000)
+      assertEquals(log.get(), 2000)
     }
     else {
-      assertEquals(log.get, 2002)
+      assertEquals(log.get(), 2002)
       assertEquals(received, 28 + (2002 to 2004).sum)
     }
 

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewAndSignalSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewAndSignalSuite.scala
@@ -18,6 +18,7 @@
 package monix.reactive.observers
 
 import minitest.TestSuite
+import monix.eval.Coeval
 import monix.execution.Ack.{Continue, Stop}
 import monix.execution.atomic.AtomicLong
 import monix.execution.internal.Platform
@@ -26,6 +27,7 @@ import monix.execution.{Ack, Scheduler}
 import monix.reactive.Observer
 import monix.reactive.OverflowStrategy.DropNewAndSignal
 import monix.execution.exceptions.DummyException
+
 import scala.concurrent.Promise
 
 object OverflowStrategyDropNewAndSignalSuite extends TestSuite[TestScheduler] {
@@ -37,14 +39,14 @@ object OverflowStrategyDropNewAndSignalSuite extends TestSuite[TestScheduler] {
 
   def buildNewForIntWithSignal(bufferSize: Int, underlying: Observer[Int])
     (implicit s: Scheduler) =
-    BufferedSubscriber(Subscriber(underlying, s), DropNewAndSignal(bufferSize, nr => Some(nr.toInt)))
+    BufferedSubscriber(Subscriber(underlying, s), DropNewAndSignal(bufferSize, nr => Coeval(Some(nr.toInt))))
 
   def buildNewForIntWithLog(bufferSize: Int, underlying: Observer[Int], log: AtomicLong)
     (implicit s: Scheduler) =
-    BufferedSubscriber(Subscriber(underlying, s), DropNewAndSignal[Int](bufferSize, { nr => log.set(nr); None }))
+    BufferedSubscriber(Subscriber(underlying, s), DropNewAndSignal[Int](bufferSize, nr => Coeval { log.set(nr); None }))
 
   def buildNewForLongWithSignal(bufferSize: Int, underlying: Observer[Long])(implicit s: Scheduler) = {
-    BufferedSubscriber(Subscriber(underlying, s), DropNewAndSignal(bufferSize, nr => Some(nr)))
+    BufferedSubscriber(Subscriber(underlying, s), DropNewAndSignal(bufferSize, nr => Coeval(Some(nr))))
   }
 
   test("should not lose events, test 1") { implicit s =>
@@ -184,12 +186,12 @@ object OverflowStrategyDropNewAndSignalSuite extends TestSuite[TestScheduler] {
 
     promise.success(Continue); s.tick()
     assertEquals(received, (1 to 9).sum)
-    assertEquals(log.get, 5)
+    assertEquals(log.get(), 5)
     for (i <- 1 to 8) assertEquals(buffer.onNext(i), Continue)
 
     s.tick()
     assertEquals(received, (1 to 8).sum * 2 + 9)
-    assertEquals(log.get, 5)
+    assertEquals(log.get(), 5)
 
     buffer.onComplete(); s.tick()
     assert(wasCompleted, "wasCompleted should be true")

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropOldAndSignalSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropOldAndSignalSuite.scala
@@ -18,7 +18,9 @@
 package monix.reactive.observers
 
 import minitest.TestSuite
+import monix.eval.Coeval
 import monix.execution.Ack.{Continue, Stop}
+import monix.execution.ChannelType.MultiProducer
 import monix.execution.atomic.AtomicLong
 import monix.execution.internal.{Platform, RunnableAction}
 import monix.execution.schedulers.TestScheduler
@@ -26,6 +28,7 @@ import monix.execution.{Ack, Scheduler}
 import monix.reactive.Observer
 import monix.reactive.OverflowStrategy.DropOldAndSignal
 import monix.execution.exceptions.DummyException
+
 import scala.concurrent.{Future, Promise}
 
 object OverflowStrategyDropOldAndSignalSuite extends TestSuite[TestScheduler] {
@@ -39,14 +42,20 @@ object OverflowStrategyDropOldAndSignalSuite extends TestSuite[TestScheduler] {
     (implicit s: Scheduler) = {
 
     BufferedSubscriber.synchronous(
-      Subscriber(underlying, s), DropOldAndSignal(bufferSize, nr => Some(nr.toInt)))
+      Subscriber(underlying, s),
+      DropOldAndSignal(bufferSize, nr => Coeval(Some(nr.toInt))),
+      MultiProducer
+    )
   }
 
   def buildNewWithLog(bufferSize: Int, underlying: Observer[Int], log: AtomicLong)
     (implicit s: Scheduler) = {
 
     BufferedSubscriber.synchronous[Int](
-      Subscriber(underlying, s), DropOldAndSignal(bufferSize, { nr => log.set(nr); None }))
+      Subscriber(underlying, s),
+      DropOldAndSignal(bufferSize, nr => Coeval { log.set(nr); None }),
+      MultiProducer
+    )
   }
 
   test("should not lose events, test 1") { implicit s =>
@@ -190,14 +199,14 @@ object OverflowStrategyDropOldAndSignalSuite extends TestSuite[TestScheduler] {
     val dropped = if (Platform.isJVM) 993 else 986
 
     assertEquals(received, (first to 1100).sum + 28)
-    assertEquals(log.get, dropped)
+    assertEquals(log.get(), dropped)
 
     log.set(0)
     assertEquals(buffer.onNext(42), Continue)
 
     s.tick()
 
-    assertEquals(log.get, 0)
+    assertEquals(log.get(), 0)
 
     buffer.onComplete(); s.tick()
     assert(wasCompleted, "wasCompleted should be true")

--- a/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
@@ -30,7 +30,7 @@ import monix.execution.ChannelType.{MultiProducer, SingleConsumer}
 import monix.execution.annotations.UnsafeProtocol
 
 import scala.util.control.NonFatal
-import monix.execution.internal.Platform.recommendedBatchSize
+import monix.execution.internal.Platform.{recommendedBatchSize, recommendedBufferChunkSize}
 import monix.tail.batches.{Batch, BatchCursor}
 import monix.tail.internal._
 import monix.tail.internal.Constants.emptyRef
@@ -2532,7 +2532,10 @@ object Iterant extends IterantInstances {
     *        ready to process it — this prevents having pauses due to
     *        back-pressuring the `Subscription.request(n)` calls
     */
-  def fromReactivePublisher[F[_], A](publisher: Publisher[A], requestCount: Int = 256, eagerBuffer: Boolean = true)
+  def fromReactivePublisher[F[_], A](
+    publisher: Publisher[A],
+    requestCount: Int = recommendedBufferChunkSize,
+    eagerBuffer: Boolean = true)
     (implicit F: Async[F]): Iterant[F, A] =
     IterantFromReactivePublisher(publisher, requestCount, eagerBuffer)
 
@@ -2616,7 +2619,7 @@ object Iterant extends IterantInstances {
     *        [[Iterant.NextBatch]] nodes, effectively specifying how many
     *        items can be pulled from the queue and processed in batches
     */
-  def fromConsumer[F[_], A](consumer: Consumer[F, A], maxBatchSize: Int = 256)
+  def fromConsumer[F[_], A](consumer: Consumer[F, A], maxBatchSize: Int = recommendedBufferChunkSize)
     (implicit F: Async[F]): Iterant[F, A] = {
 
     IterantFromConsumer(consumer, maxBatchSize)
@@ -2640,8 +2643,8 @@ object Iterant extends IterantInstances {
     */
   def fromChannel[F[_], A](
     channel: Channel[F, A],
-    bufferCapacity: BufferCapacity = Bounded(256),
-    maxBatchSize: Int = 256)
+    bufferCapacity: BufferCapacity = Bounded(recommendedBufferChunkSize),
+    maxBatchSize: Int = recommendedBufferChunkSize)
     (implicit F: Async[F]): Iterant[F, A] = {
 
     val config = ConsumerF.Config(
@@ -2727,8 +2730,8 @@ object Iterant extends IterantInstances {
     *        for optimization purposes, for when you know what you're doing
     */
   def channel[F[_], A](
-    bufferCapacity: BufferCapacity = Bounded(256),
-    maxBatchSize: Int = 256,
+    bufferCapacity: BufferCapacity = Bounded(recommendedBufferChunkSize),
+    maxBatchSize: Int = recommendedBufferChunkSize,
     producerType: ChannelType.ProducerSide = MultiProducer)
     (implicit F: Concurrent[F], cs: ContextShift[F]): F[(Producer[F, A], Iterant[F, A])] = {
 

--- a/monix-tail/shared/src/main/scala/monix/tail/IterantBuilders.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/IterantBuilders.scala
@@ -22,10 +22,12 @@ import cats.effect._
 import monix.catnap.{ConsumerF, ProducerF}
 import monix.execution.BufferCapacity.Bounded
 import monix.execution.ChannelType.MultiProducer
+import monix.execution.internal.Platform.recommendedBufferChunkSize
 import monix.execution.{BufferCapacity, ChannelType}
 import monix.tail.Iterant.Channel
 import monix.tail.batches.{Batch, BatchCursor}
 import org.reactivestreams.Publisher
+
 import scala.collection.immutable.LinearSeq
 import scala.concurrent.duration.FiniteDuration
 
@@ -256,24 +258,24 @@ object IterantBuilders {
       Iterant.intervalWithFixedDelay(initialDelay, delay)
 
     /** Aliased builder, see documentation for [[Iterant.fromReactivePublisher]]. */
-    def fromReactivePublisher[A](publisher: Publisher[A], requestCount: Int = 256, eagerBuffer: Boolean = true)
+    def fromReactivePublisher[A](publisher: Publisher[A], requestCount: Int = recommendedBufferChunkSize, eagerBuffer: Boolean = true)
       (implicit F: Async[F]): Iterant[F, A] =
       Iterant.fromReactivePublisher(publisher, requestCount, eagerBuffer)
 
     /** Aliased builder, see documentation for [[Iterant.fromConsumer]]. */
-    def fromConsumer[A](consumer: ConsumerF[F, Option[Throwable], A], maxBatchSize: Int = 256)
+    def fromConsumer[A](consumer: ConsumerF[F, Option[Throwable], A], maxBatchSize: Int = recommendedBufferChunkSize)
       (implicit F: Async[F]): Iterant[F, A] =
       Iterant.fromConsumer(consumer, maxBatchSize)
 
     /** Aliased builder, see documentation for [[Iterant.fromChannel]]. */
-    def fromChannel[A](channel: Channel[F, A], bufferCapacity: BufferCapacity = Bounded(256), maxBatchSize: Int = 256)
+    def fromChannel[A](channel: Channel[F, A], bufferCapacity: BufferCapacity = Bounded(recommendedBufferChunkSize), maxBatchSize: Int = recommendedBufferChunkSize)
       (implicit F: Async[F]): Iterant[F, A] =
       Iterant.fromChannel(channel, bufferCapacity, maxBatchSize)
 
     /** Aliased builder, see documentation for [[Iterant.channel]]. */
     def channel[A](
-      bufferCapacity: BufferCapacity = Bounded(256),
-      maxBatchSize: Int = 256,
+      bufferCapacity: BufferCapacity = Bounded(recommendedBufferChunkSize),
+      maxBatchSize: Int = recommendedBufferChunkSize,
       producerType: ChannelType.ProducerSide = MultiProducer)
       (implicit F: Concurrent[F], cs: ContextShift[F]): F[(ProducerF[F, Option[Throwable], A], Iterant[F, A])] =
       Iterant.channel(bufferCapacity, maxBatchSize, producerType)

--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -14,8 +14,9 @@ object MimaFilters {
     exclude[DirectMissingMethodProblem]("monix.tail.IterantBuilders.apply"),
     exclude[MissingClassProblem]("monix.tail.IterantBuilders$Ref$"),
     exclude[IncompatibleResultTypeProblem]("monix.tail.Iterant.apply"),
-    // Breaking
-    // https://github.com/monix/monix/pull/778
+    //
+    // BREAKING CHANGES: https://github.com/monix/monix/pull/778
+    //
     exclude[IncompatibleMethTypeProblem]("monix.catnap.ConcurrentQueue#ApplyBuilders.unbounded$extension"),
     exclude[IncompatibleMethTypeProblem]("monix.catnap.ConcurrentQueue#ApplyBuilders.bounded$extension"),
     exclude[DirectMissingMethodProblem]("monix.catnap.ConcurrentQueue#ApplyBuilders.custom$default$2$extension"),
@@ -59,7 +60,46 @@ object MimaFilters {
     exclude[ReversedMissingMethodProblem]("monix.execution.internal.collection.queues.FromMessagePassingQueue.fencePoll"),
     exclude[InheritedNewAbstractMethodProblem]("monix.execution.internal.collection.queues.FromMessagePassingQueue.fenceOffer"),
     exclude[InheritedNewAbstractMethodProblem]("monix.execution.internal.collection.queues.FromMessagePassingQueue.fencePoll"),
-    exclude[MissingClassProblem]("monix.execution.internal.collection.queues.ConcurrentQueueBuilders")
+    exclude[MissingClassProblem]("monix.execution.internal.collection.queues.ConcurrentQueueBuilders"),
+    //
+    // BREAKING CHANGES: https://github.com/monix/monix/pull/801
+    //
+    exclude[DirectMissingMethodProblem]("monix.reactive.Observable.create"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.subjects.ConcurrentSubject#SubjectAsConcurrent.this"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.subjects.ConcurrentSubject.from"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.internal.builders.CreateObservable.this"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.Builders.batched"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.Builders.synchronous"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.Builders.apply"),
+    exclude[ReversedMissingMethodProblem]("monix.reactive.observers.Builders.synchronous$default$3"),
+    exclude[ReversedMissingMethodProblem]("monix.reactive.observers.Builders.batched$default$3"),
+    exclude[ReversedMissingMethodProblem]("monix.reactive.observers.Builders.apply$default$3"),
+    exclude[ReversedMissingMethodProblem]("monix.reactive.observers.Builders.batched"),
+    exclude[ReversedMissingMethodProblem]("monix.reactive.observers.Builders.synchronous"),
+    exclude[ReversedMissingMethodProblem]("monix.reactive.observers.Builders.apply"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.BufferedSubscriber.batched"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.BufferedSubscriber.synchronous"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.BufferedSubscriber.apply"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.buffers.BuildersImpl.batched"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.buffers.BuildersImpl.synchronous"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.buffers.BuildersImpl.apply"),
+    exclude[ReversedMissingMethodProblem]("monix.reactive.observers.buffers.BuildersImpl.synchronous$default$3"),
+    exclude[ReversedMissingMethodProblem]("monix.reactive.observers.buffers.BuildersImpl.batched"),
+    exclude[ReversedMissingMethodProblem]("monix.reactive.observers.buffers.BuildersImpl.synchronous"),
+    exclude[ReversedMissingMethodProblem]("monix.reactive.observers.buffers.BuildersImpl.batched$default$3"),
+    exclude[ReversedMissingMethodProblem]("monix.reactive.observers.buffers.BuildersImpl.apply$default$3"),
+    exclude[ReversedMissingMethodProblem]("monix.reactive.observers.buffers.BuildersImpl.apply"),
+    exclude[IncompatibleMethTypeProblem]("monix.reactive.observers.buffers.SimpleBufferedSubscriber.this"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.buffers.BackPressuredBufferedSubscriber.apply"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.buffers.BackPressuredBufferedSubscriber.this"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.buffers.SimpleBufferedSubscriber.unbounded"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.buffers.SimpleBufferedSubscriber.overflowTriggering"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.buffers.BatchedBufferedSubscriber.this"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.buffers.BatchedBufferedSubscriber.apply"),
+    exclude[IncompatibleResultTypeProblem]("monix.reactive.observers.buffers.AbstractBackPressuredBufferedSubscriber.queue"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.buffers.AbstractBackPressuredBufferedSubscriber.this"),
+    exclude[IncompatibleMethTypeProblem]("monix.reactive.observers.buffers.AbstractSimpleBufferedSubscriber.this"),
+    exclude[FinalClassProblem]("monix.reactive.OverflowStrategy$Unbounded$")
   )
 
   lazy val changesFor_3_0_0_RC2 = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js"         % "sbt-scalajs"     % "0.6.25")
+addSbtPlugin("org.scala-js"         % "sbt-scalajs"     % "0.6.26")
 addSbtPlugin("com.jsuereth"         % "sbt-pgp"         % "1.1.2")
 addSbtPlugin("com.eed3si9n"         % "sbt-unidoc"      % "0.4.2")
 addSbtPlugin("pl.project13.scala"   % "sbt-jmh"         % "0.3.4")


### PR DESCRIPTION
Hi,

I've been investigating deadlock caused by Monix.

Stack trace:

    Found one Java-level deadlock:
    =============================
    "scala-execution-context-global-2252":
      waiting to lock monitor 0x00007ff024054548 (object 0x00000000891aa608, a java.lang.Class),
      which is held by "scala-execution-context-global-2251"
    "scala-execution-context-global-2251":
      waiting to lock monitor 0x00007ff024086678 (object 0x0000000089625140, a monix.reactive.internal.operators.SwitchMapObservable$$anon$1),
      which is held by "scala-execution-context-global-2250"
    "scala-execution-context-global-2250":
      waiting to lock monitor 0x00007ff024054548 (object 0x00000000891aa608, a java.lang.Class),
      which is held by "scala-execution-context-global-2251"
    
    Java stack information for the threads listed above:
    ===================================================
    "scala-execution-context-global-2252":
            at monix.reactive.internal.builders.CombineLatest2Observable.monix$reactive$internal$builders$CombineLatest2Observable$$signalOnError$1(CombineLatest2Observable.scala:86)
            - waiting to lock <0x00000000891aa608> (a java.lang.Class for monix.reactive.internal.builders.CombineLatest2Observable)
            at monix.reactive.internal.builders.CombineLatest2Observable$$anon$2.onError(CombineLatest2Observable.scala:160)
            at monix.reactive.internal.operators.MapOperator$$anon$1.onError(MapOperator.scala:55)
            at monix.reactive.internal.operators.DistinctUntilChangedByKeyOperator$$anon$1.onError(DistinctUntilChangedByKeyOperator.scala:75)
            at monix.reactive.internal.builders.AsyncStateActionObservable.$anonfun$loop$1(AsyncStateActionObservable.scala:52)
            at monix.reactive.internal.builders.AsyncStateActionObservable$$Lambda$1872/24786665.apply(Unknown Source)
            at monix.eval.internal.StackFrame$RedeemWith.recover(StackFrame.scala:38)
            at monix.eval.internal.TaskRunLoop$.startFull(TaskRunLoop.scala:108)
            at monix.eval.internal.TaskRunLoop$.$anonfun$restartAsync$1(TaskRunLoop.scala:192)
            at monix.eval.internal.TaskRunLoop$$$Lambda$554/999999316.run(Unknown Source)
            at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1402)
            at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
            at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
            at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
            at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
    "scala-execution-context-global-2251":
            at monix.reactive.internal.operators.SwitchMapObservable$$anon$1$$anon$2.onError(SwitchMapObservable.scala:74)
            - waiting to lock <0x0000000089625140> (a monix.reactive.internal.operators.SwitchMapObservable$$anon$1)
            at monix.reactive.observers.Subscriber$Implementation.onError(Subscriber.scala:207)
            at monix.reactive.internal.operators.MapOperator$$anon$1.onError(MapOperator.scala:55)
            at monix.reactive.internal.operators.CollectOperator$$anon$1.onError(CollectOperator.scala:60)
            at monix.reactive.internal.operators.MapTaskObservable$MapAsyncSubscriber.signalFinish(MapTaskObservable.scala:310)
            at monix.reactive.internal.operators.MapTaskObservable$MapAsyncSubscriber.onError(MapTaskObservable.scala:346)
            at monix.reactive.internal.operators.MapOperator$$anon$1.onError(MapOperator.scala:55)
            at monix.reactive.internal.builders.CombineLatest2Observable.monix$reactive$internal$builders$CombineLatest2Observable$$signalOnError$1(CombineLatest2Observable.scala:88)
            - locked <0x00000000891aa608> (a java.lang.Class for monix.reactive.internal.builders.CombineLatest2Observable)
            at monix.reactive.internal.builders.CombineLatest2Observable$$anon$1.onError(CombineLatest2Observable.scala:139)
            at monix.reactive.internal.builders.CombineLatest2Observable.monix$reactive$internal$builders$CombineLatest2Observable$$signalOnError$1(CombineLatest2Observable.scala:88)
            - locked <0x00000000891aa608> (a java.lang.Class for monix.reactive.internal.builders.CombineLatest2Observable)
            at monix.reactive.internal.builders.CombineLatest2Observable$$anon$1.onError(CombineLatest2Observable.scala:139)
            at monix.reactive.internal.builders.CombineLatest2Observable.monix$reactive$internal$builders$CombineLatest2Observable$$signalOnError$1(CombineLatest2Observable.scala:88)
            - locked <0x00000000891aa608> (a java.lang.Class for monix.reactive.internal.builders.CombineLatest2Observable)
            at monix.reactive.internal.builders.CombineLatest2Observable$$anon$1.onError(CombineLatest2Observable.scala:139)
            at monix.reactive.internal.operators.MapOperator$$anon$1.onError(MapOperator.scala:55)
            at monix.reactive.internal.operators.MapOperator$$anon$1.onError(MapOperator.scala:55)
            at monix.reactive.internal.builders.CombineLatest2Observable.monix$reactive$internal$builders$CombineLatest2Observable$$signalOnError$1(CombineLatest2Observable.scala:88)
            - locked <0x00000000891aa608> (a java.lang.Class for monix.reactive.internal.builders.CombineLatest2Observable)
            at monix.reactive.internal.builders.CombineLatest2Observable$$anon$2.onError(CombineLatest2Observable.scala:160)
            at monix.reactive.internal.operators.MapOperator$$anon$1.onError(MapOperator.scala:55)
            at monix.reactive.internal.operators.DistinctUntilChangedByKeyOperator$$anon$1.onError(DistinctUntilChangedByKeyOperator.scala:75)
            at monix.reactive.internal.builders.AsyncStateActionObservable.$anonfun$loop$1(AsyncStateActionObservable.scala:52)
            at monix.reactive.internal.builders.AsyncStateActionObservable$$Lambda$1872/24786665.apply(Unknown Source)
            at monix.eval.internal.StackFrame$RedeemWith.recover(StackFrame.scala:38)
            at monix.eval.internal.TaskRunLoop$.startFull(TaskRunLoop.scala:108)
            at monix.eval.internal.TaskRunLoop$.$anonfun$restartAsync$1(TaskRunLoop.scala:192)
            at monix.eval.internal.TaskRunLoop$$$Lambda$554/999999316.run(Unknown Source)
            at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1402)
            at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
            at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
            at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
            at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
    "scala-execution-context-global-2250":
            at monix.reactive.internal.builders.CombineLatest2Observable.monix$reactive$internal$builders$CombineLatest2Observable$$signalOnError$1(CombineLatest2Observable.scala:86)
            - waiting to lock <0x00000000891aa608> (a java.lang.Class for monix.reactive.internal.builders.CombineLatest2Observable)
            at monix.reactive.internal.builders.CombineLatest2Observable$$anon$2.onError(CombineLatest2Observable.scala:160)
            at monix.reactive.internal.operators.MapTaskObservable$MapAsyncSubscriber.signalFinish(MapTaskObservable.scala:310)
            at monix.reactive.internal.operators.MapTaskObservable$MapAsyncSubscriber.onError(MapTaskObservable.scala:346)
            at monix.reactive.internal.operators.MapOperator$$anon$1.onError(MapOperator.scala:55)
            at monix.reactive.internal.operators.MapOperator$$anon$1.onError(MapOperator.scala:55)
            at monix.reactive.internal.operators.MapOperator$$anon$1.onError(MapOperator.scala:55)
            at monix.reactive.internal.operators.SwitchMapObservable$$anon$1.onError(SwitchMapObservable.scala:98)
            - locked <0x0000000089625140> (a monix.reactive.internal.operators.SwitchMapObservable$$anon$1)
            at monix.reactive.internal.operators.MapTaskObservable$MapAsyncSubscriber.signalFinish(MapTaskObservable.scala:310)
            at monix.reactive.internal.operators.MapTaskObservable$MapAsyncSubscriber.onError(MapTaskObservable.scala:346)
            at monix.reactive.internal.operators.MapOperator$$anon$1.onError(MapOperator.scala:55)
            at monix.reactive.internal.operators.MapOperator$$anon$1.onError(MapOperator.scala:55)
            at monix.reactive.internal.operators.DistinctUntilChangedByKeyOperator$$anon$1.onError(DistinctUntilChangedByKeyOperator.scala:75)
            at monix.reactive.internal.builders.AsyncStateActionObservable.$anonfun$loop$1(AsyncStateActionObservable.scala:52)
            at monix.reactive.internal.builders.AsyncStateActionObservable$$Lambda$1872/24786665.apply(Unknown Source)
            at monix.eval.internal.StackFrame$RedeemWith.recover(StackFrame.scala:38)
            at monix.eval.internal.TaskRunLoop$.startFull(TaskRunLoop.scala:108)
            at monix.eval.internal.TaskRunLoop$.$anonfun$restartAsync$1(TaskRunLoop.scala:192)
            at monix.eval.internal.TaskRunLoop$$$Lambda$554/999999316.run(Unknown Source)
            at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1402)
            at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
            at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
            at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
            at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
    
    Found 1 deadlock.

The interesting part of the above stacktrace is `CombineLatest2Observable` seems to lock `a java.lang.Class for monix.reactive.internal.builders.CombineLatest2Observable`.

According to the following code, `CombineLatest2Observable` uses `self` as a lock: <https://github.com/monix/monix/blob/master/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest2Observable.scala#L85>

While I don't understand why this causes locking `java.lang.Class`, I actually can reproduce this with the following code:

```scala
object Demo {
  def main(args: Array[String]): Unit = {
    import monix.eval.Task
    import monix.reactive.Observable
    import monix.execution.Scheduler.Implicits.global
    import scala.concurrent.duration._

    val l = (Observable.range(1, 3).delayExecution(1.second) ++
      Observable.raiseError(new RuntimeException("boom"))).dump("L")

    val r = Observable(1, 2).dump("R")
    l.combineLatest(r)
      .dump("U")
      .mapEval { _ =>
        Task(dumpLocks())
      }
      .doOnError { _ =>
        Task(dumpLocks())
      }
      .completedL
      .runSyncUnsafe()
  }

  private def dumpLocks(): Unit = {
    import java.lang.management.ManagementFactory
    val bean = ManagementFactory.getThreadMXBean
    val info = bean.getThreadInfo(bean.getAllThreadIds, true, true).toList
    info.map(x => x.getThreadName -> x.getLockedMonitors.toList).foreach {
      case (thread, monitors) if monitors.nonEmpty =>
        val locks = monitors.map { info =>
          info.toString + "(" + info.getLockedStackFrame.getFileName + ":" + info.getLockedStackFrame.getLineNumber + ")"
        }
        println(s"'$thread' holds [ ${locks.mkString(", ")} ] ")
      case _ =>
    }

  }
}
```

Output:

    0: R --> 1
    1: R --> 2
    2: R completed
    0: L --> 1
    0: U --> (1,2)
    'scala-execution-context-global-13' holds [ monix.reactive.internal.builders.CombineLatest2Observable@1eb6fd3b(CombineLatest2Observable.scala:132) ] 
    'Monitor Ctrl-Break' holds [ java.io.InputStreamReader@d6871bd(StreamDecoder.java:178), java.io.InputStreamReader@d6871bd(BufferedReader.java:324) ] 
    1: L --> 2
    1: U --> (2,2)
    'scala-execution-context-global-13' holds [ monix.reactive.internal.builders.CombineLatest2Observable@1eb6fd3b(CombineLatest2Observable.scala:132) ] 
    'Monitor Ctrl-Break' holds [ java.io.InputStreamReader@d6871bd(StreamDecoder.java:178), java.io.InputStreamReader@d6871bd(BufferedReader.java:324) ] 
    2: L --> java.lang.RuntimeException: boom
    2: U --> java.lang.RuntimeException: boom
    'scala-execution-context-global-13' holds [ java.lang.Class@cd3deb2(CombineLatest2Observable.scala:88) ] 
    'Monitor Ctrl-Break' holds [ java.io.InputStreamReader@d6871bd(StreamDecoder.java:178), java.io.InputStreamReader@d6871bd(BufferedReader.java:324) ] 
    Exception in thread "main" java.lang.RuntimeException: boom
    	at Demo$.$anonfun$main$1(Demo.scala:75)
    	at monix.reactive.internal.builders.DeferObservable.unsafeSubscribeFn(DeferObservable.scala:44)
    	at monix.reactive.observables.ChainedObservable$.$anonfun$subscribe$1(ChainedObservable.scala:72)
    	at monix.execution.internal.Trampoline.monix$execution$internal$Trampoline$$immediateLoop(Trampoline.scala:65)
    	at monix.execution.internal.Trampoline.startLoop(Trampoline.scala:31)
    	at monix.execution.schedulers.TrampolineExecutionContext$JVMOptimalTrampoline.startLoop(TrampolineExecutionContext.scala:146)
    	at monix.execution.internal.Trampoline.execute(Trampoline.scala:38)
    	at monix.execution.schedulers.TrampolineExecutionContext.execute(TrampolineExecutionContext.scala:65)
    	at monix.execution.schedulers.BatchingScheduler.execute(BatchingScheduler.scala:50)
    	at monix.execution.schedulers.BatchingScheduler.execute$(BatchingScheduler.scala:47)
    	at monix.execution.schedulers.AsyncScheduler.execute(AsyncScheduler.scala:29)
    	at monix.execution.schedulers.ExecuteExtensions.executeTrampolined(ExecuteExtensions.scala:86)
    	at monix.execution.schedulers.ExecuteExtensions.executeTrampolined$(ExecuteExtensions.scala:85)
    	at monix.execution.Scheduler$Extensions.executeTrampolined(Scheduler.scala:255)
    	at monix.reactive.observables.ChainedObservable$.subscribe(ChainedObservable.scala:69)
    	at monix.reactive.internal.operators.ConcatObservable$$anon$1.$anonfun$onComplete$1(ConcatObservable.scala:50)
    	at monix.execution.Ack$AckExtensions$.syncOnContinue$extension(Ack.scala:111)
    	at monix.reactive.internal.operators.ConcatObservable$$anon$1.onComplete(ConcatObservable.scala:50)
    	at monix.reactive.internal.builders.RangeObservable.loop(RangeObservable.scala:57)
    	at monix.reactive.internal.builders.RangeObservable.unsafeSubscribeFn(RangeObservable.scala:43)
    	at monix.reactive.internal.operators.DelayExecutionByTimespanObservable$$anon$1.run(DelayExecutionByTimespanObservable.scala:36)
    	at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1402)
    	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
    	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
    	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
    	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)

This seems to happen only when `onError` is called. `onNext` seems to lock an instance of `monix.reactive.internal.builders.CombineLatest2Observable` as I expected. IIUC, anyway it is not a good idea to acquire lock per observable rather than subscription, so I added changes to avoid observable-wide locks.
