### PR TITLE
【Issue-931】Remove try-catch for EvalOnceObservable implementation

### DIFF
--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/EvalOnceObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/EvalOnceObservable.scala
@@ -32,20 +32,10 @@ private[reactive] final class EvalOnceObservable[A](a: => A) extends Observable[
   @volatile private[this] var hasResult = false
 
   private def signalResult(out: Subscriber[A], value: A, ex: Throwable): Unit = {
-    if (ex != null)
-      try out.onError(ex)
-      catch {
-        case err if NonFatal(err) =>
-          out.scheduler.reportFailure(err)
-          out.scheduler.reportFailure(ex)
-      } else
-      try {
-        out.onNext(value)
-        out.onComplete()
-      } catch {
-        case err if NonFatal(err) =>
-          out.scheduler.reportFailure(err)
-      }
+    if (ex == null) {
+      out.onNext(value)
+      out.onComplete()
+    } else out.onError(ex)
   }
 
   def unsafeSubscribeFn(subscriber: Subscriber[A]): Cancelable = {


### PR DESCRIPTION
https://github.com/monix/monix/issues/931

As written in the issue description, Observable need not to throw any exceptions as per contract so I have removed the try-catch and simply made a sequential calling for the desired processing.

I have also added one relevant test.