### PR TITLE
Fix #712: add Iterant.uncons operation

### DIFF
--- a/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
@@ -2072,6 +2072,8 @@ sealed abstract class Iterant[F[_], A] extends Product with Serializable {
     * implementable by recursing into a Resource:
     *
     * {{{
+    *   import cats._, cats.implicits._, cats.effect._
+    *
     *   def fold[F[_]: Sync, A: Monoid](iterant: Iterant[F, A]): F[A] = {
     *     def go(iterant: Iterant[F, A], acc: A): Resource[F, A] =
     *       iterant.unconsR.flatMap {

--- a/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
@@ -2061,6 +2061,12 @@ sealed abstract class Iterant[F[_], A] extends Product with Serializable {
   final def toListL(implicit F: Sync[F]): F[List[A]] =
     IterantFoldLeftL.toListL(self)(F)
 
+  final def unconsR(implicit F: Sync[F]): Resource[F, (Option[A], Iterant[F, A])] =
+    IterantUncons(self)
+
+  final def uncons(implicit F: Sync[F]): Iterant[F, (Option[A], Iterant[F, A])] =
+    Iterant.fromResource(unconsR)
+
   /** Lazily zip two iterants together.
     *
     * The length of the result will be the shorter of the two

--- a/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
@@ -2065,41 +2065,27 @@ sealed abstract class Iterant[F[_], A] extends Product with Serializable {
     * Pull the first element out of this Iterant and return it and the rest.
     * If the returned Option is None, the remainder is always empty.
     *
-    * The value returned is wrapped in Resource to preserve resource safety,
-    * and consumption of the rest must not leak outside of use.
-    *
-    * This can be used to implement custom operators. For example, `fold` is
-    * implementable by recursing into a Resource:
+    * The value returned is wrapped in Iterant to preserve resource safety,
+    * and consumption of the rest must not leak outside of use. The returned
+    * Iterant always contains a single element
     *
     * {{{
     *   import cats._, cats.implicits._, cats.effect._
     *
-    *   def fold[F[_]: Sync, A: Monoid](iterant: Iterant[F, A]): F[A] = {
-    *     def go(iterant: Iterant[F, A], acc: A): Resource[F, A] =
-    *       iterant.unconsR.flatMap {
-    *         case (None, _) => Resource.pure(acc)
+    *    def unconsFold[F[_]: Sync, A: Monoid](iterant: Iterant[F, A]): F[A] = {
+    *     def go(iterant: Iterant[F, A], acc: A): Iterant[F, A] =
+    *       iterant.uncons.flatMap {
+    *         case (None, _) => Iterant.pure(acc)
     *         case (Some(a), rest) => go(rest, acc |+| a)
     *       }
     *
-    *     go(iterant, Monoid[A].empty).use(_.pure[F])
+    *     go(iterant, Monoid[A].empty).headOptionL.map(_.getOrElse(Monoid[A].empty))
     *   }
     * }}}
     *
-    * @see [[uncons]] for version that wraps value in Iterant
-    */
-  final def unconsR(implicit F: Sync[F]): Resource[F, (Option[A], Iterant[F, A])] =
-    IterantUncons(self)
-
-  /**
-    * Pull the first element out of this Iterant and return it and the rest.
-    * If the returned Option is None, the remainder is always empty.
-    *
-    * The value returned is wrapped in Iterant to preserve resource safety.
-    *
-    * This is equivalent to doing Iterant.fromResource on a result of [[unconsR]]
     */
   final def uncons(implicit F: Sync[F]): Iterant[F, (Option[A], Iterant[F, A])] =
-    Iterant.fromResource(unconsR)
+    IterantUncons(self)
 
   /** Lazily zip two iterants together.
     *

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantUncons.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantUncons.scala
@@ -16,52 +16,52 @@
  */
 
 package monix.tail.internal
-import cats.effect.{Resource, Sync}
+import cats.effect.Sync
 import monix.tail.Iterant
 import monix.tail.Iterant.{Concat, NextCursor, Suspend}
 import cats.implicits._
 
 private[tail] object IterantUncons {
-  type Uncons[F[_], A] = Resource[F, (Option[A], Iterant[F, A])]
+  type Uncons[F[_], A] = Iterant[F, (Option[A], Iterant[F, A])]
   def apply[F[_]: Sync, A](source: Iterant[F, A]): Uncons[F, A] =
-    Resource.liftF(Sync[F].delay(new Loop[F, A])).flatMap(f => f(source))
+    Iterant.liftF(Sync[F].delay(new Loop[F, A])).flatMap(f => f(source))
 
   class Loop[F[_]: Sync, A] extends Iterant.Visitor[F, A, Uncons[F, A]] {
     def visit(ref: Iterant.Next[F, A]): Uncons[F, A] =
-      Resource.pure((Some(ref.item), Suspend(ref.rest)))
+      Iterant.pure((Some(ref.item), Suspend(ref.rest)))
 
     def visit(ref: Iterant.NextBatch[F, A]): Uncons[F, A] =
       this(ref.toNextCursor())
 
     def visit(ref: Iterant.NextCursor[F, A]): Uncons[F, A] =
-      if (ref.cursor.isEmpty) Resource.liftF(ref.rest).flatMap(this)
+      if (ref.cursor.isEmpty) Iterant.liftF(ref.rest).flatMap(this)
       else {
         val head = ref.cursor.next()
         val tail = if (ref.cursor.isEmpty) Suspend(ref.rest)
                    else NextCursor(ref.cursor, ref.rest)
-        Resource.pure((Some(head), tail))
+        Iterant.pure((Some(head), tail))
       }
 
     def visit(ref: Iterant.Suspend[F, A]): Uncons[F, A] =
-      Resource.liftF(ref.rest).flatMap(this)
+      Iterant.liftF(ref.rest).flatMap(this)
 
     def visit(ref: Iterant.Concat[F, A]): Uncons[F, A] =
-      Resource.liftF(ref.lh).flatMap(this).flatMap {
-        case (s @ Some(_), tail) => Resource.pure((s, Concat(tail.pure[F], ref.rh)))
-        case (None, _) => Resource.liftF(ref.rh).flatMap(this)
+      Iterant.liftF(ref.lh).flatMap(this).flatMap {
+        case (s @ Some(_), tail) => Iterant.pure((s, Concat(tail.pure[F], ref.rh)))
+        case (None, _) => Iterant.liftF(ref.rh).flatMap(this)
       }
 
     def visit[S](ref: Iterant.Scope[F, S, A]): Uncons[F, A] =
-      Resource.makeCase(ref.acquire)(ref.release).flatMap(rs => this(Suspend(ref.use(rs))))
+      Iterant.resourceCase(ref.acquire)(ref.release).flatMap(rs => this(Suspend(ref.use(rs))))
 
     def visit(ref: Iterant.Last[F, A]): Uncons[F, A] =
-      Resource.pure((Some(ref.item), Iterant.empty))
+      Iterant.pure((Some(ref.item), Iterant.empty))
 
     def visit(ref: Iterant.Halt[F, A]): Uncons[F, A] = ref.e match {
-      case Some(ex) => Resource.liftF(ex.raiseError[F, (Option[A], Iterant[F, A])])
-      case None => Resource.pure((None, Iterant.empty))
+      case Some(ex) => Iterant.liftF(ex.raiseError[F, (Option[A], Iterant[F, A])])
+      case None => Iterant.pure((None, Iterant.empty))
     }
 
-    def fail(e: Throwable): Uncons[F, A] = Resource.liftF(e.raiseError[F, (Option[A], Iterant[F, A])])
+    def fail(e: Throwable): Uncons[F, A] = Iterant.raiseError(e)
   }
 }

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantUncons.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantUncons.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.tail.internal
+import cats.effect.{Resource, Sync}
+import monix.tail.Iterant
+import monix.tail.Iterant.{Concat, NextCursor, Suspend}
+import cats.implicits._
+
+private[tail] object IterantUncons {
+  type Uncons[F[_], A] = Resource[F, (Option[A], Iterant[F, A])]
+  def apply[F[_]: Sync, A](source: Iterant[F, A]): Uncons[F, A] =
+    Resource.liftF(Sync[F].delay(new Loop[F, A])).flatMap(f => f(source))
+
+  class Loop[F[_]: Sync, A] extends Iterant.Visitor[F, A, Uncons[F, A]] {
+    def visit(ref: Iterant.Next[F, A]): Uncons[F, A] =
+      Resource.pure((Some(ref.item), Suspend(ref.rest)))
+
+    def visit(ref: Iterant.NextBatch[F, A]): Uncons[F, A] =
+      this(ref.toNextCursor())
+
+    def visit(ref: Iterant.NextCursor[F, A]): Uncons[F, A] =
+      if (ref.cursor.isEmpty) Resource.liftF(ref.rest).flatMap(this)
+      else {
+        val head = ref.cursor.next()
+        val tail = if (ref.cursor.isEmpty) Suspend(ref.rest)
+                   else NextCursor(ref.cursor, ref.rest)
+        Resource.pure((Some(head), tail))
+      }
+
+    def visit(ref: Iterant.Suspend[F, A]): Uncons[F, A] =
+      Resource.liftF(ref.rest).flatMap(this)
+
+    def visit(ref: Iterant.Concat[F, A]): Uncons[F, A] =
+      Resource.liftF(ref.lh).flatMap(this).flatMap {
+        case (s @ Some(_), tail) => Resource.pure((s, Concat(tail.pure[F], ref.rh)))
+        case (None, _) => Resource.liftF(ref.rh).flatMap(this)
+      }
+
+    def visit[S](ref: Iterant.Scope[F, S, A]): Uncons[F, A] =
+      Resource.makeCase(ref.acquire)(ref.release).flatMap(rs => this(Suspend(ref.use(rs))))
+
+    def visit(ref: Iterant.Last[F, A]): Uncons[F, A] =
+      Resource.pure((Some(ref.item), Iterant.empty))
+
+    def visit(ref: Iterant.Halt[F, A]): Uncons[F, A] = ref.e match {
+      case Some(ex) => Resource.liftF(ex.raiseError[F, (Option[A], Iterant[F, A])])
+      case None => Resource.pure((None, Iterant.empty))
+    }
+
+    def fail(e: Throwable): Uncons[F, A] = Resource.liftF(e.raiseError[F, (Option[A], Iterant[F, A])])
+  }
+}

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantUnconsSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantUnconsSuite.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.tail
+
+import cats.Monoid
+import cats.effect.{Resource, Sync}
+import cats.implicits._
+import cats.laws._
+import cats.laws.discipline._
+import monix.eval.Coeval
+
+object IterantUnconsSuite extends BaseTestSuite {
+  test("uncons is reversible with flatMap and concat") { implicit s =>
+    check1 { (stream: Iterant[Coeval, Int]) =>
+      stream <-> stream.uncons.flatMap { case (opt, rest) =>
+        opt.map(Iterant[Coeval].pure).foldK ++ rest
+      }
+    }
+  }
+
+  test("uncons ignoring Option is equivalent to tail") { _ =>
+    check1 { stream: Iterant[Coeval, Int] =>
+      stream.tail <-> stream.uncons.flatMap { case (_, rest) => rest }
+    }
+  }
+
+  test("uncons ignoring tail is equivalent to headOptionL") { _ =>
+    check1 { stream: Iterant[Coeval, Int] =>
+      stream.headOptionL <-> stream.unconsR.use { case (hd, _) => Coeval.pure(hd) }
+    }
+  }
+
+  test("any fold is expressible using unconsR") { _ =>
+    def unconsFold[F[_]: Sync, A: Monoid](iterant: Iterant[F, A]): F[A] = {
+      def go(iterant: Iterant[F, A], acc: A): Resource[F, A] =
+        iterant.unconsR.flatMap {
+          case (None, _) => Resource.pure(acc)
+          case (Some(a), rest) => go(rest, acc |+| a)
+        }
+
+      go(iterant, Monoid[A].empty).use(_.pure[F])
+    }
+
+    check1 { stream: Iterant[Coeval, Int] =>
+      stream.foldL <-> unconsFold(stream)
+    }
+  }
+}


### PR DESCRIPTION
* Both Resource and Iterant versions (latter could be optimized, but now it's just convenience to avoid `fromResource`.
* Single element only. Batch versions can be made later.

@alexandru should I add separate tests to check how resource alloc works, or laws are enough on our setup?