### PR TITLE
fix apparently erronous code involving Unit companion

### DIFF
--- a/monix-execution/shared/src/main/scala/monix/execution/internal/Constants.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/Constants.scala
@@ -28,5 +28,5 @@ private[monix] object Constants {
 
   val successOfUnit: Try[Unit] = Success(())
 
-  val toUnit = (_: Any) => Unit
+  val toUnit = (_: Any) => ()
 }


### PR DESCRIPTION
this was caught by the Scala 2.13 community build.
2.13.0-RC1 will forbid the old code.

```
[monix] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.16/project-builds/monix-8191d972d6ee8c789100269dc8adc6fabc14b328/monix-execution/shared/src/main/scala/monix/execution/internal/Constants.scala:31:28: `Unit` companion object is not allowed in source; instead, use `()` for the unit value
[monix] [error]   val toUnit = (_: Any) => Unit
[monix] [error]                            ^
[monix] [error] one error found
```