### PR TITLE
Update Cats-Effect to 1.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ addCommandAlias("ci-jvm-all", s";ci-jvm ;unidoc")
 addCommandAlias("release",    ";project monix ;+clean ;+package ;+publishSigned")
 
 val catsVersion = "1.4.0"
-val catsEffectVersion = "1.1.0"
+val catsEffectVersion = "1.2.0"
 val catsEffectLawsVersion = catsEffectVersion
 val jcToolsVersion = "2.1.2"
 val reactiveStreamsVersion = "1.0.2"

--- a/monix-catnap/jvm/src/test/scala/monix/catnap/MVarJVMSuite.scala
+++ b/monix-catnap/jvm/src/test/scala/monix/catnap/MVarJVMSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/jvm/src/test/scala/monix/catnap/SemaphoreJVMSuite.scala
+++ b/monix-catnap/jvm/src/test/scala/monix/catnap/SemaphoreJVMSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/main/scala/monix/catnap/CancelableF.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/CancelableF.scala
@@ -21,8 +21,7 @@ import cats.Applicative
 import cats.effect.{CancelToken, Sync}
 import monix.catnap.cancelables.BooleanCancelableF
 import monix.execution.annotations.UnsafeBecauseImpure
-import monix.execution.internal.Platform
-
+import monix.execution.exceptions.CompositeException
 import scala.collection.mutable.ListBuffer
 
 /** Represents a pure data structure that describes an effectful,
@@ -144,8 +143,10 @@ object CancelableF {
         errors.toList match {
           case Nil =>
             F.unit
-          case first :: rest =>
-            F.raiseError(Platform.composeErrors(first, rest: _*))
+          case first :: Nil =>
+            F.raiseError(first)
+          case list =>
+            F.raiseError(CompositeException(list))
         }
       }
     }

--- a/monix-catnap/shared/src/main/scala/monix/catnap/cancelables/SingleAssignCancelableF.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/cancelables/SingleAssignCancelableF.scala
@@ -50,7 +50,7 @@ final class SingleAssignCancelableF[F[_]] private (extra: CancelableF[F])(implic
         case IsCanceled | IsEmptyCanceled => F.unit
         case current @ IsActive(s) =>
           if (state.compareAndSet(current, IsCanceled))
-            F.guarantee(s.cancel)(extra.cancel)
+            CancelableF.cancelAllTokens(s.cancel, extra.cancel)
           else
             loop()
         case Empty =>


### PR DESCRIPTION
Had to updated this myself, @scala-steward couldn't because we've got a failing test due to changing the behavior of errors thrown in bracket's release.