### PR TITLE
Eagerly null out dequeued elements in ChunkedArrayQueue

### DIFF
--- a/monix-execution/shared/src/main/scala/monix/execution/internal/collection/ChunkedArrayQueue.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/collection/ChunkedArrayQueue.scala
@@ -76,6 +76,7 @@ private[monix] final class ChunkedArrayQueue[A] private (
   def dequeue(): A = {
     if ((headArray ne tailArray) || headIndex < tailIndex) {
       val result = headArray(headIndex).asInstanceOf[A]
+      headArray(headIndex) = null
       headIndex += 1
 
       if (headIndex == modulo) {


### PR DESCRIPTION
This is a very simplistic fix for an issue I'm having, opening this for discussion (and to avoid keeping this in a local fork :-))

G1 Old Gen before the fix:
![image](https://user-images.githubusercontent.com/283332/50773499-ae97f000-1299-11e9-8bb7-a8e025fcfce5.png)

After the fix:
![image](https://user-images.githubusercontent.com/283332/50773511-b788c180-1299-11e9-82b6-ac10abc8e610.png)
