### PR TITLE
Fix #787: encapsulate local ctx on task execution

### DIFF
--- a/monix-eval/jvm/src/test/scala/monix/eval/TaskLocalJVMSuite.scala
+++ b/monix-eval/jvm/src/test/scala/monix/eval/TaskLocalJVMSuite.scala
@@ -123,4 +123,20 @@ object TaskLocalJVMSuite extends SimpleTestSuite {
     val r = task.runSyncUnsafeOpt(Duration.Inf)
     assertEquals(r, 100)
   }
+
+  test("local state is encapsulated by Task run loop") {
+    import monix.execution.Scheduler.Implicits.global
+    implicit val opts = Task.defaultOptions.enableLocalContextPropagation
+    val local = TaskLocal(0).memoize
+
+    val task = for {
+      l <- local
+      x <- l.read
+      _ <- l.write(x + 1)
+    } yield x
+
+    for (_ <- 1 to 10) task.runSyncUnsafeOpt()
+    val r = task.runSyncUnsafeOpt()
+    assertEquals(r, 0)
+  }
 }

--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -27,6 +27,7 @@ import monix.execution._
 import monix.execution.annotations.{UnsafeBecauseBlocking, UnsafeBecauseImpure}
 import monix.execution.internal.Platform.fusionMaxStackDepth
 import monix.execution.internal.{Newtype1, Platform}
+import monix.execution.misc.Local
 import monix.execution.schedulers.{CanBlock, TracingScheduler, TrampolinedRunnable}
 
 import scala.annotation.unchecked.{uncheckedVariance => uV}
@@ -577,7 +578,9 @@ sealed abstract class Task[+A] extends Serializable {
     */
   @UnsafeBecauseImpure
   def runToFutureOpt(implicit s: Scheduler, opts: Options): CancelableFuture[A] =
-    TaskRunLoop.startFuture(this, s, opts)
+    Local.bindCurrentIf(opts.localContextPropagation) {
+      TaskRunLoop.startFuture(this, s, opts)
+    }
 
   /** Triggers the asynchronous execution, with a provided callback
     * that's going to be called at some point in the future with
@@ -697,7 +700,9 @@ sealed abstract class Task[+A] extends Serializable {
     */
   @UnsafeBecauseImpure
   def runAsyncOpt(cb: Either[Throwable, A] => Unit)(implicit s: Scheduler, opts: Options): Cancelable =
-    UnsafeCancelUtils.taskToCancelable(runAsyncOptF(cb)(s, opts))
+    Local.bindCurrentIf(opts.localContextPropagation) {
+      UnsafeCancelUtils.taskToCancelable(runAsyncOptF(cb)(s, opts))
+    }
 
   /** Triggers the asynchronous execution, returning a `Task[Unit]`
     * (aliased to `CancelToken[Task]` in Cats-Effect) which can
@@ -795,7 +800,9 @@ sealed abstract class Task[+A] extends Serializable {
     */
   @UnsafeBecauseImpure
   def runAsyncOptF(cb: Either[Throwable, A] => Unit)(implicit s: Scheduler, opts: Options): CancelToken[Task] =
-    TaskRunLoop.startLight(this, s, opts, Callback.fromAttempt(cb))
+    Local.bindCurrentIf(opts.localContextPropagation) {
+      TaskRunLoop.startLight(this, s, opts, Callback.fromAttempt(cb))
+    }
 
   /** Triggers the asynchronous execution of the source task
     * in a "fire and forget" fashion.
@@ -914,7 +921,9 @@ sealed abstract class Task[+A] extends Serializable {
   @UnsafeBecauseImpure
   def runAsyncUncancelableOpt(cb: Either[Throwable, A] => Unit)
     (implicit s: Scheduler, opts: Task.Options): Unit =
-    TaskRunLoop.startLight(this, s, opts, Callback.fromAttempt(cb), isCancelable = false)
+    Local.bindCurrentIf(opts.localContextPropagation) {
+      TaskRunLoop.startLight(this, s, opts, Callback.fromAttempt(cb), isCancelable = false)
+    }
 
   /** Executes the source until completion, or until the first async
     * boundary, whichever comes first.
@@ -975,7 +984,9 @@ sealed abstract class Task[+A] extends Serializable {
     */
   @UnsafeBecauseImpure
   final def runSyncStepOpt(implicit s: Scheduler, opts: Options): Either[Task[A], A] =
-    TaskRunLoop.startStep(this, s, opts)
+    Local.bindCurrentIf(opts.localContextPropagation) {
+      TaskRunLoop.startStep(this, s, opts)
+    }
 
   /** Evaluates the source task synchronously and returns the result
     * immediately or blocks the underlying thread until the result is
@@ -1070,7 +1081,9 @@ sealed abstract class Task[+A] extends Serializable {
   final def runSyncUnsafeOpt(timeout: Duration = Duration.Inf)
     (implicit s: Scheduler, opts: Options, permit: CanBlock): A = {
     /*_*/
-    TaskRunSyncUnsafe(this, timeout, s, opts)
+    Local.bindCurrentIf(opts.localContextPropagation) {
+      TaskRunSyncUnsafe(this, timeout, s, opts)
+    }
     /*_*/
   }
 

--- a/monix-execution/shared/src/main/scala/monix/execution/misc/Local.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/misc/Local.scala
@@ -76,6 +76,9 @@ object Local {
   def bindClear[R](f: => R): R =
     macro Macros.localLetClear
 
+  private[monix] def bindCurrentIf[R](b: => Boolean)(f: => R): R =
+    macro Macros.localLetCurrentIf
+
   /** Convert a closure `() => R` into another closure of the same
     * type whose [[Local.Context]] is saved when calling closed
     * and restored upon invocation.
@@ -145,6 +148,15 @@ object Local {
        $Local.setContext($Map.empty)
        try { $f } finally { $Local.setContext($saved) }
        """)
+    }
+
+    def localLetCurrentIf(b: Tree)(f: Tree): Tree = {
+      val Local = symbolOf[Local[_]].companion
+      resetTree(
+        q"""
+           if (!$b) { $f }
+           else ${localLet(q"$Local.getContext()")(f)}
+         """)
     }
   }
 }


### PR DESCRIPTION
I basically redid what was in one of my previous PRs. This ensures Local context is left unchanged when an unsafe method starts executing.

Not entirely sure this fixes all the possible issues (I'm suspicious about `.start`), but I think it's better than what we currently have.