### PR TITLE
WIP: Make TaskLocal behave well in combination with Observable

### DIFF
--- a/monix-catnap/jvm/src/test/scala/monix/catnap/MVarJVMSuite.scala
+++ b/monix-catnap/jvm/src/test/scala/monix/catnap/MVarJVMSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/jvm/src/test/scala/monix/catnap/SemaphoreJVMSuite.scala
+++ b/monix-catnap/jvm/src/test/scala/monix/catnap/SemaphoreJVMSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -2066,7 +2066,7 @@ abstract class Observable[+A] extends Serializable { self =>
     *      powered by [[monix.eval.TaskLike]]
     */
   final def mapEval[B](f: A => Task[B]): Observable[B] =
-    new MapTaskObservable[A, B](self, f)
+    new MapEvalObservable[A, B](self, f)
 
   /** Version of [[mapEval]] that can work with generic
     * `F[_]` tasks, anything that's supported via [[monix.eval.TaskLike]]

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/TaskAsObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/TaskAsObservable.scala
@@ -22,13 +22,15 @@ import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 import monix.execution.Callback
 import monix.eval.Task
+import monix.reactive.internal.util.TaskRun
 
 private[reactive] final
 class TaskAsObservable[+A](task: Task[A]) extends Observable[A] {
   def unsafeSubscribeFn(subscriber: Subscriber[A]): Cancelable = {
     import subscriber.scheduler
+    implicit val opts = TaskRun.options(scheduler)
 
-    task.runAsync(new Callback[Throwable, A] {
+    task.runAsyncOpt(new Callback[Throwable, A] {
       def onSuccess(value: A): Unit = {
         subscriber.onNext(value)
         subscriber.onComplete()

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnCompleteOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnCompleteOperator.scala
@@ -20,7 +20,9 @@ package monix.reactive.internal.operators
 import monix.eval.Task
 import monix.execution.Ack
 import monix.reactive.Observable.Operator
+import monix.reactive.internal.util.TaskRun
 import monix.reactive.observers.Subscriber
+
 import scala.concurrent.Future
 
 private[reactive] final
@@ -29,6 +31,7 @@ class DoOnCompleteOperator[A](task: Task[Unit]) extends Operator[A,A] {
   def apply(out: Subscriber[A]): Subscriber[A] =
     new Subscriber[A] {
       implicit val scheduler = out.scheduler
+      private[this] implicit val opts = TaskRun.options(scheduler)
 
       def onNext(elem: A): Future[Ack] = out.onNext(elem)
       def onError(ex: Throwable): Unit = out.onError(ex)
@@ -39,6 +42,6 @@ class DoOnCompleteOperator[A](task: Task[Unit]) extends Operator[A,A] {
             out.onComplete()
           case Left(ex) =>
             out.onError(ex)
-        }.runToFuture
+        }.runToFutureOpt
     }
 }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnErrorOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnErrorOperator.scala
@@ -19,9 +19,12 @@ package monix.reactive.internal.operators
 
 import monix.eval.Task
 import monix.execution.Ack
+
 import scala.util.control.NonFatal
 import monix.reactive.Observable.Operator
+import monix.reactive.internal.util.TaskRun
 import monix.reactive.observers.Subscriber
+
 import scala.concurrent.Future
 
 private[reactive] final
@@ -30,6 +33,7 @@ class DoOnErrorOperator[A](cb: Throwable => Task[Unit]) extends Operator[A,A] {
   def apply(out: Subscriber[A]): Subscriber[A] =
     new Subscriber[A] {
       implicit val scheduler = out.scheduler
+      private[this] implicit val opts = TaskRun.options(scheduler)
 
       def onNext(elem: A): Future[Ack] = out.onNext(elem)
       def onComplete(): Unit = out.onComplete()
@@ -43,7 +47,7 @@ class DoOnErrorOperator[A](cb: Throwable => Task[Unit]) extends Operator[A,A] {
             case Left(err) =>
               scheduler.reportFailure(err)
               out.onError(ex)
-          }.runToFuture
+          }.runToFutureOpt
         }
         catch {
           case err if NonFatal(err) =>

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FlatScanObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FlatScanObservable.scala
@@ -32,7 +32,7 @@ import scala.util.Failure
 
 /** Implementation for `Observable.scanTask`.
   *
-  * Implementation is based on [[MapTaskObservable]].
+  * Implementation is based on [[MapEvalObservable]].
   *
   * Tricky concurrency handling within, here be dragons!
   */

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/util/TaskRun.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/util/TaskRun.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.reactive.internal.util
+
+import monix.eval.Task
+import monix.execution.Scheduler
+import monix.execution.schedulers.TracingScheduler
+
+private[reactive] object TaskRun {
+  /**
+    * Builds a [[monix.eval.Task.Options]] reference, for executing
+    * tasks in the context of `Observable`.
+    */
+  def options(implicit s: Scheduler): Task.Options =
+    s match {
+      case _: TracingScheduler => optionsWithLocalsRef
+      case _ => Task.defaultOptions
+    }
+
+  /**
+    * Options value for execution tasks with
+    * "local context propagation" enabled.
+    */
+  val optionsWithLocalsRef = Task.defaultOptions.enableLocalContextPropagation
+}


### PR DESCRIPTION
This PR changes `Observable` operators that make use of `Task` to detect `TracingScheduler` and enable the `localContextPropagation` option when executing the tasks.

This should make `Observable` play well with `TaskLocal`.