### PR TITLE
Make Task.deferFuture not reset locals

### DIFF
--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskFromFuture.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskFromFuture.scala
@@ -94,7 +94,7 @@ private[eval] object TaskFromFuture {
       start,
       trampolineBefore = false,
       trampolineAfter = false,
-      restoreLocals = true
+      restoreLocals = false
     )
   }
 
@@ -103,7 +103,7 @@ private[eval] object TaskFromFuture {
       start,
       trampolineBefore = true,
       trampolineAfter = false,
-      restoreLocals = true)
+      restoreLocals = false)
 
   private def startSimple[A](ctx: Task.Context, cb: Callback[Throwable, A], f: Future[A]) = {
     f.value match {


### PR DESCRIPTION
This is part of a fix for #848. We reset locals on boundary when going from Future, and it seems we shouldn't.

Used same approach as in #839.