### PR TITLE
Compile Benchmarks in CI

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,15 +7,13 @@ val allProjects = List(
   "eval",
   "tail",
   "reactive",
-  "java",
-  "benchmarksPrev",
-  "benchmarksNext"
+  "java"
 )
 
 addCommandAlias("ci",          ";ci-jvm ;ci-js")
 addCommandAlias("ci-all",      ";ci-jvm ;ci-js ;mimaReportBinaryIssues ;unidoc")
-addCommandAlias("ci-js",       s";clean ;coreJS/test:compile ;${allProjects.filter(_ != "java").map(_ + "JS/test").mkString(" ;")}")
-addCommandAlias("ci-jvm",      s";clean ;coreJVM/test:compile ;${allProjects.map(_ + "JVM/test").mkString(" ;")}")
+addCommandAlias("ci-js",       s";clean ;coreJS/test:compile ;${allProjects.filter(_ != "java").map(_ + "JS/test").mkString(" ;")} ;benchmarksPrev ;benchmarksNext")
+addCommandAlias("ci-jvm",      s";clean ;coreJVM/test:compile ;${allProjects.map(_ + "JVM/test").mkString(" ;")} ;benchmarksPrev ;benchmarksNext")
 addCommandAlias("ci-jvm-mima", s";ci-jvm ;mimaReportBinaryIssues")
 addCommandAlias("ci-jvm-all",  s";ci-jvm-mima ;unidoc")
 addCommandAlias("release",     ";project monix ;+clean ;+package ;+publishSigned")

--- a/build.sbt
+++ b/build.sbt
@@ -10,10 +10,15 @@ val allProjects = List(
   "java"
 )
 
+val benchmarkProjects = List(
+  "benchmarksPrev",
+  "benchmarksNext"
+).map(_ + "/compile")
+
 addCommandAlias("ci",          ";ci-jvm ;ci-js")
 addCommandAlias("ci-all",      ";ci-jvm ;ci-js ;mimaReportBinaryIssues ;unidoc")
-addCommandAlias("ci-js",       s";clean ;coreJS/test:compile ;${allProjects.filter(_ != "java").map(_ + "JS/test").mkString(" ;")} ;benchmarksPrev ;benchmarksNext")
-addCommandAlias("ci-jvm",      s";clean ;coreJVM/test:compile ;${allProjects.map(_ + "JVM/test").mkString(" ;")} ;benchmarksPrev ;benchmarksNext")
+addCommandAlias("ci-js",       s";clean ;coreJS/test:compile ;${(allProjects.filter(_ != "java").map(_ + "JS/test") ++ benchmarkProjects).mkString(" ;")}")
+addCommandAlias("ci-jvm",      s";clean ;coreJVM/test:compile ;${(allProjects.map(_ + "JVM/test") ++ benchmarkProjects).mkString(" ;")}")
 addCommandAlias("ci-jvm-mima", s";ci-jvm ;mimaReportBinaryIssues")
 addCommandAlias("ci-jvm-all",  s";ci-jvm-mima ;unidoc")
 addCommandAlias("release",     ";project monix ;+clean ;+package ;+publishSigned")

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,8 @@ val allProjects = List(
 )
 
 val benchmarkProjects = List(
-  "benchmarksPrev",
+  // Enable after 2.13 version is released for previous version
+  // "benchmarksPrev",
   "benchmarksNext"
 ).map(_ + "/compile")
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,9 @@ val allProjects = List(
   "eval",
   "tail",
   "reactive",
-  "java"
+  "java",
+  "benchmarksPrev",
+  "benchmarksNext"
 )
 
 addCommandAlias("ci",          ";ci-jvm ;ci-js")


### PR DESCRIPTION
Currently CI ignores benchmarks so they can become wrong without anyone noticing and just compilation shouldn't cost us too much time

EDIT: CI fails because we don't have `3.0.0-RC1` for Scala `2.13.0-M5`, I'll handle it later