### PR TITLE
fix compile errors with latest Scala 2.13

### DIFF
--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -2480,7 +2480,7 @@ abstract class Observable[+A] extends Serializable { self =>
     *        throws an error.
     */
   final def onErrorRecover[B >: A](pf: PartialFunction[Throwable, B]): Observable[B] =
-    onErrorHandleWith(ex => (pf andThen Observable.now).applyOrElse(ex, Observable.raiseError))
+    onErrorHandleWith(ex => (pf.andThen(Observable.now(_))).applyOrElse(ex, Observable.raiseError _))
 
   /** Returns an Observable that mirrors the behavior of the source,
     * unless the source is terminated with an `onError`, in which case


### PR DESCRIPTION
https://scala-ci.typesafe.com/job/scala-2.13.x-integrate-community-build/1981/consoleText

```
[monix] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.16/project-builds/monix-68f96a20147d411e5f7069a24342c5d9f961029a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala:2483:52: missing argument list for method now in object Observable
[monix] [error] Unapplied methods are only converted to functions when a function type is expected.
[monix] [error] You can make this conversion explicit by writing `now _` or `now(_)` instead of `now`.
[monix] [error]     onErrorHandleWith(ex => (pf andThen Observable.now).applyOrElse(ex, Observable.raiseError))
[monix] [error]                                                    ^
[monix] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.16/project-builds/monix-68f96a20147d411e5f7069a24342c5d9f961029a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala:2483:84: missing argument list for method raiseError in object Observable
[monix] [error] Unapplied methods are only converted to functions when a function type is expected.
[monix] [error] You can make this conversion explicit by writing `raiseError _` or `raiseError(_)` instead of `raiseError`.
[monix] [error]     onErrorHandleWith(ex => (pf andThen Observable.now).applyOrElse(ex, Observable.raiseError))
[monix] [error]                                                                                    ^
```