### PR TITLE
Implement ContextShift.evalOn in terms of Task.executeOn

### DIFF
--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -4669,7 +4669,11 @@ private[eval] abstract class TaskContextShift extends TaskTimers {
       override def shift: Task[Unit] =
         Task.shift(s)
       override def evalOn[A](ec: ExecutionContext)(fa: Task[A]): Task[A] =
-        Task.shift(ec).bracket(_ => fa)(_ => Task.shift(s))
+        ec match {
+          case ref: Scheduler => fa.executeOn(ref, forceAsync = true)
+          case _ => fa.executeOn(Scheduler(ec), forceAsync = true)
+        }
+
     }
 }
 

--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -4658,7 +4658,11 @@ private[eval] abstract class TaskContextShift extends TaskTimers {
       override def shift: Task[Unit] =
         Task.shift
       override def evalOn[A](ec: ExecutionContext)(fa: Task[A]): Task[A] =
-        Task.shift(ec).bracket(_ => fa)(_ => Task.shift)
+        ec match {
+          case ref: Scheduler => fa.executeOn(ref, forceAsync = true)
+          case _ => fa.executeOn(Scheduler(ec), forceAsync = true)
+        }
+
     }
 
   /** Builds a `cats.effect.ContextShift` instance, given a

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskClockTimerAndContextShiftSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskClockTimerAndContextShiftSuite.scala
@@ -20,10 +20,11 @@ package monix.eval
 import java.util.concurrent.TimeUnit
 
 import cats.effect.{Clock, ContextShift, Timer}
+import monix.execution.exceptions.DummyException
 import monix.execution.schedulers.TestScheduler
 
 import scala.concurrent.duration._
-import scala.util.Success
+import scala.util.{Failure, Success}
 
 object TaskClockTimerAndContextShiftSuite extends BaseTestSuite {
   test("Task.clock is implicit") { _ =>
@@ -126,6 +127,20 @@ object TaskClockTimerAndContextShiftSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(1)))
   }
 
+  test("Task.contextShift.evalOn(s2) failure") { implicit s =>
+    val s2 = TestScheduler()
+    val dummy = DummyException("dummy")
+    val f = Task.contextShift.evalOn(s2)(Task.raiseError(dummy)).runToFuture
+
+    assertEquals(f.value, None)
+    s.tick()
+    assertEquals(f.value, None)
+    s2.tick()
+    assertEquals(f.value, None)
+    s.tick()
+    assertEquals(f.value, Some(Failure(dummy)))
+  }
+
   test("Task.contextShift(s).shift") { implicit s =>
     val f = Task.contextShift(s).shift.runToFuture
     assertEquals(f.value, None)
@@ -143,5 +158,19 @@ object TaskClockTimerAndContextShiftSuite extends BaseTestSuite {
     s2.tick()
     s.tick()
     assertEquals(f.value, Some(Success(1)))
+  }
+
+  test("Task.contextShift(s).evalOn(s2) failure") { implicit s =>
+    val s2 = TestScheduler()
+    val dummy = DummyException("dummy")
+    val f = Task.contextShift(s).evalOn(s2)(Task.raiseError(dummy)).runToFuture
+
+    assertEquals(f.value, None)
+    s.tick()
+    assertEquals(f.value, None)
+    s2.tick()
+    assertEquals(f.value, None)
+    s.tick()
+    assertEquals(f.value, Some(Failure(dummy)))
   }
 }

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskClockTimerAndContextShiftSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskClockTimerAndContextShiftSuite.scala
@@ -156,7 +156,7 @@ object TaskClockTimerAndContextShiftSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(1)))
   }
 
-  test("Task.contextShift(s).evalOn(s2) injects s2 to Task.deferAction") { implicit s =>
+  test("Task.contextShift.evalOn(s2) injects s2 to Task.deferAction") { implicit s =>
     val s2 = TestScheduler()
 
     var wasScheduled = false


### PR DESCRIPTION
Following suggestion from @oleg-py 
Should be a bit safer considering Monix's auto-shifts