### PR TITLE
【Issue-928】Add defaults values for benchmarking

### DIFF
--- a/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalAttemptBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalAttemptBenchmark.scala
@@ -29,15 +29,25 @@ import org.openjdk.jmh.annotations._
   *
   * Or to run the benchmark from within SBT:
   *
-  *     jmh:run -i 10 -wi 10 -f 2 -t 1 monix.benchmarks.CoevalAttemptBenchmark
+  *     jmh:run monix.benchmarks.TaskShiftBenchmark
+  *     The above test will take default values as "10 iterations", "10 warm-up iterations",
+  *     "2 forks", "1 thread".
   *
-  * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread".
+  *     Or to specify custom values use below format:
+  *
+  *     jmh:run -i 20 -wi 20 -f 4 -t 2 monix.benchmarks.TaskShiftBenchmark
+  *
+  * Which means "20 iterations", "20 warm-up iterations", "4 forks", "2 thread".
   * Please note that benchmarks should be usually executed at least in
   * 10 iterations (as a rule of thumb), but more is better.
   */
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@Warmup(iterations = 10)
+@Fork(2)
+@Threads(1)
 class CoevalAttemptBenchmark {
   @Param(Array("10000"))
   var size: Int = _

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalDeepBindBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalDeepBindBenchmark.scala
@@ -29,15 +29,25 @@ import org.openjdk.jmh.annotations._
   *
   * Or to run the benchmark from within SBT:
   *
-  *     jmh:run -i 10 -wi 10 -f 2 -t 1 monix.benchmarks.CoevalDeepBindBenchmark
+  *     jmh:run monix.benchmarks.TaskShiftBenchmark
+  *     The above test will take default values as "10 iterations", "10 warm-up iterations",
+  *     "2 forks", "1 thread".
   *
-  * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread".
+  *     Or to specify custom values use below format:
+  *
+  *     jmh:run -i 20 -wi 20 -f 4 -t 2 monix.benchmarks.TaskShiftBenchmark
+  *
+  * Which means "20 iterations", "20 warm-up iterations", "4 forks", "2 thread".
   * Please note that benchmarks should be usually executed at least in
   * 10 iterations (as a rule of thumb), but more is better.
   */
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@Warmup(iterations = 10)
+@Fork(2)
+@Threads(1)
 class CoevalDeepBindBenchmark {
   @Param(Array("3000"))
   var size: Int = _

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalHandleErrorBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalHandleErrorBenchmark.scala
@@ -29,15 +29,25 @@ import monix.eval.Coeval
   *
   * Or to run the benchmark from within SBT:
   *
-  *     jmh:run -i 10 -wi 10 -f 2 -t 1 monix.benchmarks.CoevalHandleErrorBenchmark
+  *     jmh:run monix.benchmarks.TaskShiftBenchmark
+  *     The above test will take default values as "10 iterations", "10 warm-up iterations",
+  *     "2 forks", "1 thread".
   *
-  * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread".
+  *     Or to specify custom values use below format:
+  *
+  *     jmh:run -i 20 -wi 20 -f 4 -t 2 monix.benchmarks.TaskShiftBenchmark
+  *
+  * Which means "20 iterations", "20 warm-up iterations", "4 forks", "2 thread".
   * Please note that benchmarks should be usually executed at least in
   * 10 iterations (as a rule of thumb), but more is better.
   */
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@Warmup(iterations = 10)
+@Fork(2)
+@Threads(1)
 class CoevalHandleErrorBenchmark {
   @Param(Array("10000"))
   var size: Int = _

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalMapCallsBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalMapCallsBenchmark.scala
@@ -30,15 +30,25 @@ import org.openjdk.jmh.annotations._
   *
   * Or to run the benchmark from within SBT:
   *
-  *     jmh:run -i 10 -wi 10 -f 2 -t 1 monix.benchmarks.CoevalMapCallsBenchmark
+  *     jmh:run monix.benchmarks.TaskShiftBenchmark
+  *     The above test will take default values as "10 iterations", "10 warm-up iterations",
+  *     "2 forks", "1 thread".
   *
-  * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread".
+  *     Or to specify custom values use below format:
+  *
+  *     jmh:run -i 20 -wi 20 -f 4 -t 2 monix.benchmarks.TaskShiftBenchmark
+  *
+  * Which means "20 iterations", "20 warm-up iterations", "4 forks", "2 thread".
   * Please note that benchmarks should be usually executed at least in
   * 10 iterations (as a rule of thumb), but more is better.
   */
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@Warmup(iterations = 10)
+@Fork(2)
+@Threads(1)
 class CoevalMapCallsBenchmark {
   import CoevalMapCallsBenchmark.test
 

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalMapStreamBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalMapStreamBenchmark.scala
@@ -30,15 +30,26 @@ import org.openjdk.jmh.annotations._
   *
   * Or to run the benchmark from within SBT:
   *
-  *     jmh:run -i 10 -wi 10 -f 2 -t 1 monix.benchmarks.CoevalMapStreamBenchmark
   *
-  * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread".
+  *     jmh:run monix.benchmarks.TaskShiftBenchmark
+  *     The above test will take default values as "10 iterations", "10 warm-up iterations",
+  *     "2 forks", "1 thread".
+  *
+  *     Or to specify custom values use below format:
+  *
+  *     jmh:run -i 20 -wi 20 -f 4 -t 2 monix.benchmarks.TaskShiftBenchmark
+  *
+  * Which means "20 iterations", "20 warm-up iterations", "4 forks", "2 thread".
   * Please note that benchmarks should be usually executed at least in
   * 10 iterations (as a rule of thumb), but more is better.
   */
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@Warmup(iterations = 10)
+@Fork(2)
+@Threads(1)
 class CoevalMapStreamBenchmark {
   import CoevalMapStreamBenchmark.streamTest
 

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalShallowBindBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalShallowBindBenchmark.scala
@@ -28,15 +28,25 @@ import org.openjdk.jmh.annotations._
   *
   * Or to run the benchmark from within SBT:
   *
-  *     jmh:run -i 10 -wi 10 -f 2 -t 1 monix.benchmarks.CoevalShallowBindBenchmark
+  *     jmh:run monix.benchmarks.TaskShiftBenchmark
+  *     The above test will take default values as "10 iterations", "10 warm-up iterations",
+  *     "2 forks", "1 thread".
   *
-  * Which means "10 iterations", "10 warm-up iterations", "2 fork", "1 thread".
+  *     Or to specify custom values use below format:
+  *
+  *     jmh:run -i 20 -wi 20 -f 4 -t 2 monix.benchmarks.TaskShiftBenchmark
+  *
+  * Which means "20 iterations", "20 warm-up iterations", "4 forks", "2 thread".
   * Please note that benchmarks should be usually executed at least in
   * 10 iterations (as a rule of thumb), but more is better.
   */
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@Warmup(iterations = 10)
+@Fork(2)
+@Threads(1)
 class CoevalShallowBindBenchmark {
   @Param(Array("10000"))
   var size: Int = _

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/IterantMapFoldBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/IterantMapFoldBenchmark.scala
@@ -30,15 +30,25 @@ import org.openjdk.jmh.annotations._
   *
   * Or to run the benchmark from within SBT:
   *
-  *     jmh:run -i 10 -wi 10 -f 2 -t 1 monix.benchmarks.IterantMapFoldBenchmark
+  *     jmh:run monix.benchmarks.TaskShiftBenchmark
+  *     The above test will take default values as "10 iterations", "10 warm-up iterations",
+  *     "2 forks", "1 thread".
   *
-  * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread".
+  *     Or to specify custom values use below format:
+  *
+  *     jmh:run -i 20 -wi 20 -f 4 -t 2 monix.benchmarks.TaskShiftBenchmark
+  *
+  * Which means "20 iterations", "20 warm-up iterations", "4 forks", "2 thread".
   * Please note that benchmarks should be usually executed at least in
   * 10 iterations (as a rule of thumb), but more is better.
   */
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@Warmup(iterations = 10)
+@Fork(2)
+@Threads(1)
 class IterantMapFoldBenchmark {
   import IterantMapFoldBenchmark._
 

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/ObservableConcatMapBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/ObservableConcatMapBenchmark.scala
@@ -35,15 +35,25 @@ import scala.concurrent.{Await, Promise}
   *
   * Or to run the benchmark from within SBT:
   *
-  *     jmh:run -i 10 -wi 10 -f 2 -t 1 monix.benchmarks.ObservableConcatMapBenchmark
+  *     jmh:run monix.benchmarks.TaskShiftBenchmark
+  *     The above test will take default values as "10 iterations", "10 warm-up iterations",
+  *     "2 forks", "1 thread".
   *
-  * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread".
+  *     Or to specify custom values use below format:
+  *
+  *     jmh:run -i 20 -wi 20 -f 4 -t 2 monix.benchmarks.TaskShiftBenchmark
+  *
+  * Which means "20 iterations", "20 warm-up iterations", "4 forks", "2 thread".
   * Please note that benchmarks should be usually executed at least in
   * 10 iterations (as a rule of thumb), but more is better.
   */
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@Warmup(iterations = 10)
+@Fork(2)
+@Threads(1)
 class ObservableConcatMapBenchmark {
   @Param(Array("100000"))
   var size: Int = _

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/TrampolinedRunnableBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/TrampolinedRunnableBenchmark.scala
@@ -29,15 +29,25 @@ import org.openjdk.jmh.annotations._
   *
   * Or to run the benchmark from within SBT:
   *
-  *     jmh:run -i 10 -wi 10 -f 2 -t 1 monix.benchmarks.TrampolinedRunnableBenchmark
+  *     jmh:run monix.benchmarks.TaskShiftBenchmark
+  *     The above test will take default values as "10 iterations", "10 warm-up iterations",
+  *     "2 forks", "1 thread".
   *
-  * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread".
+  *     Or to specify custom values use below format:
+  *
+  *     jmh:run -i 20 -wi 20 -f 4 -t 2 monix.benchmarks.TaskShiftBenchmark
+  *
+  * Which means "20 iterations", "20 warm-up iterations", "4 forks", "2 thread".
   * Please note that benchmarks should be usually executed at least in
   * 10 iterations (as a rule of thumb), but more is better.
   */
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@Warmup(iterations = 10)
+@Fork(2)
+@Threads(1)
 class TrampolinedRunnableBenchmark {
   @Param(Array("3000"))
   var size: Int = _

--- a/benchmarks/vnext/src/main/scala/monix/benchmarks/AsyncQueueBenchmark.scala
+++ b/benchmarks/vnext/src/main/scala/monix/benchmarks/AsyncQueueBenchmark.scala
@@ -32,15 +32,25 @@ import scala.concurrent.{Await, Future}
   *
   * Or to run the benchmark from within SBT:
   *
-  *     jmh:run -i 10 -wi 10 -f 2 -t 1 monix.benchmarks.AsyncQueueBenchmark
+  *     jmh:run monix.benchmarks.TaskShiftBenchmark
+  *     The above test will take default values as "10 iterations", "10 warm-up iterations",
+  *     "2 forks", "1 thread".
   *
-  * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread".
+  *     Or to specify custom values use below format:
+  *
+  *     jmh:run -i 20 -wi 20 -f 4 -t 2 monix.benchmarks.TaskShiftBenchmark
+  *
+  * Which means "20 iterations", "20 warm-up iterations", "4 forks", "2 thread".
   * Please note that benchmarks should be usually executed at least in
   * 10 iterations (as a rule of thumb), but more is better.
   */
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@Warmup(iterations = 10)
+@Fork(2)
+@Threads(1)
 class AsyncQueueBenchmark {
   @Param(Array("10000"))
   var size: Int = _

--- a/benchmarks/vnext/src/main/scala/monix/benchmarks/TaskShiftBenchmark.scala
+++ b/benchmarks/vnext/src/main/scala/monix/benchmarks/TaskShiftBenchmark.scala
@@ -32,15 +32,25 @@ import scala.concurrent.duration.Duration
   *
   * Or to run the benchmark from within SBT:
   *
-  *     jmh:run -i 10 -wi 10 -f 2 -t 1 monix.benchmarks.TaskShiftBenchmark
+  *     jmh:run monix.benchmarks.TaskShiftBenchmark
+  *     The above test will take default values as "10 iterations", "10 warm-up iterations",
+  *     "2 forks", "1 thread".
   *
-  * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread".
+  *     Or to specify custom values use below format:
+  *
+  *     jmh:run -i 20 -wi 20 -f 4 -t 2 monix.benchmarks.TaskShiftBenchmark
+  *
+  * Which means "20 iterations", "20 warm-up iterations", "4 forks", "2 thread".
   * Please note that benchmarks should be usually executed at least in
   * 10 iterations (as a rule of thumb), but more is better.
   */
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@Warmup(iterations = 10)
+@Fork(2)
+@Threads(1)
 class TaskShiftBenchmark {
   @Param(Array("3000"))
   var size: Int = _

--- a/benchmarks/vprev/src/main/scala/monix/benchmarks/AsyncQueueBenchmark.scala
+++ b/benchmarks/vprev/src/main/scala/monix/benchmarks/AsyncQueueBenchmark.scala
@@ -32,15 +32,25 @@ import scala.concurrent.{Await, Future}
   *
   * Or to run the benchmark from within SBT:
   *
-  *     jmh:run -i 10 -wi 10 -f 2 -t 1 monix.benchmarks.AsyncQueueBenchmark
+  *     jmh:run monix.benchmarks.TaskShiftBenchmark
+  *     The above test will take default values as "10 iterations", "10 warm-up iterations",
+  *     "2 forks", "1 thread".
   *
-  * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread".
+  *     Or to specify custom values use below format:
+  *
+  *     jmh:run -i 20 -wi 20 -f 4 -t 2 monix.benchmarks.TaskShiftBenchmark
+  *
+  * Which means "20 iterations", "20 warm-up iterations", "4 forks", "2 thread".
   * Please note that benchmarks should be usually executed at least in
   * 10 iterations (as a rule of thumb), but more is better.
   */
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@Warmup(iterations = 10)
+@Fork(2)
+@Threads(1)
 class AsyncQueueBenchmark {
   @Param(Array("10000"))
   var size: Int = _


### PR DESCRIPTION
https://github.com/monix/monix/issues/928

@Avasil 
I have added the defaults values for various parameters for benchmarking tests.
Also, have added the quick snippet for the code run.

```
[IJ]sbt:benchmarksNext> jmh:run monix.benchmarks.TaskShiftBenchmark
[info] Running (fork) org.openjdk.jmh.Main monix.benchmarks.TaskShiftBenchmark
....
[info] # JMH version: 1.21
[info] # VM version: JDK 1.8.0_212, OpenJDK 64-Bit Server VM, 25.212-b03
[info] # VM invoker: /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/bin/java
[info] # VM options: <none>
[info] # Warmup: 10 iterations, 10 s each
[info] # Measurement: 10 iterations, 10 s each
[info] # Timeout: 10 min per iteration
[info] # Threads: 1 thread, will synchronize iterations
[info] # Benchmark mode: Throughput, ops/time
[info] # Benchmark: monix.benchmarks.TaskShiftBenchmark.createCancelable
[info] # Parameters: (size = 3000)
....
```

```
IJ]sbt:benchmarksNext> jmh:run -i 20 -wi 20 -f 4 -t 2 monix.benchmarks.TaskShiftBenchmark
....
[info] Running (fork) org.openjdk.jmh.Main -i 20 -wi 20 -f 4 -t 2 monix.benchmarks.TaskShiftBenchmark
[info] # JMH version: 1.21
[info] # VM version: JDK 1.8.0_212, OpenJDK 64-Bit Server VM, 25.212-b03
[info] # VM invoker: /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/bin/java
[info] # VM options: <none>
[info] # Warmup: 20 iterations, 10 s each
[info] # Measurement: 20 iterations, 10 s each
[info] # Timeout: 10 min per iteration
[info] # Threads: 2 threads, will synchronize iterations
[info] # Benchmark mode: Throughput, ops/time
[info] # Benchmark: monix.benchmarks.TaskShiftBenchmark.createCancelable
[info] # Parameters: (size = 3000)
....
```