### PR TITLE
Add Observable.throttle

### DIFF
--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -3061,6 +3061,32 @@ abstract class Observable[+A] extends Serializable { self =>
   final def takeWhileNotCanceled(c: BooleanCancelable): Observable[A] =
     self.liftByOperator(new TakeWhileNotCanceledOperator(c))
 
+  /** Returns an Observable that emits maximum `n` items per given `period`.
+    *
+    * Unlike [[Observable!.throttleLast]] and [[Observable!.throttleFirst]]
+    * it does not discard any elements.
+    *
+    * If the source observable completes, then the current buffer gets
+    * signaled downstream. If the source triggers an error then the
+    * current buffer is being dropped and the error gets propagated
+    * immediately.
+    *
+    * Usage:
+    *
+    * {{{
+    *   import scala.concurrent.duration._
+    *
+    *   // emits two items per second
+    *   Observable.fromIterable(0 to 10)
+    *     .throttle(1.second, 2)
+    * }}}
+    *
+    * @param  period time that has to pass before emiting new items
+    * @param  n      maximum number of items emitted per given `period`
+    */
+  final def throttle(period: FiniteDuration, n: Int): Observable[A] =
+    bufferTimedWithPressure(period, n).flatMap(Observable.fromIterable)
+
   /** Returns an Observable that emits only the first item emitted by
     * the source Observable during sequential time windows of a
     * specified duration.
@@ -3069,6 +3095,20 @@ abstract class Observable[+A] extends Serializable { self =>
     * tracks passage of time whereas `throttleLast` ticks at scheduled
     * intervals.
     *
+    * Usage:
+    *
+    * {{{
+    *   import scala.concurrent.duration._
+    *
+    *   // emits 0, 5, 10 in 1 second intervals
+    *   Observable.fromIterable(0 to 10)
+    *     // without delay, it would return only 0
+    *     .delayOnNext(200.millis)
+    *     .throttleFirst(1.second)
+    * }}}
+    *
+    * @see [[throttle]] for a version that allows to specify number
+    *      of elements processed by a period and does not drop any elements
     * @param interval time to wait before emitting another item after
     *        emitting the last item
     */
@@ -3080,6 +3120,20 @@ abstract class Observable[+A] extends Serializable { self =>
     *
     * Alias for [[sample]].
     *
+    * Usage:
+    *
+    * {{{
+    *   import scala.concurrent.duration._
+    *
+    *   // emits 3, 8, 10 in 1 second intervals
+    *   Observable.fromIterable(0 to 10)
+    *     // without delay, it would return only 10
+    *     .delayOnNext(200.millis)
+    *     .throttleLast(1.second)
+    * }}}
+    *
+    * @see [[throttle]] for a version that allows to specify number
+    *      of elements processed by a period and does not drop any elements
     * @param period duration of windows within which the last item
     *        emitted by the source Observable will be emitted
     */
@@ -3096,8 +3150,23 @@ abstract class Observable[+A] extends Serializable { self =>
     * results from the `sample` operator will emit no item for that
     * sampling period.
     *
+    * Usage:
+    *
+    * {{{
+    *   import scala.concurrent.duration._
+    *
+    *   // emits 3, 8, 10 in 1 second intervals
+    *   Observable.fromIterable(0 to 10)
+    *     // without delay, it would return only 10
+    *     .delayOnNext(200.millis)
+    *     .sample(1.second)
+    * }}}
+    *
     * @see [[sampleBy]] for fine control
     * @see [[sampleRepeated]] for repeating the last value on silence
+    * @see [[throttle]] for a version that allows to specify number
+    *      of elements processed by a period and does not drop any elements
+    *
     * @param period the timespan at which sampling occurs
     */
   final def sample(period: FiniteDuration): Observable[A] =

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BaseOperatorSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BaseOperatorSuite.scala
@@ -75,7 +75,7 @@ abstract class BaseOperatorSuite extends BaseTestSuite {
 
     createObservable(sourceCount) match {
       case None => ignore()
-      case Some(Sample(obs, count, sum, waitForFirst, waitForNext)) =>
+      case Some(Sample(obs, count, _, waitForFirst, waitForNext)) =>
         obs.unsafeSubscribeFn(new Observer[Long] {
           def onNext(elem: Long): Ack = {
             received += 1

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ThrottleSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ThrottleSuite.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.reactive.internal.operators
+
+import monix.reactive.Observable
+
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.duration._
+import scala.util.Success
+
+object ThrottleSuite extends BaseOperatorSuite {
+  def sum(sourceCount: Int) = {
+    sourceCount * (sourceCount - 1) / 2
+  }
+
+  def createObservable(sourceCount: Int) = Some {
+    require(sourceCount > 0, "sourceCount must be strictly positive")
+
+    val o = Observable
+      .range(0, sourceCount)
+      .throttle(1.second, 2)
+
+    Sample(o, sourceCount, sum(sourceCount), 1.second, 1.second)
+  }
+
+  def observableInError(sourceCount: Int, ex: Throwable) = None
+  def brokenUserCodeObservable(sourceCount: Int, ex: Throwable) = None
+
+  override def cancelableObservables() = {
+    val o = Observable.intervalAtFixedRate(500.millis).throttle(1.second, 2)
+    Seq(
+      Sample(o, 0, 0, 0.seconds, 0.seconds),
+      Sample(o, 2, 3, 1.seconds, 1.seconds)
+    )
+  }
+
+  test("should emit elements at given rate without dropping them") { implicit s =>
+    val lastElements = ListBuffer[Long]()
+
+    val f = Observable
+      .range(0, 10)
+      .throttle(1.second, 2)
+      .map(lastElements += _)
+      .completedL
+      .runToFuture
+
+    s.tick(1.seconds)
+    assertEquals(lastElements.toList, List(0, 1))
+    s.tick(2.seconds)
+    assertEquals(lastElements.toList, List(0, 1, 2, 3, 4, 5))
+    s.tick(1.day)
+    assertEquals(lastElements.toList, List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))
+    assertEquals(f.value, Some(Success(())))
+  }
+}


### PR DESCRIPTION
I'm not aware of equivalent in ReactiveX but it's quite handy operator and `bufferTimedWithPressure` is confusing and hard to find

It's called `throttle` in Akka Streams: https://doc.akka.io/docs/akka/current/stream/operators/Source-or-Flow/throttle.html

And `metered` in fs2