### PR TITLE
Improve encapsulation test, encapsulate locals on ContextShift

### DIFF
--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRunLoop.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRunLoop.scala
@@ -131,6 +131,22 @@ private[eval] object TaskRunLoop {
                   current = FlatMap(next, new RestoreContext(old, restore))
                   /*_*/
               }
+              // If LCP has changed to "enable", encapsulate local context
+              val useLCP = context.options.localContextPropagation
+              if (useLCP && useLCP != old.options.localContextPropagation) {
+                Local.bind(Local.getContext()) {
+                  startFull(
+                    current,
+                    context,
+                    cba,
+                    rcb,
+                    bFirstRef,
+                    bRestRef,
+                    currentIndex
+                  )
+                }
+                return
+              }
             } catch {
               case e if NonFatal(e) && catchError =>
                 current = Error(e)


### PR DESCRIPTION
I've improved the test to cover more ways to execute Task with LCP. Found a few related to `startFull` not being encapsulated, if the execution starts without LCP and gets it enabled halfway through, such as `task.executeWithOptions(_.enableLocalContextPropagation).unsafeRunSync()`.