### PR TITLE
Make benchmarks compile

### DIFF
--- a/benchmarks/vnext/src/main/scala/monix/benchmarks/AsyncQueueBenchmark.scala
+++ b/benchmarks/vnext/src/main/scala/monix/benchmarks/AsyncQueueBenchmark.scala
@@ -19,7 +19,7 @@ package monix.benchmarks
 
 import java.util.concurrent.TimeUnit
 import monix.execution.ChannelType.{MPMC, SPMC, SPSC}
-import monix.execution.{AsyncQueue, CancelableFuture, ChannelType}
+import monix.execution.{AsyncQueue, CancelableFuture, ChannelType, BufferCapacity}
 import org.openjdk.jmh.annotations._
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
@@ -61,7 +61,8 @@ class AsyncQueueBenchmark {
   }
 
   def test(producers: Int, workers: Int, channelType: ChannelType): Long = {
-    val queue = AsyncQueue[Int](capacity = 1024, channelType = channelType)
+    val capacity = BufferCapacity.Bounded(1024)
+    val queue = new AsyncQueue[Int](capacity, channelType = channelType)
     val workers = 1
 
     def producer(n: Int): Future[Long] =

--- a/monix-execution/shared/src/main/scala/monix/execution/AsyncQueue.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/AsyncQueue.scala
@@ -109,7 +109,7 @@ import scala.concurrent.duration._
   * concurrency bugs. If you're not sure what multi-threading scenario you
   * have, then just stick with the default `MPMC`.
   */
-final class AsyncQueue[A] private (
+final class AsyncQueue[A] private[monix] (
   capacity: BufferCapacity,
   channelType: ChannelType,
   retryDelay: FiniteDuration = 10.millis)


### PR DESCRIPTION
`AsyncQueue` suffered some changes in its API but the benchmark sources were
not updated, most likely because they are not compiled in the CI.

I have not touched the CI pipeline but maybe it would be better to do so.