### PR TITLE
Allow sharing local context for Future interop

### DIFF
--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRestartCallback.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRestartCallback.scala
@@ -151,8 +151,8 @@ private[internal] object TaskRestartCallback {
   private final class WithLocals(context: Context, callback: Callback[Throwable, Any])
     extends TaskRestartCallback(context, callback) {
 
-    private[this] var preparedLocals: Local.Context = _
-    private[this] var previousLocals: Local.Context = _
+    private[this] var preparedLocals: Local.ContextRef = _
+    private[this] var previousLocals: Local.ContextRef = _
 
     override protected def prepareStart(task: Task.Async[_]): Unit = {
       preparedLocals =

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRunLoop.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRunLoop.scala
@@ -24,6 +24,7 @@ import monix.eval.Task
 import monix.execution.internal.collection.ChunkedArrayStack
 import monix.execution.misc.Local
 import monix.execution.{CancelableFuture, ExecutionModel, Scheduler}
+
 import scala.concurrent.Promise
 import scala.util.control.NonFatal
 
@@ -134,7 +135,7 @@ private[eval] object TaskRunLoop {
               // If LCP has changed to "enable", encapsulate local context
               val useLCP = context.options.localContextPropagation
               if (useLCP && useLCP != old.options.localContextPropagation) {
-                Local.bind(Local.getContext()) {
+                Local.isolate {
                   startFull(
                     current,
                     context,
@@ -203,7 +204,7 @@ private[eval] object TaskRunLoop {
         context.frameRef.reset()
 
         // Transporting the current context if localContextPropagation == true.
-        Local.bind(savedLocals) {
+        Local.bindRef(savedLocals) {
           // Using frameIndex = 1 to ensure at least one cycle gets executed
           startFull(source, context, cb, rcb, bindCurrent, bindRest, 1)
         }

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskLocalSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskLocalSuite.scala
@@ -200,4 +200,19 @@ object TaskLocalSuite extends SimpleTestSuite {
 
     t.runToFutureOpt
   }
+
+  testAsync("TaskLocal.isolate should prevent context changes") {
+    val t = for {
+      local <- TaskLocal(0)
+      inc = local.read.map(_ + 1).flatMap(local.write)
+      _     <- inc
+      res1  <- local.read
+      _     <- Task(assertEquals(res1, 1))
+      _     <- TaskLocal.isolate(inc)
+      res2  <- local.read
+      _     <- Task(assertEquals(res1, res2))
+    } yield ()
+
+    t.runToFutureOpt
+  }
 }

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskStartSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskStartSuite.scala
@@ -52,7 +52,7 @@ object TaskStartSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(1)))
   }
 
-  testAsync("task.start keeps current Local.Context on join") { _ =>
+  testAsync("task.start shares Local.Context with fibers") { _ =>
     import monix.execution.Scheduler.Implicits.global
     import cats.syntax.all._
     implicit val opts = Task.defaultOptions.enableLocalContextPropagation
@@ -60,14 +60,15 @@ object TaskStartSuite extends BaseTestSuite {
     val task = for {
       local <- TaskLocal(0)
       _ <- local.write(100)
-      f <- (Task.shift *> local.read <* local.write(200)).start
       v1 <- local.read
+      f <- (Task.shift *> local.read <* local.write(200)).start
+      // Here, before joining, reads are nondeterministic
       v2 <- f.join
       v3 <- local.read
     } yield (v1, v2, v3)
 
     for (v <- task.runToFutureOpt) yield {
-      assertEquals(v, (100, 100, 100))
+      assertEquals(v, (100, 100, 200))
     }
   }
 

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TracingSchedulerServiceSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TracingSchedulerServiceSuite.scala
@@ -36,7 +36,10 @@ object TracingSchedulerServiceSuite extends SimpleTestSuite {
       val local2 = Local(0)
       local2 := 100
 
-      val ref = local1.bind(100)(Future(local1.get + local2.get))
+      val ref = Local.isolate {
+        local1 := 100
+        Future(local1.get + local2.get)
+      }
       local1 := 999
       local2 := 999
       ref

--- a/monix-execution/shared/src/main/scala/monix/execution/misc/Local.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/misc/Local.scala
@@ -261,8 +261,8 @@ final class Local[A](default: () => A) {
   /** Execute a block with a specific local value, restoring the
     * current state upon completion.
     */
+  @deprecated("Binds on Local prevent propagation of writes to other locals. Use Local.isolate directly", "3.0.0-RC3")
   def bind[R](value: A)(f: => R): R = {
-    // TODO - currently this doesn't propagate concurrent writes
     // to other locals, if any, so acts like freeze all
     val parent: AtomicAny[Local.Context] = Local.getContext()
     Local.setContext(AtomicAny(parent.get))
@@ -273,8 +273,8 @@ final class Local[A](default: () => A) {
   /** Execute a block with the `Local` cleared, restoring the current
     * state upon completion.
     */
+  @deprecated("Binds on Local prevent propagation of writes to other locals. Use Local.isolate directly", "3.0.0-RC3")
   def bindClear[R](f: => R): R = {
-    // TODO - see comment above for bind
     val parent: AtomicAny[Local.Context] = Local.getContext()
     Local.setContext(AtomicAny(parent.get))
     Local.clearKey(key)
@@ -283,7 +283,7 @@ final class Local[A](default: () => A) {
 
   /** Clear the Local's value. Other [[Local Locals]] are not modified.
     *
-    * General usage should be via [[bindClear]] to avoid leaks.
+    * General usage should be in [[Local.isolate]] to avoid leaks.
     */
   def clear(): Unit =
     Local.clearKey(key)

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/TracingRunnable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/TracingRunnable.scala
@@ -17,6 +17,7 @@
 
 package monix.execution.schedulers
 
+import monix.execution.atomic.AtomicAny
 import monix.execution.misc.Local
 import monix.execution.misc.Local.Context
 
@@ -26,12 +27,12 @@ import monix.execution.misc.Local.Context
   *
   * Used by [[TracingScheduler]].
   */
-final class TracingRunnable(r: Runnable, context: Context = Local.getContext())
+final class TracingRunnable(r: Runnable, contextRef: AtomicAny[Context] = Local.getContext())
   extends Runnable {
 
   override def run(): Unit = {
-    val prev: Context = Local.getContext()
-    Local.setContext(context)
+    val prev = Local.getContext()
+    Local.setContext(contextRef)
     try r.run() finally Local.setContext(prev)
   }
 }

--- a/monix-execution/shared/src/test/scala/monix/execution/misc/LocalSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/misc/LocalSuite.scala
@@ -49,35 +49,15 @@ object LocalSuite extends SimpleTestSuite {
     assertEquals(local.get, 3)
   }
 
-  test("bind") {
-    val local = Local(0)
-    local := 100
-    assertEquals(local.get, 100)
-
-    val r = local.bind(200) {
-      local.get * 2
-    }
-
-    assertEquals(r, 400)
-    assertEquals(local.get, 100)
-  }
-
-  test("bindClear") {
-    val local = Local(10)
-    local := 100
-    assertEquals(local.get, 100)
-
-    val r = local.bindClear(local.get * 2)
-    assertEquals(r, 20)
-    assertEquals(local.get, 100)
-  }
-
   test("snapshot doesn't get captured in lazy execution") {
     val local1 = Local(0)
     val local2 = Local(0)
     local2 := 100
 
-    val value = local1.bind(100)(Eval.always(local1.get + local2.get))
+    val value = Local.isolate {
+      local1 := 100
+      Eval.always(local1.get + local2.get)
+    }
     local1 := 999
     local2 := 999
 
@@ -92,7 +72,10 @@ object LocalSuite extends SimpleTestSuite {
     val local2 = Local(0)
     local2 := 100
 
-    val f = local1.bind(100)(Future(local1.get + local2.get))
+    val f = Local.isolate {
+      local1 := 100
+      Future(local1.get + local2.get)
+    }
     local1 := 999
     local2 := 999
 
@@ -108,7 +91,10 @@ object LocalSuite extends SimpleTestSuite {
     val local2 = Local(0)
     local2 := 100
 
-    val f = local1.bind(100)(Future(local1.get + local2.get))
+    val f = Local.isolate {
+      local1 := 100
+      Future(local1.get + local2.get)
+    }
     local1 := 999
     local2 := 999
 
@@ -119,7 +105,10 @@ object LocalSuite extends SimpleTestSuite {
     val local = Local(0)
     local := 100
 
-    val f = local.bind(200)(Local.closed(() => local.get))
+    val f = Local.isolate {
+      local := 200
+      Local.closed(() => local.get)
+    }
     assertEquals(local.get, 100)
     assertEquals(f(), 200)
   }

--- a/monix-execution/shared/src/test/scala/monix/execution/schedulers/TracingSchedulerSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/schedulers/TracingSchedulerSuite.scala
@@ -39,7 +39,10 @@ object TracingSchedulerSuite extends SimpleTestSuite {
     val local2 = Local(0)
     local2 := 100
 
-    val f = local1.bind(100)(Future(local1.get + local2.get))
+    val f = Local.isolate {
+      local1 := 100
+      Future(local1.get + local2.get)
+    }
     local1 := 999
     local2 := 999
 
@@ -56,11 +59,17 @@ object TracingSchedulerSuite extends SimpleTestSuite {
     val local2 = Local(0)
     local2 := 100
 
-    val f = local1.bind(100)(Future(local1.get + local2.get))
+    val f = Local.isolate {
+      local1 := 100
+      Future(local1.get + local2.get)
+    }
     local1 := 42
     local2 := 999
 
-    val f2 = local2.bindClear(Future(local1.get + local2.get))
+    val f2 = Local.isolate {
+      local2.clear()
+      Future(local1.get + local2.get)
+    }
 
     assertEquals(f.value, None)
     ec.tick()
@@ -74,7 +83,10 @@ object TracingSchedulerSuite extends SimpleTestSuite {
     val local2 = Local(0)
     local2 := 100
 
-    val f = local1.bind(100)(Future(local1.get + local2.get))
+    val f = Local.isolate {
+      local1 := 100
+      Future(local1.get + local2.get)
+    }
     local1 := 999
     local2 := 999
 
@@ -89,7 +101,10 @@ object TracingSchedulerSuite extends SimpleTestSuite {
     val local2 = Local(0)
     local2 := 100
 
-    val f = local1.bind(100)(Future.delayedResult(1.second)(local1.get + local2.get))
+    val f = Local.isolate {
+      local1 := 100
+      Future.delayedResult(1.second)(local1.get + local2.get)
+    }
     local1 := 999
     local2 := 999
 
@@ -106,7 +121,8 @@ object TracingSchedulerSuite extends SimpleTestSuite {
     val local2 = Local(0)
     local2 := 100
 
-    val f = local1.bind(100) {
+    val f = Local.isolate {
+      local1 := 100
       var sum = 0
       var count = 0
       val p = Promise[Int]()

--- a/monix-execution/shared/src/test/scala/monix/execution/schedulers/TracingSchedulerSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/schedulers/TracingSchedulerSuite.scala
@@ -57,12 +57,15 @@ object TracingSchedulerSuite extends SimpleTestSuite {
     local2 := 100
 
     val f = local1.bind(100)(Future(local1.get + local2.get))
-    local1 := 999
+    local1 := 42
     local2 := 999
+
+    val f2 = local2.bindClear(Future(local1.get + local2.get))
 
     assertEquals(f.value, None)
     ec.tick()
     assertEquals(f.value, Some(Success(200)))
+    assertEquals(f2.value, Some(Success(42)))
   }
 
   testAsync("captures locals in actual async execution") {

--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -4,6 +4,11 @@ import com.typesafe.tools.mima.core.ProblemFilters.exclude
 object MimaFilters {
 
   lazy val changesFor_3_0_0: Seq[ProblemFilter] = Seq(
+    // Breaking changes for https://github.com/monix/monix/pull/866
+    exclude[IncompatibleResultTypeProblem]("monix.execution.schedulers.TracingRunnable.<init>$default$2"),
+    exclude[IncompatibleMethTypeProblem]("monix.execution.schedulers.TracingRunnable.this"),
+    exclude[IncompatibleResultTypeProblem]("monix.execution.misc.Local.getContext"),
+    exclude[IncompatibleMethTypeProblem]("monix.execution.misc.Local.setContext"),
     // Breaking changes for https://github.com/monix/monix/pull/822
     exclude[DirectMissingMethodProblem]("monix.execution.CancelableFuture.catsInstances"),
     exclude[MissingClassProblem]("monix.execution.CancelableFuture$CatsInstances"),


### PR DESCRIPTION
Attempt to fix #837 and #848, with `AtomicAny[Map[_, _]]` model.

As a side bonus, #851 is fixed automatically.

Needs more tests, `TaskLocal.isolate`, and I also would like to experiment on making `bind` not affect the reads of non-bound locals.