### PR TITLE
Specify exception on timeout

### DIFF
--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -2212,7 +2212,16 @@ sealed abstract class Task[+A] extends Serializable {
     * task emitting any item.
     */
   final def timeout(after: FiniteDuration): Task[A] =
-    timeoutTo(after, raiseError(new TimeoutException(s"Task timed-out after $after of inactivity")))
+    timeoutWith(after, new TimeoutException(s"Task timed-out after $after of inactivity"))
+
+  /** Returns a Task that mirrors the source Task but that triggers a
+    * specified `Exception` in case the given duration passes
+    * without the task emitting any item.
+    * @param exception The `Exception` to throw after given duration
+    *                  passes
+    */
+  final def timeoutWith(after: FiniteDuration, exception: Exception): Task[A] =
+    timeoutTo(after, raiseError(exception))
 
   /** Returns a Task that mirrors the source Task but switches to the
     * given backup Task in case the given duration passes without the


### PR DESCRIPTION
This PR allows you specify an exception when calling `.timout` on a `Task`. The reason why this PR is being made is that in one of our company projects using Monix we make heavy use of `.timeout` as well as recovering after `.timeout`. Due to needing to know if a Monix `Task` raised an exception due to a `timeout`, we had to create this ugly workaround 

```scala
private def isThrowableMonixTimeout(throwable: Throwable): Boolean =
  throwable match {
    // This is the exception that is thrown when you do .timeout on a Task
    case t: TimeoutException if t.getMessage.contains("Task timed-out after") => true
    case _                                                                    => false
  }
```

This simple PR allows you to specify your own type of `TimeoutException`