### PR TITLE
Observable buffers refactoring

### DIFF
--- a/monix-catnap/shared/src/main/scala/monix/catnap/ConcurrentQueue.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/ConcurrentQueue.scala
@@ -197,6 +197,8 @@ final class ConcurrentQueue[F[_], A] private (
     */
   @UnsafeProtocol
   def tryPoll: F[Option[A]] = tryPollRef
+  private[this] val tryPollRef =
+    F.delay(Option(tryPollUnsafe()))
 
   /** Fetches a value from the queue, or if the queue is empty it awaits
     * asynchronously until a value is made available.
@@ -354,10 +356,6 @@ final class ConcurrentQueue[F[_], A] private (
   private[this] val pollMap: A => A = a => a
   private[this] val offerTest: Boolean => Boolean = x => x
   private[this] val offerMap: Boolean => Unit = _ => ()
-
-  /** Cached implementation for [[tryPoll]]. */
-  private[this] val tryPollRef =
-    F.delay(Option(tryPollUnsafe()))
 
   private def toSeq(buffer: ArrayBuffer[A]): Seq[A] =
     buffer.toArray[Any].toSeq.asInstanceOf[Seq[A]]

--- a/monix-execution/js/src/main/scala/monix/execution/internal/Platform.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/internal/Platform.scala
@@ -43,6 +43,7 @@ private[monix] object Platform {
     *
     * It's always a power of 2, because then for
     * applying the modulo operation we can just do:
+    *
     * {{{
     *   val modulus = Platform.recommendedBatchSize - 1
     *   // ...
@@ -50,6 +51,13 @@ private[monix] object Platform {
     * }}}
     */
   final val recommendedBatchSize: Int = 512
+
+  /** Recommended chunk size in unbounded buffer implementations that are chunked,
+    * or in chunked streams.
+    *
+    * Should be a power of 2.
+    */
+  final val recommendedBufferChunkSize: Int = 128
 
   /**
     * Auto cancelable run loops are set to `false` if Monix

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/Platform.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/Platform.scala
@@ -112,10 +112,11 @@ private[monix] object Platform {
     * which now recommends for this default to be `true` due to the design
     * of its type classes.
     */
-  val autoCancelableRunLoops: Boolean =
+  val autoCancelableRunLoops: Boolean = {
     Option(System.getProperty("monix.environment.autoCancelableRunLoops", ""))
       .map(_.toLowerCase)
       .forall(v => v != "no" && v != "false" && v != "0")
+  }
 
   /**
     * Default value for local context propagation loops is set to

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/Platform.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/Platform.scala
@@ -81,14 +81,14 @@ private[monix] object Platform {
     * Can be configured by setting Java properties:
     *
     * <pre>
-    *   java -Dmonix.environment.recommendedBufferChunkSize=128 \
+    *   java -Dmonix.environment.bufferChunkSize=128 \
     *        ...
     * </pre>
     *
     * Should be a power of 2 or it gets rounded to one.
     */
   val recommendedBufferChunkSize: Int = {
-    Option(System.getProperty("monix.environment.chunkBufferSize", ""))
+    Option(System.getProperty("monix.environment.bufferChunkSize", ""))
       .filter(s => s != null && s.nonEmpty)
       .flatMap(s => Try(s.toInt).toOption)
       .map(math.nextPowerOf2)

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/Platform.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/Platform.scala
@@ -65,6 +65,36 @@ private[monix] object Platform {
       .getOrElse(1024)
   }
 
+  /** Recommended chunk size in unbounded buffer implementations that are chunked,
+    * or in chunked streaming.
+    *
+    * Examples:
+    *
+    *  - the default when no `chunkSizeHint` is specified in
+    *    [[monix.execution.BufferCapacity.Unbounded BufferCapacity.Unbounded]]
+    *  - the chunk size used in
+    *    [[monix.reactive.OverflowStrategy.Unbounded OverflowStrategy.Unbounded]]
+    *  - the default in
+    *    [[monix.tail.Iterant.fromConsumer Iterant.fromConsumer]] or in
+    *    [[monix.tail.Iterant.fromConsumer Iterant.fromChannel]]
+    *
+    * Can be configured by setting Java properties:
+    *
+    * <pre>
+    *   java -Dmonix.environment.recommendedBufferChunkSize=128 \
+    *        ...
+    * </pre>
+    *
+    * Should be a power of 2 or it gets rounded to one.
+    */
+  val recommendedBufferChunkSize: Int = {
+    Option(System.getProperty("monix.environment.chunkBufferSize", ""))
+      .filter(s => s != null && s.nonEmpty)
+      .flatMap(s => Try(s.toInt).toOption)
+      .map(math.nextPowerOf2)
+      .getOrElse(256)
+  }
+
   /** Default value for auto cancelable loops, set to `false`.
     *
     * On top of the JVM the default can be overridden by setting the following

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/FromCircularQueue.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/FromCircularQueue.scala
@@ -31,6 +31,9 @@ private[internal] abstract class FromCircularQueue[A](queue: ConcurrentCircularA
   def fenceOffer(): Unit
   def fencePoll(): Unit
 
+  final def isEmpty: Boolean =
+    queue.isEmpty
+
   final def offer(elem: A): Int =
     if (queue.offer(elem)) 0 else 1
 

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/FromJavaQueue.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/FromJavaQueue.scala
@@ -27,6 +27,9 @@ private[internal] class FromJavaQueue[A](queue: util.Queue[A])
   final def fenceOffer(): Unit = ()
   final def fencePoll(): Unit = ()
 
+  final def isEmpty: Boolean =
+    queue.isEmpty
+
   final def offer(elem: A): Int =
     if (queue.offer(elem)) 0 else 1
 

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/FromMessagePassingQueue.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/FromMessagePassingQueue.scala
@@ -31,6 +31,8 @@ private[internal] abstract class FromMessagePassingQueue[A](queue: MessagePassin
   def fenceOffer(): Unit
   def fencePoll(): Unit
 
+  final def isEmpty: Boolean =
+    queue.isEmpty
   final def offer(elem: A): Int =
     if (queue.offer(elem)) 0 else 1
   final def poll(): A =

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/LowLevelConcurrentQueueBuilders.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/LowLevelConcurrentQueueBuilders.scala
@@ -69,7 +69,8 @@ private[internal] trait LowLevelConcurrentQueueBuilders {
     * Builds an bounded `ConcurrentQueue` reference.
     */
   private def unbounded[A](chunkSize: Option[Int], ct: ChannelType, fenced: Boolean): LowLevelConcurrentQueue[A] = {
-    val chunk = chunkSize.getOrElse(Platform.recommendedBatchSize)
+    val chunk = chunkSize.getOrElse(Platform.recommendedBufferChunkSize)
+
     if (UnsafeAccess.IS_OPENJDK_COMPATIBLE) {
       // Support for memory fences in Unsafe is only available in Java 8+
       if (UnsafeAccess.HAS_JAVA8_INTRINSICS || !fenced) {

--- a/monix-execution/shared/src/main/scala/monix/execution/ChannelType.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/ChannelType.scala
@@ -92,8 +92,15 @@ object ChannelType {
     * Enumeration for describing the type of the producer, with two
     * possible values:
     *
-    *  - [[MultiProducer]]
+    *  - [[MultiProducer]] (default)
     *  - [[SingleProducer]]
+    *
+    * This is often used to optimize the underlying buffer used.
+    * The multi-producer option is the safe default and specifies
+    * that multiple producers (threads, actors, etc) can push events
+    * concurrently, whereas the single-producer option specifies that
+    * a single producer can (sequentially) push events and can be used
+    * as an (unsafe) optimization.
     */
   sealed abstract class ProducerSide(val value: String)
     extends Serializable

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/collection/LowLevelConcurrentQueue.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/collection/LowLevelConcurrentQueue.scala
@@ -18,6 +18,7 @@
 package monix.execution.internal.collection
 
 private[monix] trait LowLevelConcurrentQueue[A] extends Serializable {
+  def isEmpty: Boolean
   def offer(a: A): Int
   def poll(): A
   def drainToBuffer(buffer: scala.collection.mutable.Buffer[A], limit: Int): Int

--- a/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/BuildersImpl.scala
+++ b/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/BuildersImpl.scala
@@ -17,12 +17,14 @@
 
 package monix.reactive.observers.buffers
 
+import monix.execution.ChannelType
+import monix.execution.ChannelType.MultiProducer
 import monix.reactive.OverflowStrategy
 import monix.reactive.OverflowStrategy._
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
 
 private[observers] trait BuildersImpl { self: BufferedSubscriber.type =>
-  def apply[A](subscriber: Subscriber[A], bufferPolicy: OverflowStrategy[A]): Subscriber[A] = {
+  def apply[A](subscriber: Subscriber[A], bufferPolicy: OverflowStrategy[A], producerType: ChannelType.ProducerSide = MultiProducer): Subscriber[A] = {
     bufferPolicy match {
       case Unbounded =>
         SyncBufferedSubscriber.unbounded(subscriber)
@@ -48,7 +50,7 @@ private[observers] trait BuildersImpl { self: BufferedSubscriber.type =>
     }
   }
 
-  def synchronous[A](subscriber: Subscriber[A], bufferPolicy: OverflowStrategy.Synchronous[A]): Subscriber.Sync[A] = {
+  def synchronous[A](subscriber: Subscriber[A], bufferPolicy: OverflowStrategy.Synchronous[A], producerType: ChannelType.ProducerSide = MultiProducer): Subscriber.Sync[A] = {
     bufferPolicy match {
       case Unbounded =>
         SyncBufferedSubscriber.unbounded(subscriber)
@@ -72,6 +74,6 @@ private[observers] trait BuildersImpl { self: BufferedSubscriber.type =>
     }
   }
 
-  def batched[A](underlying: Subscriber[List[A]], bufferSize: Int): Subscriber[A] =
+  def batched[A](underlying: Subscriber[List[A]], bufferSize: Int, producerType: ChannelType.ProducerSide = MultiProducer): Subscriber[A] =
     BatchedBufferedSubscriber(underlying, bufferSize)
 }

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/AbstractBackPressuredBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/AbstractBackPressuredBufferedSubscriber.scala
@@ -17,11 +17,15 @@
 
 package monix.reactive.observers.buffers
 
-import monix.execution.Ack
+import monix.execution.{Ack, ChannelType}
 import monix.execution.Ack.{Continue, Stop}
+import monix.execution.BufferCapacity.Unbounded
+import monix.execution.ChannelType._
 import monix.execution.atomic.Atomic
 import monix.execution.atomic.PaddingStrategy.LeftRight256
-import monix.execution.internal.math
+import monix.execution.internal.collection.LowLevelConcurrentQueue
+import monix.execution.internal.{Platform, math}
+
 import scala.util.control.NonFatal
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
 
@@ -33,7 +37,7 @@ import scala.util.{Failure, Success}
   * [[BatchedBufferedSubscriber]].
   */
 private[observers] abstract class AbstractBackPressuredBufferedSubscriber[A,R]
-  (out: Subscriber[R], _bufferSize: Int)
+  (out: Subscriber[R], _bufferSize: Int, pt: ChannelType.ProducerSide)
   extends CommonBufferMembers with BufferedSubscriber[A] {
 
   require(_bufferSize > 0, "bufferSize must be a strictly positive number")
@@ -42,8 +46,12 @@ private[observers] abstract class AbstractBackPressuredBufferedSubscriber[A,R]
   private[this] val em = out.scheduler.executionModel
   implicit final val scheduler = out.scheduler
 
-  protected final val queue: ConcurrentQueue[A] =
-    ConcurrentQueue.unbounded()
+  protected final val queue: LowLevelConcurrentQueue[A] =
+    LowLevelConcurrentQueue(
+      Unbounded(Some(scala.math.min(Platform.recommendedBatchSize, bufferSize))),
+      ChannelType.assemble(pt, SingleConsumer),
+      fenced = false
+    )
 
   private[this] val itemsToPush =
     Atomic.withPadding(0, LeftRight256)
@@ -64,7 +72,7 @@ private[observers] abstract class AbstractBackPressuredBufferedSubscriber[A,R]
         case Some(v) => v
       }
 
-      backPressured.get match {
+      backPressured.get() match {
         case null =>
           if (toPush < bufferSize) {
             queue.offer(elem)

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/AbstractBackPressuredBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/AbstractBackPressuredBufferedSubscriber.scala
@@ -48,7 +48,7 @@ private[observers] abstract class AbstractBackPressuredBufferedSubscriber[A,R]
 
   protected final val queue: LowLevelConcurrentQueue[A] =
     LowLevelConcurrentQueue(
-      Unbounded(Some(scala.math.min(Platform.recommendedBatchSize, bufferSize))),
+      Unbounded(Some(scala.math.min(Platform.recommendedBufferChunkSize, bufferSize))),
       ChannelType.assemble(pt, SingleConsumer),
       fenced = false
     )
@@ -188,7 +188,7 @@ private[observers] abstract class AbstractBackPressuredBufferedSubscriber[A,R]
     private final def fastLoop(prevAck: Future[Ack], lastProcessed: Int, startIndex: Int): Unit = {
       def stopStreaming(): Unit = {
         downstreamIsComplete = true
-        val bp = backPressured.get
+        val bp = backPressured.get()
         if (bp != null) bp.success(Stop)
       }
 

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/BackPressuredBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/BackPressuredBufferedSubscriber.scala
@@ -17,6 +17,7 @@
 
 package monix.reactive.observers.buffers
 
+import monix.execution.ChannelType
 import monix.reactive.observers.Subscriber
 
 /** A `BufferedSubscriber` implementation for the
@@ -24,8 +25,8 @@ import monix.reactive.observers.Subscriber
   * buffer overflow strategy.
   */
 private[observers] final class BackPressuredBufferedSubscriber[A] private
-  (out: Subscriber[A], _bufferSize: Int)
-  extends AbstractBackPressuredBufferedSubscriber[A,A](out, _bufferSize) {
+  (out: Subscriber[A], _bufferSize: Int, pt: ChannelType.ProducerSide)
+  extends AbstractBackPressuredBufferedSubscriber[A,A](out, _bufferSize, pt) {
 
   @volatile protected var p50, p51, p52, p53, p54, p55, p56, p57 = 5
   @volatile protected var q50, q51, q52, q53, q54, q55, q56, q57 = 5
@@ -38,6 +39,11 @@ private[observers] final class BackPressuredBufferedSubscriber[A] private
 }
 
 private[observers] object BackPressuredBufferedSubscriber {
-  def apply[A](underlying: Subscriber[A], bufferSize: Int): BackPressuredBufferedSubscriber[A] =
-    new BackPressuredBufferedSubscriber[A](underlying, bufferSize)
+  def apply[A](
+    underlying: Subscriber[A],
+    bufferSize: Int,
+    producerType: ChannelType.ProducerSide): BackPressuredBufferedSubscriber[A] = {
+
+    new BackPressuredBufferedSubscriber[A](underlying, bufferSize, producerType)
+  }
 }

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/BatchedBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/BatchedBufferedSubscriber.scala
@@ -17,8 +17,10 @@
 
 package monix.reactive.observers.buffers
 
+import monix.execution.ChannelType
 import monix.execution.internal.Platform
 import monix.reactive.observers.Subscriber
+
 import scala.collection.mutable.ListBuffer
 
 /** A `BufferedSubscriber` implementation for the
@@ -26,9 +28,12 @@ import scala.collection.mutable.ListBuffer
   * buffer overflowStrategy that sends events in bundles.
   */
 private[monix] final class BatchedBufferedSubscriber[A] private
-  (out: Subscriber[List[A]], _bufferSize: Int)
+  (out: Subscriber[List[A]], _bufferSize: Int, pt: ChannelType.ProducerSide)
   extends AbstractBackPressuredBufferedSubscriber[A, ListBuffer[A]](
-    subscriberBufferToList(out), _bufferSize) { self =>
+    subscriberBufferToList(out),
+    _bufferSize,
+    pt
+  ) { self =>
 
   @volatile protected var p50, p51, p52, p53, p54, p55, p56, p57 = 5
   @volatile protected var q50, q51, q52, q53, q54, q55, q56, q57 = 5
@@ -46,6 +51,9 @@ private[monix] final class BatchedBufferedSubscriber[A] private
 
 private[monix] object BatchedBufferedSubscriber {
   /** Builder for [[BatchedBufferedSubscriber]] */
-  def apply[A](underlying: Subscriber[List[A]], bufferSize: Int): BatchedBufferedSubscriber[A] =
-    new BatchedBufferedSubscriber[A](underlying, bufferSize)
+  def apply[A](
+    underlying: Subscriber[List[A]],
+    bufferSize: Int,
+    producerType: ChannelType.ProducerSide): BatchedBufferedSubscriber[A] =
+    new BatchedBufferedSubscriber[A](underlying, bufferSize, producerType)
 }

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/ConcurrentQueue.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/ConcurrentQueue.scala
@@ -42,10 +42,10 @@ private[buffers] object ConcurrentQueue {
     val maxCapacity = math.max(4, nextPowerOf2(capacity))
     if (UnsafeAccess.IS_OPENJDK_COMPATIBLE) {
       new FromMessagePassingQueue[A](
-        if (maxCapacity <= Platform.recommendedBatchSize)
+        if (maxCapacity <= Platform.recommendedBufferChunkSize)
           new MpscArrayQueue[A](maxCapacity)
         else {
-          val initialCapacity = math.min(Platform.recommendedBatchSize, maxCapacity / 2)
+          val initialCapacity = math.min(Platform.recommendedBufferChunkSize, maxCapacity / 2)
           new MpscChunkedArrayQueue[A](initialCapacity, maxCapacity)
         }
       )
@@ -58,7 +58,7 @@ private[buffers] object ConcurrentQueue {
   /** Builds an unbounded queue. */
   def unbounded[A](): ConcurrentQueue[A] = {
     if (UnsafeAccess.IS_OPENJDK_COMPATIBLE) {
-      val size = Platform.recommendedBatchSize
+      val size = Platform.recommendedBufferChunkSize
       new FromMessagePassingQueue[A](new MpscUnboundedArrayQueue[A](size))
     }
     else {

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/DropNewBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/DropNewBufferedSubscriber.scala
@@ -17,10 +17,12 @@
 
 package monix.reactive.observers.buffers
 
+import monix.eval.Coeval
 import monix.execution.Ack
 import monix.execution.Ack.{Continue, Stop}
 import monix.execution.atomic.PaddingStrategy.{LeftRight128, LeftRight256}
 import monix.execution.atomic.{Atomic, AtomicInt}
+
 import scala.util.control.NonFatal
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
 
@@ -33,7 +35,7 @@ import scala.util.{Failure, Success}
   * overflow strategies.
   */
 private[observers] final class DropNewBufferedSubscriber[A] private
-  (out: Subscriber[A], bufferSize: Int, onOverflow: Long => Option[A] = null)
+  (out: Subscriber[A], bufferSize: Int, onOverflow: Long => Coeval[Option[A]] = null)
   extends CommonBufferMembers with BufferedSubscriber[A] with Subscriber.Sync[A] {
 
   require(bufferSize > 0, "bufferSize must be a strictly positive number")
@@ -170,7 +172,7 @@ private[observers] final class DropNewBufferedSubscriber[A] private
               if (onOverflow == null || droppedCount.get == 0)
                 null.asInstanceOf[A]
               else
-                onOverflow(droppedCount.getAndSet(0)) match {
+                onOverflow(droppedCount.getAndSet(0)).value() match {
                   case Some(value) => value
                   case None => null.asInstanceOf[A]
                 }
@@ -271,7 +273,7 @@ private[observers] object DropNewBufferedSubscriber {
     * [[monix.reactive.OverflowStrategy.DropNewAndSignal DropNewAndSignal]]
     * overflowStrategy.
     */
-  def withSignal[A](underlying: Subscriber[A], bufferSize: Int, onOverflow: Long => Option[A]): DropNewBufferedSubscriber[A] =
+  def withSignal[A](underlying: Subscriber[A], bufferSize: Int, onOverflow: Long => Coeval[Option[A]]): DropNewBufferedSubscriber[A] =
     new DropNewBufferedSubscriber[A](underlying, bufferSize, onOverflow)
 }
 

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/SimpleBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/SimpleBufferedSubscriber.scala
@@ -17,12 +17,16 @@
 
 package monix.reactive.observers.buffers
 
-import monix.execution.Ack
+import monix.execution.{Ack, ChannelType}
 import monix.execution.Ack.{Continue, Stop}
+import monix.execution.BufferCapacity.{Bounded, Unbounded}
+import monix.execution.ChannelType.SingleConsumer
 import monix.execution.atomic.Atomic
 import monix.execution.atomic.PaddingStrategy.LeftRight256
 import monix.execution.exceptions.BufferOverflowException
+import monix.execution.internal.collection.LowLevelConcurrentQueue
 import monix.execution.internal.math.nextPowerOf2
+
 import scala.util.control.NonFatal
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
 
@@ -41,7 +45,7 @@ import scala.util.{Failure, Success}
   * used with care, since it can eat the whole heap memory.
   */
 private[observers] final class SimpleBufferedSubscriber[A] protected
-  (out: Subscriber[A], _qRef: ConcurrentQueue[A], capacity: Int)
+  (out: Subscriber[A], _qRef: LowLevelConcurrentQueue[A], capacity: Int)
   extends AbstractSimpleBufferedSubscriber[A](out, _qRef, capacity) {
 
   @volatile protected var p50, p51, p52, p53, p54, p55, p56, p57 = 5
@@ -49,7 +53,7 @@ private[observers] final class SimpleBufferedSubscriber[A] protected
 }
 
 private[observers] abstract class AbstractSimpleBufferedSubscriber[A] protected
-  (out: Subscriber[A], _qRef: ConcurrentQueue[A], capacity: Int)
+  (out: Subscriber[A], _qRef: LowLevelConcurrentQueue[A], capacity: Int)
   extends CommonBufferMembers with BufferedSubscriber[A] with Subscriber.Sync[A] {
 
   private[this] val queue = _qRef
@@ -65,11 +69,10 @@ private[observers] abstract class AbstractSimpleBufferedSubscriber[A] protected
         Stop
       }
       else try {
-        if (queue.offer(elem)) {
+        if (queue.offer(elem) == 0) {
           pushToConsumer()
           Continue
-        }
-        else {
+        } else {
           onError(BufferOverflowException(
             s"Downstream observer is too slow, buffer overflowed with a " +
             s"specified maximum capacity of $capacity"
@@ -249,14 +252,16 @@ private[observers] abstract class AbstractSimpleBufferedSubscriber[A] protected
 }
 
 private[observers] object SimpleBufferedSubscriber {
-  def unbounded[A](underlying: Subscriber[A]): SimpleBufferedSubscriber[A] = {
-    val queue = ConcurrentQueue.unbounded[A]()
+  def unbounded[A](underlying: Subscriber[A], chunkSizeHint: Option[Int], pt: ChannelType.ProducerSide): SimpleBufferedSubscriber[A] = {
+    val ct = ChannelType.assemble(pt, SingleConsumer)
+    val queue = LowLevelConcurrentQueue[A](Unbounded(chunkSizeHint), ct, fenced = false)
     new SimpleBufferedSubscriber[A](underlying, queue, Int.MaxValue)
   }
 
-  def overflowTriggering[A](underlying: Subscriber[A], bufferSize: Int): SimpleBufferedSubscriber[A] = {
+  def overflowTriggering[A](underlying: Subscriber[A], bufferSize: Int, pt: ChannelType.ProducerSide): SimpleBufferedSubscriber[A] = {
     val maxCapacity = math.max(4, nextPowerOf2(bufferSize))
-    val queue = ConcurrentQueue.limited[A](bufferSize)
+    val ct = ChannelType.assemble(pt, SingleConsumer)
+    val queue = LowLevelConcurrentQueue[A](Bounded(bufferSize), ct, fenced = false)
     new SimpleBufferedSubscriber[A](underlying, queue, maxCapacity)
   }
 }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/OverflowStrategy.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/OverflowStrategy.scala
@@ -45,7 +45,7 @@ object OverflowStrategy {
     * Using this overflowStrategy implies that with a fast data source, the system's
     * memory can be exhausted and the process might blow up on lack of memory.
     */
-  case object Unbounded extends Synchronous[Nothing]
+  final case object Unbounded extends Synchronous[Nothing]
 
   /** A [[OverflowStrategy]] specifying that on reaching the maximum size,
     * the pipeline should cancel the subscription and send an `onError`

--- a/monix-reactive/shared/src/main/scala/monix/reactive/OverflowStrategy.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/OverflowStrategy.scala
@@ -17,6 +17,7 @@
 
 package monix.reactive
 
+import monix.eval.Coeval
 import monix.execution.internal.Platform
 
 /** Represents the buffering overflowStrategy chosen for actions that
@@ -70,7 +71,7 @@ object OverflowStrategy {
   final case class BackPressure(bufferSize: Int)
     extends OverflowStrategy[Nothing] {
 
-    require(bufferSize > 1, "bufferSize should be strictly greater than 1")
+    require(bufferSize > 1, "bufferSize must be strictly greater than 1")
   }
 
   /** A [[OverflowStrategy]] specifying that on reaching the maximum size,
@@ -83,7 +84,7 @@ object OverflowStrategy {
   final case class DropNew(bufferSize: Int)
     extends Evicted[Nothing] {
 
-    require(bufferSize > 1, "bufferSize should be strictly greater than 1")
+    require(bufferSize > 1, "bufferSize must be strictly greater than 1")
   }
 
   /** A [[OverflowStrategy]] specifying that on reaching the maximum size,
@@ -103,10 +104,10 @@ object OverflowStrategy {
     *        a new message that will be sent to downstream. If it returns
     *        `None`, then no message gets sent to downstream.
     */
-  final case class DropNewAndSignal[A](bufferSize: Int, onOverflow: Long => Option[A])
+  final case class DropNewAndSignal[A](bufferSize: Int, onOverflow: Long => Coeval[Option[A]])
     extends Evicted[A] {
 
-    require(bufferSize > 1, "bufferSize should be strictly greater than 1")
+    require(bufferSize > 1, "bufferSize must be strictly greater than 1")
   }
 
   /** A [[OverflowStrategy]] specifying that on reaching the maximum size,
@@ -119,7 +120,7 @@ object OverflowStrategy {
   final case class DropOld(bufferSize: Int)
     extends Evicted[Nothing] {
 
-    require(bufferSize > 1, "bufferSize should be strictly greater than 1")
+    require(bufferSize > 1, "bufferSize must be strictly greater than 1")
   }
 
   /** A [[OverflowStrategy]] specifying that on reaching the maximum size,
@@ -139,10 +140,10 @@ object OverflowStrategy {
     *        a new message that will be sent to downstream. If it returns
     *        `None`, then no message gets sent to downstream.
     */
-  final case class DropOldAndSignal[A](bufferSize: Int, onOverflow: Long => Option[A])
+  final case class DropOldAndSignal[A](bufferSize: Int, onOverflow: Long => Coeval[Option[A]])
     extends Evicted[A] {
 
-    require(bufferSize > 1, "bufferSize should be strictly greater than 1")
+    require(bufferSize > 1, "bufferSize must be strictly greater than 1")
   }
 
   /** A [[OverflowStrategy]] specifying that on reaching the maximum size,
@@ -155,7 +156,7 @@ object OverflowStrategy {
   final case class ClearBuffer(bufferSize: Int)
     extends Evicted[Nothing] {
 
-    require(bufferSize > 1, "bufferSize should be strictly greater than 1")
+    require(bufferSize > 1, "bufferSize must be strictly greater than 1")
   }
 
   /** A [[OverflowStrategy]] specifying that on reaching the maximum size,
@@ -174,10 +175,10 @@ object OverflowStrategy {
     *        a number of messages that were dropped, a function that builds
     *        a new message that will be sent to downstream.
     */
-  final case class ClearBufferAndSignal[A](bufferSize: Int, onOverflow: Long => Option[A])
+  final case class ClearBufferAndSignal[A](bufferSize: Int, onOverflow: Long => Coeval[Option[A]])
     extends Evicted[A] {
 
-    require(bufferSize > 1, "bufferSize should be strictly greater than 1")
+    require(bufferSize > 1, "bufferSize must be strictly greater than 1")
   }
 
   /** A category of [[OverflowStrategy]] for buffers that can be used

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Pipe.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Pipe.scala
@@ -17,7 +17,9 @@
 
 package monix.reactive
 
-import monix.execution.Scheduler
+import monix.execution.ChannelType.MultiProducer
+import monix.execution.{ChannelType, Scheduler}
+
 import scala.util.control.NonFatal
 import monix.reactive.Observable.Operator
 import monix.reactive.OverflowStrategy.{Synchronous, Unbounded}
@@ -64,9 +66,27 @@ abstract class Pipe[I, +O] extends Serializable {
     * @param strategy is the [[OverflowStrategy]] used for the underlying
     *                 multi-producer/single-consumer buffer
     */
-  def concurrent(strategy: Synchronous[I])(implicit s: Scheduler): (Observer.Sync[I], Observable[O]) = {
+  def concurrent(strategy: Synchronous[I])(implicit s: Scheduler): (Observer.Sync[I], Observable[O]) =
+    concurrent(strategy, MultiProducer)
+
+
+  /** Returns an input/output pair with an input that can be
+    * used synchronously and concurrently (without back-pressure or
+    * multi-threading issues) to push signals to multiple subscribers.
+    *
+    * @param strategy is the [[OverflowStrategy]] used for the underlying
+    *                 multi-producer/single-consumer buffer
+    *
+    * @param producerType specifies the
+    *        [[monix.execution.ChannelType.ProducerSide ChannelType.ProducerSide]],
+    *        which configures the type of the producer, for performance optimization;
+    *        can be multi producer (the default) or single producer
+    */
+  def concurrent(strategy: Synchronous[I], producerType: ChannelType.ProducerSide)
+    (implicit s: Scheduler): (Observer.Sync[I], Observable[O]) = {
+
     val (in,out) = multicast(s)
-    val buffer = BufferedSubscriber.synchronous[I](Subscriber(in, s), strategy)
+    val buffer = BufferedSubscriber.synchronous[I](Subscriber(in, s), strategy, producerType)
     (buffer, out)
   }
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CreateObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CreateObservable.scala
@@ -18,6 +18,7 @@
 package monix.reactive.internal.builders
 
 import monix.execution.Cancelable
+import monix.execution.ChannelType.MultiProducer
 import scala.util.control.NonFatal
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
 import monix.reactive.{Observable, OverflowStrategy}
@@ -29,7 +30,7 @@ private[reactive] final class CreateObservable[+A](
   extends Observable[A] {
 
   def unsafeSubscribeFn(subscriber: Subscriber[A]): Cancelable = {
-    val out = BufferedSubscriber.synchronous(subscriber, overflowStrategy)
+    val out = BufferedSubscriber.synchronous(subscriber, overflowStrategy, MultiProducer)
     try f(out) catch {
       case ex if NonFatal(ex) =>
         subscriber.scheduler.reportFailure(ex)

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CreateObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CreateObservable.scala
@@ -17,8 +17,7 @@
 
 package monix.reactive.internal.builders
 
-import monix.execution.Cancelable
-import monix.execution.ChannelType.MultiProducer
+import monix.execution.{Cancelable, ChannelType}
 import scala.util.control.NonFatal
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
 import monix.reactive.{Observable, OverflowStrategy}
@@ -26,11 +25,12 @@ import monix.reactive.{Observable, OverflowStrategy}
 /** Implementation for [[monix.reactive.Observable.create]]. */
 private[reactive] final class CreateObservable[+A](
   overflowStrategy: OverflowStrategy.Synchronous[A],
+  producerType: ChannelType.ProducerSide,
   f: Subscriber.Sync[A] => Cancelable)
   extends Observable[A] {
 
   def unsafeSubscribeFn(subscriber: Subscriber[A]): Cancelable = {
-    val out = BufferedSubscriber.synchronous(subscriber, overflowStrategy, MultiProducer)
+    val out = BufferedSubscriber.synchronous(subscriber, overflowStrategy, producerType)
     try f(out) catch {
       case ex if NonFatal(ex) =>
         subscriber.scheduler.reportFailure(ex)

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/AsyncBoundaryOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/AsyncBoundaryOperator.scala
@@ -17,6 +17,7 @@
 
 package monix.reactive.internal.operators
 
+import monix.execution.ChannelType.SingleProducer
 import monix.reactive.Observable.Operator
 import monix.reactive.OverflowStrategy
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
@@ -26,5 +27,5 @@ class AsyncBoundaryOperator[A](overflowStrategy: OverflowStrategy[A])
   extends Operator[A,A] {
 
   def apply(out: Subscriber[A]): Subscriber[A] =
-    BufferedSubscriber(out, overflowStrategy)
+    BufferedSubscriber(out, overflowStrategy, SingleProducer)
 }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferIntrospectiveObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferIntrospectiveObservable.scala
@@ -18,6 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Cancelable
+import monix.execution.ChannelType.SingleProducer
 import monix.reactive.Observable
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
 
@@ -26,5 +27,5 @@ class BufferIntrospectiveObservable[+A](source: Observable[A], maxSize: Int)
   extends Observable[List[A]] {
 
   def unsafeSubscribeFn(subscriber: Subscriber[List[A]]): Cancelable =
-    source.unsafeSubscribeFn(BufferedSubscriber.batched(subscriber, maxSize))
+    source.unsafeSubscribeFn(BufferedSubscriber.batched(subscriber, maxSize, SingleProducer))
 }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapParallelOrderedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapParallelOrderedObservable.scala
@@ -24,6 +24,7 @@ import monix.eval.Task
 import monix.execution.Ack.{Continue, Stop}
 import monix.execution.cancelables.{CompositeCancelable, SingleAssignCancelable}
 import monix.execution.AsyncSemaphore
+import monix.execution.ChannelType.MultiProducer
 import monix.execution.{Ack, Cancelable, CancelableFuture}
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
 import monix.reactive.{Observable, OverflowStrategy}
@@ -64,7 +65,7 @@ private[reactive] final class MapParallelOrderedObservable[A, B](
     // everything gets canceled at once
     private[this] val releaseTask = Task.eval(semaphore.release())
     // Buffer with the supplied  overflow strategy.
-    private[this] val buffer = BufferedSubscriber[B](out, overflowStrategy)
+    private[this] val buffer = BufferedSubscriber[B](out, overflowStrategy, MultiProducer)
 
     // Flag indicating whether a final event was called, after which
     // nothing else can happen. It's a very light protection, as

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapParallelUnorderedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapParallelUnorderedObservable.scala
@@ -20,9 +20,11 @@ package monix.reactive.internal.operators
 import monix.execution.{Ack, AsyncSemaphore, Callback, Cancelable}
 import monix.eval.Task
 import monix.execution.Ack.{Continue, Stop}
+import monix.execution.ChannelType.MultiProducer
 import monix.execution.cancelables.{CompositeCancelable, SingleAssignCancelable}
 import monix.reactive.{Observable, OverflowStrategy}
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
+
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}
@@ -75,7 +77,7 @@ private[reactive] final class MapParallelUnorderedObservable[A,B](
     // everything gets canceled at once
     private[this] val releaseTask = Task.eval(semaphore.release())
     // Buffer with the supplied  overflow strategy.
-    private[this] val buffer = BufferedSubscriber[B](out, overflowStrategy)
+    private[this] val buffer = BufferedSubscriber[B](out, overflowStrategy, MultiProducer)
 
     // Flag indicating whether a final event was called, after which
     // nothing else can happen. It's a very light protection, as

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MergeMapObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MergeMapObservable.scala
@@ -18,6 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.{Continue, Stop}
+import monix.execution.ChannelType.MultiProducer
 import monix.execution.{Ack, Cancelable}
 import monix.execution.cancelables._
 import monix.execution.exceptions.CompositeException
@@ -25,7 +26,6 @@ import monix.reactive.observers.{BufferedSubscriber, Subscriber}
 import monix.reactive.{Observable, OverflowStrategy}
 import monix.execution.atomic.Atomic
 import scala.util.control.NonFatal
-
 import scala.collection.mutable
 
 private[reactive] final class MergeMapObservable[A,B](
@@ -41,7 +41,7 @@ private[reactive] final class MergeMapObservable[A,B](
     composite += source.unsafeSubscribeFn(new Subscriber[A] {
       implicit val scheduler = downstream.scheduler
       private[this] val subscriberB: Subscriber[B] =
-        BufferedSubscriber(downstream, overflowStrategy)
+        BufferedSubscriber(downstream, overflowStrategy, MultiProducer)
 
       private[this] val upstreamIsDone = Atomic(false)
       private[this] val errors = if (delayErrors)

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ObserveOnObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ObserveOnObservable.scala
@@ -17,6 +17,7 @@
 
 package monix.reactive.internal.operators
 
+import monix.execution.ChannelType.SingleProducer
 import monix.execution.{Ack, Cancelable, Scheduler}
 import monix.reactive.{Observable, OverflowStrategy}
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
@@ -39,7 +40,7 @@ class ObserveOnObservable[+A](source: Observable[A], altS: Scheduler, os: Overfl
         def onComplete() = out.onComplete()
       }
 
-      BufferedSubscriber(ref, os)
+      BufferedSubscriber(ref, os, SingleProducer)
     }
 
     // Unfortunately we have to do double wrapping of our Subscriber,

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/rstreams/SubscriberAsReactiveSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/rstreams/SubscriberAsReactiveSubscriber.scala
@@ -19,11 +19,13 @@ package monix.reactive.internal.rstreams
 
 import monix.execution.Ack
 import monix.execution.Ack.{Continue, Stop}
+import monix.execution.ChannelType.SingleProducer
 import monix.execution.rstreams.SingleAssignSubscription
 import monix.execution.schedulers.TrampolineExecutionContext.immediate
 import monix.reactive.OverflowStrategy.Unbounded
 import monix.reactive.observers.{BufferedSubscriber, Subscriber}
 import org.reactivestreams.{Subscriber => RSubscriber, Subscription => RSubscription}
+
 import scala.concurrent.Future
 
 private[reactive] object SubscriberAsReactiveSubscriber {
@@ -35,7 +37,7 @@ private[reactive] object SubscriberAsReactiveSubscriber {
     * the call may pass asynchronous boundaries, the emitted events need to be buffered.
     * The `requestCount` constructor parameter also represents the buffer size.
     *
-    * To async an instance, [[SubscriberAsReactiveSubscriber.apply]] must be used: 
+    * To async an instance, [[SubscriberAsReactiveSubscriber.apply]] must be used:
     * {{{
     *   // uses the default requestCount of 128
     *   val subscriber = SubscriberAsReactiveSubscriber(new Observer[Int] {
@@ -151,7 +153,7 @@ private[reactive] final class AsyncSubscriberAsReactiveSubscriber[A]
 
 
   private[this] val buffer: Subscriber.Sync[A] =
-    BufferedSubscriber.synchronous(downstream, Unbounded)
+    BufferedSubscriber.synchronous(downstream, Unbounded, SingleProducer)
 
   def onSubscribe(s: RSubscription): Unit =
     subscription := s

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observers/BufferedSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observers/BufferedSubscriber.scala
@@ -17,6 +17,8 @@
 
 package monix.reactive.observers
 
+import monix.execution.ChannelType
+import monix.execution.ChannelType.MultiProducer
 import monix.reactive.OverflowStrategy
 import monix.reactive.observers.buffers.BuildersImpl
 
@@ -67,12 +69,18 @@ private[reactive] trait Builders {
   /** Given an [[OverflowStrategy]] wraps a [[Subscriber]] into a
     * buffered subscriber.
     */
-  def apply[A](subscriber: Subscriber[A], bufferPolicy: OverflowStrategy[A]): Subscriber[A]
+  def apply[A](
+    subscriber: Subscriber[A],
+    bufferPolicy: OverflowStrategy[A],
+    producerType: ChannelType.ProducerSide = MultiProducer): Subscriber[A]
 
   /** Given an synchronous [[OverflowStrategy overflow strategy]] wraps
     * a [[Subscriber]] into a buffered subscriber.
     */
-  def synchronous[A](subscriber: Subscriber[A], bufferPolicy: OverflowStrategy.Synchronous[A]): Subscriber.Sync[A]
+  def synchronous[A](
+    subscriber: Subscriber[A],
+    bufferPolicy: OverflowStrategy.Synchronous[A],
+    producerType: ChannelType.ProducerSide = MultiProducer): Subscriber.Sync[A]
 
   /** Builds a batched buffered subscriber.
     *
@@ -86,7 +94,10 @@ private[reactive] trait Builders {
     * So a batched buffered subscriber is implicitly delivering
     * the back-pressure overflow strategy.
     */
-  def batched[A](underlying: Subscriber[List[A]], bufferSize: Int): Subscriber[A]
+  def batched[A](
+    underlying: Subscriber[List[A]],
+    bufferSize: Int,
+    producerType: ChannelType.ProducerSide = MultiProducer): Subscriber[A]
 }
 
 object BufferedSubscriber extends Builders with BuildersImpl

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observers/BufferedSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observers/BufferedSubscriber.scala
@@ -60,7 +60,7 @@ import monix.reactive.observers.buffers.BuildersImpl
   *    upstream data sources, or dropping events from the head or the
   *    tail of the queue, or attempting to apply back-pressure, etc...
   *
-  * See [[OverflowStrategy OverflowStrategy]] for the buffer
+  * See [[monix.reactive.OverflowStrategy OverflowStrategy]] for the buffer
   * policies available.
   */
 trait BufferedSubscriber[-A] extends Subscriber[A]

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressureBatchedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressureBatchedSuite.scala
@@ -20,8 +20,10 @@ package monix.reactive.observers
 import minitest.TestSuite
 import monix.execution.Ack
 import monix.execution.Ack.{Continue, Stop}
+import monix.execution.ChannelType.MultiProducer
 import monix.execution.schedulers.TestScheduler
 import monix.execution.exceptions.DummyException
+
 import scala.concurrent.{Future, Promise}
 import scala.util.Success
 
@@ -38,6 +40,7 @@ object OverflowStrategyBackPressureBatchedSuite extends TestSuite[TestScheduler]
 
     val buffer = BufferedSubscriber.batched[Int](
       bufferSize = 5,
+      producerType = MultiProducer,
       underlying = new Subscriber[List[Int]] {
         def onNext(elem: List[Int]) = promise.future
         def onError(ex: Throwable) = throw new IllegalStateException()
@@ -98,7 +101,7 @@ object OverflowStrategyBackPressureBatchedSuite extends TestSuite[TestScheduler]
       }
     }
 
-    val buffer = BufferedSubscriber.batched[Int](underlying, 1000)
+    val buffer = BufferedSubscriber.batched[Int](underlying, 1000, MultiProducer)
     for (i <- 0 until 1000) buffer.onNext(i)
     buffer.onComplete()
 
@@ -129,7 +132,7 @@ object OverflowStrategyBackPressureBatchedSuite extends TestSuite[TestScheduler]
       }
     }
 
-    val buffer = BufferedSubscriber.batched[Int](underlying, 1000)
+    val buffer = BufferedSubscriber.batched[Int](underlying, 1000, MultiProducer)
     def loop(n: Int): Unit =
       if (n > 0)
         s.executeAsync { () => buffer.onNext(n); loop(n-1) }
@@ -166,7 +169,7 @@ object OverflowStrategyBackPressureBatchedSuite extends TestSuite[TestScheduler]
       }
     }
 
-    val buffer = BufferedSubscriber.batched[Int](underlying, 512)
+    val buffer = BufferedSubscriber.batched[Int](underlying, 512, MultiProducer)
     def loop(n: Int): Unit =
       if (n > 0)
         s.executeAsync { () => buffer.onNext(n); loop(n-1) }
@@ -191,7 +194,7 @@ object OverflowStrategyBackPressureBatchedSuite extends TestSuite[TestScheduler]
       val scheduler = s
     }
 
-    val buffer = BufferedSubscriber.batched(underlying, 5)
+    val buffer = BufferedSubscriber.batched(underlying, 5, MultiProducer)
     buffer.onError(DummyException("dummy"))
     s.tickOne()
 
@@ -210,7 +213,7 @@ object OverflowStrategyBackPressureBatchedSuite extends TestSuite[TestScheduler]
       val scheduler = s
     }
 
-    val buffer = BufferedSubscriber.batched(underlying, 5)
+    val buffer = BufferedSubscriber.batched(underlying, 5, MultiProducer)
     buffer.onNext(1)
     buffer.onError(DummyException("dummy"))
 
@@ -229,7 +232,7 @@ object OverflowStrategyBackPressureBatchedSuite extends TestSuite[TestScheduler]
       val scheduler = s
     }
 
-    val buffer = BufferedSubscriber.batched(underlying, 5)
+    val buffer = BufferedSubscriber.batched(underlying, 5, MultiProducer)
     for (i <- 0 until 20) buffer.onNext(i)
     buffer.onError(DummyException("dummy"))
 
@@ -246,7 +249,7 @@ object OverflowStrategyBackPressureBatchedSuite extends TestSuite[TestScheduler]
       def onComplete() = wasCompleted = true
     }
 
-    val buffer = BufferedSubscriber.batched(underlying, 8)
+    val buffer = BufferedSubscriber.batched(underlying, 8, MultiProducer)
     buffer.onComplete()
 
     s.tickOne()
@@ -264,7 +267,7 @@ object OverflowStrategyBackPressureBatchedSuite extends TestSuite[TestScheduler]
       def onComplete() = wasCompleted = true
     }
 
-    val buffer = BufferedSubscriber.batched(underlying, 8)
+    val buffer = BufferedSubscriber.batched(underlying, 8, MultiProducer)
     buffer.onNext(1)
     buffer.onComplete()
 

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyClearBufferAndSignalSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyClearBufferAndSignalSuite.scala
@@ -18,6 +18,7 @@
 package monix.reactive.observers
 
 import minitest.TestSuite
+import monix.eval.Coeval
 import monix.execution.Ack.{Continue, Stop}
 import monix.execution.atomic.AtomicLong
 import monix.execution.internal.{Platform, RunnableAction}
@@ -26,6 +27,7 @@ import monix.execution.{Ack, Scheduler}
 import monix.reactive.Observer
 import monix.reactive.OverflowStrategy.ClearBufferAndSignal
 import monix.execution.exceptions.DummyException
+
 import scala.concurrent.{Future, Promise}
 
 object OverflowStrategyClearBufferAndSignalSuite extends TestSuite[TestScheduler] {
@@ -39,14 +41,14 @@ object OverflowStrategyClearBufferAndSignalSuite extends TestSuite[TestScheduler
     (implicit s: Scheduler) = {
 
     BufferedSubscriber(Subscriber(underlying, s),
-      ClearBufferAndSignal(bufferSize, nr => Some(nr.toInt)))
+      ClearBufferAndSignal(bufferSize, nr => Coeval(Some(nr.toInt))))
   }
 
   def buildNewWithLog(bufferSize: Int, underlying: Observer[Int], log: AtomicLong)
     (implicit s: Scheduler) = {
 
     BufferedSubscriber[Int](Subscriber(underlying, s),
-      ClearBufferAndSignal(bufferSize, { nr => log.set(nr); None }))
+      ClearBufferAndSignal(bufferSize, nr => Coeval { log.set(nr); None }))
   }
 
   test("should not lose events, test 1") { implicit s =>
@@ -187,10 +189,10 @@ object OverflowStrategyClearBufferAndSignalSuite extends TestSuite[TestScheduler
 
     if (Platform.isJVM) {
       assertEquals(received, 28 + (2000 to 2004).sum)
-      assertEquals(log.get, 2000)
+      assertEquals(log.get(), 2000)
     }
     else {
-      assertEquals(log.get, 2002)
+      assertEquals(log.get(), 2002)
       assertEquals(received, 28 + (2002 to 2004).sum)
     }
 

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewAndSignalSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewAndSignalSuite.scala
@@ -18,6 +18,7 @@
 package monix.reactive.observers
 
 import minitest.TestSuite
+import monix.eval.Coeval
 import monix.execution.Ack.{Continue, Stop}
 import monix.execution.atomic.AtomicLong
 import monix.execution.internal.Platform
@@ -26,6 +27,7 @@ import monix.execution.{Ack, Scheduler}
 import monix.reactive.Observer
 import monix.reactive.OverflowStrategy.DropNewAndSignal
 import monix.execution.exceptions.DummyException
+
 import scala.concurrent.Promise
 
 object OverflowStrategyDropNewAndSignalSuite extends TestSuite[TestScheduler] {
@@ -37,14 +39,14 @@ object OverflowStrategyDropNewAndSignalSuite extends TestSuite[TestScheduler] {
 
   def buildNewForIntWithSignal(bufferSize: Int, underlying: Observer[Int])
     (implicit s: Scheduler) =
-    BufferedSubscriber(Subscriber(underlying, s), DropNewAndSignal(bufferSize, nr => Some(nr.toInt)))
+    BufferedSubscriber(Subscriber(underlying, s), DropNewAndSignal(bufferSize, nr => Coeval(Some(nr.toInt))))
 
   def buildNewForIntWithLog(bufferSize: Int, underlying: Observer[Int], log: AtomicLong)
     (implicit s: Scheduler) =
-    BufferedSubscriber(Subscriber(underlying, s), DropNewAndSignal[Int](bufferSize, { nr => log.set(nr); None }))
+    BufferedSubscriber(Subscriber(underlying, s), DropNewAndSignal[Int](bufferSize, nr => Coeval { log.set(nr); None }))
 
   def buildNewForLongWithSignal(bufferSize: Int, underlying: Observer[Long])(implicit s: Scheduler) = {
-    BufferedSubscriber(Subscriber(underlying, s), DropNewAndSignal(bufferSize, nr => Some(nr)))
+    BufferedSubscriber(Subscriber(underlying, s), DropNewAndSignal(bufferSize, nr => Coeval(Some(nr))))
   }
 
   test("should not lose events, test 1") { implicit s =>
@@ -184,12 +186,12 @@ object OverflowStrategyDropNewAndSignalSuite extends TestSuite[TestScheduler] {
 
     promise.success(Continue); s.tick()
     assertEquals(received, (1 to 9).sum)
-    assertEquals(log.get, 5)
+    assertEquals(log.get(), 5)
     for (i <- 1 to 8) assertEquals(buffer.onNext(i), Continue)
 
     s.tick()
     assertEquals(received, (1 to 8).sum * 2 + 9)
-    assertEquals(log.get, 5)
+    assertEquals(log.get(), 5)
 
     buffer.onComplete(); s.tick()
     assert(wasCompleted, "wasCompleted should be true")

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropOldAndSignalSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropOldAndSignalSuite.scala
@@ -18,7 +18,9 @@
 package monix.reactive.observers
 
 import minitest.TestSuite
+import monix.eval.Coeval
 import monix.execution.Ack.{Continue, Stop}
+import monix.execution.ChannelType.MultiProducer
 import monix.execution.atomic.AtomicLong
 import monix.execution.internal.{Platform, RunnableAction}
 import monix.execution.schedulers.TestScheduler
@@ -26,6 +28,7 @@ import monix.execution.{Ack, Scheduler}
 import monix.reactive.Observer
 import monix.reactive.OverflowStrategy.DropOldAndSignal
 import monix.execution.exceptions.DummyException
+
 import scala.concurrent.{Future, Promise}
 
 object OverflowStrategyDropOldAndSignalSuite extends TestSuite[TestScheduler] {
@@ -39,14 +42,20 @@ object OverflowStrategyDropOldAndSignalSuite extends TestSuite[TestScheduler] {
     (implicit s: Scheduler) = {
 
     BufferedSubscriber.synchronous(
-      Subscriber(underlying, s), DropOldAndSignal(bufferSize, nr => Some(nr.toInt)))
+      Subscriber(underlying, s),
+      DropOldAndSignal(bufferSize, nr => Coeval(Some(nr.toInt))),
+      MultiProducer
+    )
   }
 
   def buildNewWithLog(bufferSize: Int, underlying: Observer[Int], log: AtomicLong)
     (implicit s: Scheduler) = {
 
     BufferedSubscriber.synchronous[Int](
-      Subscriber(underlying, s), DropOldAndSignal(bufferSize, { nr => log.set(nr); None }))
+      Subscriber(underlying, s),
+      DropOldAndSignal(bufferSize, nr => Coeval { log.set(nr); None }),
+      MultiProducer
+    )
   }
 
   test("should not lose events, test 1") { implicit s =>
@@ -190,14 +199,14 @@ object OverflowStrategyDropOldAndSignalSuite extends TestSuite[TestScheduler] {
     val dropped = if (Platform.isJVM) 993 else 986
 
     assertEquals(received, (first to 1100).sum + 28)
-    assertEquals(log.get, dropped)
+    assertEquals(log.get(), dropped)
 
     log.set(0)
     assertEquals(buffer.onNext(42), Continue)
 
     s.tick()
 
-    assertEquals(log.get, 0)
+    assertEquals(log.get(), 0)
 
     buffer.onComplete(); s.tick()
     assert(wasCompleted, "wasCompleted should be true")

--- a/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
@@ -30,7 +30,7 @@ import monix.execution.ChannelType.{MultiProducer, SingleConsumer}
 import monix.execution.annotations.UnsafeProtocol
 
 import scala.util.control.NonFatal
-import monix.execution.internal.Platform.recommendedBatchSize
+import monix.execution.internal.Platform.{recommendedBatchSize, recommendedBufferChunkSize}
 import monix.tail.batches.{Batch, BatchCursor}
 import monix.tail.internal._
 import monix.tail.internal.Constants.emptyRef
@@ -2532,7 +2532,10 @@ object Iterant extends IterantInstances {
     *        ready to process it — this prevents having pauses due to
     *        back-pressuring the `Subscription.request(n)` calls
     */
-  def fromReactivePublisher[F[_], A](publisher: Publisher[A], requestCount: Int = 256, eagerBuffer: Boolean = true)
+  def fromReactivePublisher[F[_], A](
+    publisher: Publisher[A],
+    requestCount: Int = recommendedBufferChunkSize,
+    eagerBuffer: Boolean = true)
     (implicit F: Async[F]): Iterant[F, A] =
     IterantFromReactivePublisher(publisher, requestCount, eagerBuffer)
 
@@ -2616,7 +2619,7 @@ object Iterant extends IterantInstances {
     *        [[Iterant.NextBatch]] nodes, effectively specifying how many
     *        items can be pulled from the queue and processed in batches
     */
-  def fromConsumer[F[_], A](consumer: Consumer[F, A], maxBatchSize: Int = 256)
+  def fromConsumer[F[_], A](consumer: Consumer[F, A], maxBatchSize: Int = recommendedBufferChunkSize)
     (implicit F: Async[F]): Iterant[F, A] = {
 
     IterantFromConsumer(consumer, maxBatchSize)
@@ -2640,8 +2643,8 @@ object Iterant extends IterantInstances {
     */
   def fromChannel[F[_], A](
     channel: Channel[F, A],
-    bufferCapacity: BufferCapacity = Bounded(256),
-    maxBatchSize: Int = 256)
+    bufferCapacity: BufferCapacity = Bounded(recommendedBufferChunkSize),
+    maxBatchSize: Int = recommendedBufferChunkSize)
     (implicit F: Async[F]): Iterant[F, A] = {
 
     val config = ConsumerF.Config(
@@ -2727,8 +2730,8 @@ object Iterant extends IterantInstances {
     *        for optimization purposes, for when you know what you're doing
     */
   def channel[F[_], A](
-    bufferCapacity: BufferCapacity = Bounded(256),
-    maxBatchSize: Int = 256,
+    bufferCapacity: BufferCapacity = Bounded(recommendedBufferChunkSize),
+    maxBatchSize: Int = recommendedBufferChunkSize,
     producerType: ChannelType.ProducerSide = MultiProducer)
     (implicit F: Concurrent[F], cs: ContextShift[F]): F[(Producer[F, A], Iterant[F, A])] = {
 

--- a/monix-tail/shared/src/main/scala/monix/tail/IterantBuilders.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/IterantBuilders.scala
@@ -22,10 +22,12 @@ import cats.effect._
 import monix.catnap.{ConsumerF, ProducerF}
 import monix.execution.BufferCapacity.Bounded
 import monix.execution.ChannelType.MultiProducer
+import monix.execution.internal.Platform.recommendedBufferChunkSize
 import monix.execution.{BufferCapacity, ChannelType}
 import monix.tail.Iterant.Channel
 import monix.tail.batches.{Batch, BatchCursor}
 import org.reactivestreams.Publisher
+
 import scala.collection.immutable.LinearSeq
 import scala.concurrent.duration.FiniteDuration
 
@@ -256,7 +258,7 @@ object IterantBuilders {
       Iterant.intervalWithFixedDelay(initialDelay, delay)
 
     /** Aliased builder, see documentation for [[Iterant.fromReactivePublisher]]. */
-    def fromReactivePublisher[A](publisher: Publisher[A], requestCount: Int = 256, eagerBuffer: Boolean = true)
+    def fromReactivePublisher[A](publisher: Publisher[A], requestCount: Int = recommendedBufferChunkSize, eagerBuffer: Boolean = true)
       (implicit F: Async[F]): Iterant[F, A] =
       Iterant.fromReactivePublisher(publisher, requestCount, eagerBuffer)
 
@@ -266,14 +268,14 @@ object IterantBuilders {
       Iterant.fromConsumer(consumer, maxBatchSize)
 
     /** Aliased builder, see documentation for [[Iterant.fromChannel]]. */
-    def fromChannel[A](channel: Channel[F, A], bufferCapacity: BufferCapacity = Bounded(256), maxBatchSize: Int = 256)
+    def fromChannel[A](channel: Channel[F, A], bufferCapacity: BufferCapacity = Bounded(recommendedBufferChunkSize), maxBatchSize: Int = recommendedBufferChunkSize)
       (implicit F: Async[F]): Iterant[F, A] =
       Iterant.fromChannel(channel, bufferCapacity, maxBatchSize)
 
     /** Aliased builder, see documentation for [[Iterant.channel]]. */
     def channel[A](
-      bufferCapacity: BufferCapacity = Bounded(256),
-      maxBatchSize: Int = 256,
+      bufferCapacity: BufferCapacity = Bounded(recommendedBufferChunkSize),
+      maxBatchSize: Int = recommendedBufferChunkSize,
       producerType: ChannelType.ProducerSide = MultiProducer)
       (implicit F: Concurrent[F], cs: ContextShift[F]): F[(ProducerF[F, Option[Throwable], A], Iterant[F, A])] =
       Iterant.channel(bufferCapacity, maxBatchSize, producerType)

--- a/monix-tail/shared/src/main/scala/monix/tail/IterantBuilders.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/IterantBuilders.scala
@@ -263,7 +263,7 @@ object IterantBuilders {
       Iterant.fromReactivePublisher(publisher, requestCount, eagerBuffer)
 
     /** Aliased builder, see documentation for [[Iterant.fromConsumer]]. */
-    def fromConsumer[A](consumer: ConsumerF[F, Option[Throwable], A], maxBatchSize: Int = 256)
+    def fromConsumer[A](consumer: ConsumerF[F, Option[Throwable], A], maxBatchSize: Int = recommendedBufferChunkSize)
       (implicit F: Async[F]): Iterant[F, A] =
       Iterant.fromConsumer(consumer, maxBatchSize)
 

--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -98,7 +98,8 @@ object MimaFilters {
     exclude[DirectMissingMethodProblem]("monix.reactive.observers.buffers.BatchedBufferedSubscriber.apply"),
     exclude[IncompatibleResultTypeProblem]("monix.reactive.observers.buffers.AbstractBackPressuredBufferedSubscriber.queue"),
     exclude[DirectMissingMethodProblem]("monix.reactive.observers.buffers.AbstractBackPressuredBufferedSubscriber.this"),
-    exclude[IncompatibleMethTypeProblem]("monix.reactive.observers.buffers.AbstractSimpleBufferedSubscriber.this")
+    exclude[IncompatibleMethTypeProblem]("monix.reactive.observers.buffers.AbstractSimpleBufferedSubscriber.this"),
+    exclude[FinalClassProblem]("monix.reactive.OverflowStrategy$Unbounded$")
   )
 
   lazy val changesFor_3_0_0_RC2 = Seq(

--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -14,8 +14,9 @@ object MimaFilters {
     exclude[DirectMissingMethodProblem]("monix.tail.IterantBuilders.apply"),
     exclude[MissingClassProblem]("monix.tail.IterantBuilders$Ref$"),
     exclude[IncompatibleResultTypeProblem]("monix.tail.Iterant.apply"),
-    // Breaking
-    // https://github.com/monix/monix/pull/778
+    //
+    // BREAKING CHANGES: https://github.com/monix/monix/pull/778
+    //
     exclude[IncompatibleMethTypeProblem]("monix.catnap.ConcurrentQueue#ApplyBuilders.unbounded$extension"),
     exclude[IncompatibleMethTypeProblem]("monix.catnap.ConcurrentQueue#ApplyBuilders.bounded$extension"),
     exclude[DirectMissingMethodProblem]("monix.catnap.ConcurrentQueue#ApplyBuilders.custom$default$2$extension"),
@@ -59,7 +60,45 @@ object MimaFilters {
     exclude[ReversedMissingMethodProblem]("monix.execution.internal.collection.queues.FromMessagePassingQueue.fencePoll"),
     exclude[InheritedNewAbstractMethodProblem]("monix.execution.internal.collection.queues.FromMessagePassingQueue.fenceOffer"),
     exclude[InheritedNewAbstractMethodProblem]("monix.execution.internal.collection.queues.FromMessagePassingQueue.fencePoll"),
-    exclude[MissingClassProblem]("monix.execution.internal.collection.queues.ConcurrentQueueBuilders")
+    exclude[MissingClassProblem]("monix.execution.internal.collection.queues.ConcurrentQueueBuilders"),
+    //
+    // BREAKING CHANGES: https://github.com/monix/monix/pull/801
+    //
+    exclude[DirectMissingMethodProblem]("monix.reactive.Observable.create"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.subjects.ConcurrentSubject#SubjectAsConcurrent.this"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.subjects.ConcurrentSubject.from"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.internal.builders.CreateObservable.this"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.Builders.batched"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.Builders.synchronous"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.Builders.apply"),
+    exclude[ReversedMissingMethodProblem]("monix.reactive.observers.Builders.synchronous$default$3"),
+    exclude[ReversedMissingMethodProblem]("monix.reactive.observers.Builders.batched$default$3"),
+    exclude[ReversedMissingMethodProblem]("monix.reactive.observers.Builders.apply$default$3"),
+    exclude[ReversedMissingMethodProblem]("monix.reactive.observers.Builders.batched"),
+    exclude[ReversedMissingMethodProblem]("monix.reactive.observers.Builders.synchronous"),
+    exclude[ReversedMissingMethodProblem]("monix.reactive.observers.Builders.apply"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.BufferedSubscriber.batched"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.BufferedSubscriber.synchronous"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.BufferedSubscriber.apply"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.buffers.BuildersImpl.batched"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.buffers.BuildersImpl.synchronous"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.buffers.BuildersImpl.apply"),
+    exclude[ReversedMissingMethodProblem]("monix.reactive.observers.buffers.BuildersImpl.synchronous$default$3"),
+    exclude[ReversedMissingMethodProblem]("monix.reactive.observers.buffers.BuildersImpl.batched"),
+    exclude[ReversedMissingMethodProblem]("monix.reactive.observers.buffers.BuildersImpl.synchronous"),
+    exclude[ReversedMissingMethodProblem]("monix.reactive.observers.buffers.BuildersImpl.batched$default$3"),
+    exclude[ReversedMissingMethodProblem]("monix.reactive.observers.buffers.BuildersImpl.apply$default$3"),
+    exclude[ReversedMissingMethodProblem]("monix.reactive.observers.buffers.BuildersImpl.apply"),
+    exclude[IncompatibleMethTypeProblem]("monix.reactive.observers.buffers.SimpleBufferedSubscriber.this"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.buffers.BackPressuredBufferedSubscriber.apply"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.buffers.BackPressuredBufferedSubscriber.this"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.buffers.SimpleBufferedSubscriber.unbounded"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.buffers.SimpleBufferedSubscriber.overflowTriggering"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.buffers.BatchedBufferedSubscriber.this"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.buffers.BatchedBufferedSubscriber.apply"),
+    exclude[IncompatibleResultTypeProblem]("monix.reactive.observers.buffers.AbstractBackPressuredBufferedSubscriber.queue"),
+    exclude[DirectMissingMethodProblem]("monix.reactive.observers.buffers.AbstractBackPressuredBufferedSubscriber.this"),
+    exclude[IncompatibleMethTypeProblem]("monix.reactive.observers.buffers.AbstractSimpleBufferedSubscriber.this")
   )
 
   lazy val changesFor_3_0_0_RC2 = Seq(


### PR DESCRIPTION
- Fixes #701 by making buffers configured with `OverflowStrategy.BackPressure` to use a chunk size of `min(bufferSize, defaultChunkSize)`
- introduces `Platform.recommendedBufferChunkSize`, a new global value for setting the recommended chunk size of unbounded buffers, set to 256
- adds `ChannelType.ProducerSide` parameters to `Observable` utils that create buffers (starts from `BufferedSubscriber`, but also `Observable.create`, `ConcurrentSubject`, `Pipe`)