### PR TITLE
Add UnsafeBecauseImpure Annotation to foreach.

### DIFF
--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -1743,6 +1743,7 @@ sealed abstract class Task[+A] extends Serializable {
     *
     * Exceptions in `f` are reported using provided (implicit) Scheduler
     */
+  @UnsafeBecauseImpure
   final def foreach(f: A => Unit)(implicit s: Scheduler): Unit =
     runToFuture.foreach(f)
 


### PR DESCRIPTION
Because it calls runToFuture, which is Impure.