### PR TITLE
TaskLocal should propagate when used with Bracket Methods

### DIFF
--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskShift.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskShift.scala
@@ -32,7 +32,8 @@ private[eval] object TaskShift {
     Async(
       new Register(ec),
       trampolineBefore = false,
-      trampolineAfter = false)
+      trampolineAfter = false,
+      restoreLocals = false)
   }
 
   // Implementing Async's "start" via `ForkedStart` in order to signal

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskLocalSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskLocalSuite.scala
@@ -187,4 +187,17 @@ object TaskLocalSuite extends SimpleTestSuite {
 
     t.runToFutureOpt
   }
+
+  testAsync("TaskLocal should work with bracket") {
+    val t = for {
+      local <- TaskLocal(0)
+      _ <- Task.unit
+        .executeAsync
+        .guarantee(local.write(10))
+      value <- local.read
+      _ <- Task.eval(assertEquals(value, 10))
+    } yield ()
+
+    t.runToFutureOpt
+  }
 }


### PR DESCRIPTION
Related to #806

Making PR as suggested by @oleg-py 

The difference between
```scala
Task.unit
    .executeAsync
    .guarantee(local.write(10))
```

and

```scala
Task.unit
    .guarantee(local.write(10))
```

is that the former starts `TaskRestartCallback` twice (the first one is just after evaluating `guarantee` body) and the latter just once. 

@alexandru If you could provide some explanation of `TaskRestartCallback` that would help immensely in putting all the pieces together. :) I feel like I'm getting somewhere with my understanding but there are a lot of guesses at this point