### PR TITLE
Add void to Task + Coeval

### DIFF
--- a/monix-eval/shared/src/main/scala/monix/eval/Coeval.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Coeval.scala
@@ -861,6 +861,11 @@ sealed abstract class Coeval[+A] extends (() => A) with Serializable { self =>
       a => f(None).map(_ => a)
     )
 
+  /** Returns this coeval mapped to unit
+    */
+  final def void: Coeval[Unit] =
+    this.map(_ => ())
+
   /** Zips the values of `this` and `that` coeval, and creates a new coeval
     * that will emit the tuple of their results.
     */

--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -2399,6 +2399,11 @@ sealed abstract class Task[+A] extends Serializable {
       a     <- this
       end   <- Task.clock.monotonic(NANOSECONDS)
     } yield (FiniteDuration(end - start, NANOSECONDS), a)
+
+  /** Returns this task mapped to unit
+    */
+  final def void: Task[Unit] =
+    this.map(_ => ())
 }
 
 /** Builders for [[Task]].


### PR DESCRIPTION
I know we have this in cats. But its pretty annoying having to import just for `void`.