### PR TITLE
Fix #938 — fixes resource handling in Iterant.repeat, adds Iterant.retryIfEmpty

### DIFF
--- a/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
@@ -1409,6 +1409,17 @@ sealed abstract class Iterant[F[_], A] extends Product with Serializable {
   final def repeat(implicit F: Sync[F]): Iterant[F, A] =
     IterantRepeat(self)
 
+  /**
+    * Retries processing the source stream after the search is
+    * detected as being empty.
+    *
+    * {{{
+    *
+    * }}}
+    */
+  final def retryIfEmpty(maxRetries: Option[Int])(implicit F: Sync[F]): Iterant[F, A] =
+    IterantRetryIfEmpty(self, maxRetries)
+
   /** Returns an `Iterant` that mirrors the behavior of the source,
     * unless the source is terminated with an error, in which case
     * the streaming of events continues with the specified backup

--- a/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
@@ -1405,6 +1405,25 @@ sealed abstract class Iterant[F[_], A] extends Product with Serializable {
   /** Repeats the items emitted by the source continuously
     *
     * It terminates either on error or if the source is empty.
+    *
+    * In case repetition on empty streams is desired, then combine with
+    * [[retryIfEmpty]]:
+    *
+    * {{{
+    *   import monix.eval.Coeval
+    *   import scala.util.Random
+    *
+    *   val stream = Iterant[Coeval].suspend(Coeval {
+    *     val nr = Random.nextInt()
+    *     if (nr % 10 != 0)
+    *       Iterant[Coeval].empty[Int]
+    *     else
+    *       Iterant[Coeval].of(1, 2, 3)
+    *   })
+    *
+    *   // Will eventually repeat elements 1, 2, 3
+    *   stream.retryIfEmpty(None).repeat
+    * }}}
     */
   final def repeat(implicit F: Sync[F]): Iterant[F, A] =
     IterantRepeat(self)
@@ -1414,8 +1433,23 @@ sealed abstract class Iterant[F[_], A] extends Product with Serializable {
     * detected as being empty.
     *
     * {{{
+    *   import monix.eval.Coeval
+    *   import scala.util.Random
     *
+    *   val stream = Iterant[Coeval].suspend(Coeval {
+    *     val nr = Random.nextInt()
+    *     if (nr % 10 != 0)
+    *       Iterant[Coeval].empty[Int]
+    *     else
+    *       Iterant[Coeval].of(1, 2, 3)
+    *   })
+    *
+    *   // Will eventually stream elements 1, 2, 3
+    *   stream.retryIfEmpty(None)
     * }}}
+    *
+    * @param maxRetries is an optional integer specifying a maximum
+    *        number of retries before it gives up
     */
   final def retryIfEmpty(maxRetries: Option[Int])(implicit F: Sync[F]): Iterant[F, A] =
     IterantRetryIfEmpty(self, maxRetries)

--- a/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
@@ -1449,7 +1449,8 @@ sealed abstract class Iterant[F[_], A] extends Product with Serializable {
     * }}}
     *
     * @param maxRetries is an optional integer specifying a maximum
-    *        number of retries before it gives up
+    *        number of retries before it gives up and returns an
+    *        empty stream
     */
   final def retryIfEmpty(maxRetries: Option[Int])(implicit F: Sync[F]): Iterant[F, A] =
     IterantRetryIfEmpty(self, maxRetries)

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantRepeat.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantRepeat.scala
@@ -20,7 +20,6 @@ package monix.tail.internal
 import cats.effect.Sync
 import cats.syntax.all._
 import monix.execution.internal.Platform
-import monix.execution.internal.collection.ChunkedArrayStack
 import monix.tail.Iterant
 import monix.tail.Iterant.{Concat, Halt, Last, Next, NextBatch, NextCursor, Scope, Suspend}
 import monix.tail.batches.{BatchCursor, GenericBatch, GenericCursor}
@@ -34,11 +33,10 @@ private[tail] object IterantRepeat {
       case Halt(_) => source
       case Last(item) => repeatOne(item)
       case _ =>
-        Suspend(F.delay(new Loop(source).apply(source)))
+        Suspend(F.delay { new Loop[F, A](source).cycle() })
     }
 
   private def repeatOne[F[_], A](item: A)(implicit F: Sync[F]): Iterant[F, A] = {
-
     val batch = new GenericBatch[A] {
       def cursor(): BatchCursor[A] =
         new GenericCursor[A] {
@@ -54,81 +52,64 @@ private[tail] object IterantRepeat {
   private final class Loop[F[_], A](source: Iterant[F, A])(implicit F: Sync[F])
     extends Iterant.Visitor[F, A, Iterant[F, A]] {
 
-    private[this] var isEmpty = true
-    private[this] var stack: ChunkedArrayStack[F[Iterant[F, A]]] = _
-    private[this] val continue = F.delay(visit(Constants.emptyRef.asInstanceOf[Halt[F, A]]))
-
-    def visit(ref: Next[F, A]): Iterant[F, A] = {
-      if (isEmpty) isEmpty = false
-      Next(ref.item, ref.rest.map(this))
+    private[this] var hasElements = false
+    private[this] val repeatTask = F.delay {
+      if (hasElements)
+        cycle()
+      else
+        Iterant.empty[F, A]
     }
 
-    def visit(ref: NextBatch[F, A]): Iterant[F, A] = {
-      if (isEmpty) {
-        val cursor = ref.batch.cursor()
-        visit(NextCursor(cursor, ref.rest))
-      } else {
-        NextBatch[F, A](ref.batch, ref.rest.map(this))
-      }
+    def cycle(): Iterant[F, A] = {
+      Concat(F.pure(apply(source)), repeatTask)
     }
 
-    def visit(ref: NextCursor[F, A]): Iterant[F, A] = {
-      val cursor = ref.cursor
-      if (isEmpty) isEmpty = cursor.isEmpty
-      NextCursor[F, A](cursor, ref.rest.map(this))
+    override def visit(ref: Next[F, A]): Iterant[F, A] = {
+      hasElements = true
+      ref
     }
 
-    def visit(ref: Suspend[F, A]): Iterant[F, A] =
-      Suspend[F, A](ref.rest.map(this))
-
-    def visit(ref: Concat[F, A]): Iterant[F, A] = {
-      if (stack == null) stack = ChunkedArrayStack()
-      stack.push(ref.rh)
-      Suspend(ref.lh.map(this))
+    override def visit(ref: NextBatch[F, A]): Iterant[F, A] = {
+      if (hasElements)
+        ref
+      else
+        visit(NextCursor(ref.batch.cursor(), ref.rest))
     }
 
-    def visit[S](ref: Scope[F, S, A]): Iterant[F, A] = {
-      isEmpty = false
-      Concat(F.pure(ref), continue)
+    override def visit(ref: NextCursor[F, A]): Iterant[F, A] = {
+      hasElements = hasElements || !ref.cursor.isEmpty
+      if (hasElements)
+        ref
+      else
+        Suspend(ref.rest.map(this))
     }
 
-    def visit(ref: Last[F, A]): Iterant[F, A] = {
-      val next =
-        if (stack == null) null.asInstanceOf[F[Iterant[F, A]]]
-        else stack.pop()
+    override def visit(ref: Suspend[F, A]): Iterant[F, A] =
+      Suspend(ref.rest.map(this))
 
-      next match {
-        case null =>
-          isEmpty = true
-          Next(ref.item, F.pure(source).map(this))
-        case rest =>
-          isEmpty = false
-          Next(ref.item, rest.map(this))
-      }
+    override def visit(ref: Concat[F, A]): Iterant[F, A] = {
+      if (hasElements)
+        ref
+      else
+        Concat(ref.lh.map(this), ref.rh.map(this))
     }
 
-    def visit(ref: Halt[F, A]): Iterant[F, A] =
-      ref.e match {
-        case None =>
-          val next =
-            if (stack == null) null.asInstanceOf[F[Iterant[F, A]]]
-            else stack.pop()
+    override def visit[S](ref: Scope[F, S, A]): Iterant[F, A] = {
+      if (hasElements)
+        ref
+      else
+        ref.runMap(this)
+    }
 
-          next match {
-            case null =>
-              if (isEmpty) ref
-              else {
-                isEmpty = true
-                Suspend(F.pure(source).map(this))
-              }
-            case rest =>
-              Suspend(rest.map(this))
-          }
-        case _ =>
-          ref
-      }
+    override def visit(ref: Last[F, A]): Iterant[F, A] = {
+      hasElements = true
+      ref
+    }
 
-    def fail(e: Throwable): Iterant[F, A] =
+    override def visit(ref: Halt[F, A]): Iterant[F, A] =
+      ref
+
+    override def fail(e: Throwable): Iterant[F, A] =
       Iterant.raiseError(e)
   }
 }

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantRetryIfEmpty.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantRetryIfEmpty.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.tail
+package internal
+
+import cats.effect.Sync
+import cats.syntax.all._
+import monix.tail.Iterant.{Concat, Halt, Last, Next, NextBatch, NextCursor, Scope, Suspend}
+
+object IterantRetryIfEmpty {
+  /**
+    * Implementation for `Iterant.retryIfEmpty`.
+    */
+  def apply[F[_], A](source: Iterant[F, A], maxRetries: Option[Int])(implicit F: Sync[F]): Iterant[F, A] =
+    source match {
+      case Last(_) | Next(_, _) =>
+        source
+      case Halt(_) if maxRetries.exists(_ > 0) =>
+        source
+      case _ =>
+        Suspend(F.delay {
+          new Loop[F, A](source, maxRetries).cycle()
+        })
+    }
+
+  private final class Loop[F[_], A](source: Iterant[F, A], maxRetries: Option[Int])(implicit F: Sync[F])
+    extends Iterant.Visitor[F, A, Iterant[F, A]] {
+
+    private[this] var hasElements = false
+    private[this] var retriesRemaining = maxRetries.getOrElse(-1)
+    private[this] val retryTask = F.delay {
+      if (hasElements || retriesRemaining == 0)
+        Iterant.empty[F, A]
+      else {
+        if (retriesRemaining > 0) retriesRemaining -= 1
+        cycle()
+      }
+    }
+
+    def cycle(): Iterant[F, A] = {
+      Concat(F.pure(apply(source)), retryTask)
+    }
+
+    override def visit(ref: Next[F, A]): Iterant[F, A] = {
+      hasElements = true
+      ref
+    }
+
+    override def visit(ref: NextBatch[F, A]): Iterant[F, A] = {
+      if (hasElements)
+        ref
+      else
+        visit(NextCursor(ref.batch.cursor(), ref.rest))
+    }
+
+    override def visit(ref: NextCursor[F, A]): Iterant[F, A] = {
+      hasElements = hasElements || !ref.cursor.isEmpty
+      if (hasElements) ref
+      else Suspend(ref.rest.map(this))
+    }
+
+    override def visit(ref: Suspend[F, A]): Iterant[F, A] =
+      Suspend(ref.rest.map(this))
+
+    override def visit(ref: Concat[F, A]): Iterant[F, A] = {
+      if (hasElements) ref
+      else Concat(ref.lh.map(this), ref.rh.map(this))
+    }
+
+    override def visit[S](ref: Scope[F, S, A]): Iterant[F, A] = {
+      if (hasElements) ref
+      else ref.runMap(this)
+    }
+
+    override def visit(ref: Last[F, A]): Iterant[F, A] = {
+      hasElements = true
+      ref
+    }
+
+    override def visit(ref: Halt[F, A]): Iterant[F, A] =
+      ref
+
+    override def fail(e: Throwable): Iterant[F, A] =
+      Iterant.raiseError(e)
+  }
+}

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantRetryIfEmptySuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantRetryIfEmptySuite.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.tail
+
+import cats.laws._
+import cats.laws.discipline._
+import monix.eval.Coeval
+
+object IterantRetryIfEmptySuite extends BaseTestSuite {
+  test("Iterant.pure(1).retryIfEmpty mirrors source") { _ =>
+    val r = Iterant[Coeval].pure(1).retryIfEmpty(None).toListL.value()
+    assertEquals(r, List(1))
+  }
+
+  test("Iterant.suspend(Iterant.pure(1)).retryIfEmpty mirrors source") { _ =>
+    val r = Iterant.suspend(Iterant[Coeval].pure(1)).retryIfEmpty(None).toListL.value()
+    assertEquals(r, List(1))
+  }
+
+  test("(batch ++ batch ++ batch ++ batch).retryIfEmpty mirrors source") { _ =>
+    def batch(start: Int) = Iterant[Coeval].fromArray(Array(start, start + 1, start + 2))
+    val r = (batch(1) ++ batch(4) ++ batch(7) ++ batch(10)).retryIfEmpty(None).toListL.value()
+    assertEquals(r, (1 to 12).toList)
+  }
+
+  test("iterant.retryIfEmpty <-> iterant (for pure streams)") { _ =>
+    check1 { (stream: Iterant[Coeval, Int]) =>
+      stream.retryIfEmpty(Some(1)) <-> stream
+    }
+  }
+
+  test("iterant.retryIfEmpty handles Scopes properly") { _ =>
+    var cycles = 0
+    var acquired = 0
+    val empty = Iterant[Coeval].suspend(Coeval {
+      cycles += 1
+      Iterant[Coeval].empty[Int]
+    })
+
+    val resource = Iterant[Coeval].resource(Coeval(acquired += 1))(_ => Coeval {
+      assertEquals(acquired, 1)
+      acquired -= 1
+    }).flatMap(_ => Iterant[Coeval].empty[Int])
+
+    val r = (empty ++ resource).retryIfEmpty(Some(2)).toListL.value()
+    assertEquals(r, Nil)
+    assertEquals(cycles, 3)
+    assertEquals(acquired, 0)
+  }
+}

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantRetryIfEmptySuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantRetryIfEmptySuite.scala
@@ -19,7 +19,7 @@ package monix.tail
 
 import cats.laws._
 import cats.laws.discipline._
-import monix.eval.Coeval
+import monix.eval.{Coeval, Task}
 
 object IterantRetryIfEmptySuite extends BaseTestSuite {
   test("Iterant.pure(1).retryIfEmpty mirrors source") { _ =>
@@ -52,14 +52,77 @@ object IterantRetryIfEmptySuite extends BaseTestSuite {
       Iterant[Coeval].empty[Int]
     })
 
-    val resource = Iterant[Coeval].resource(Coeval(acquired += 1))(_ => Coeval {
-      assertEquals(acquired, 1)
-      acquired -= 1
-    }).flatMap(_ => Iterant[Coeval].empty[Int])
+    val resource = Iterant[Coeval]
+      .resource(Coeval(acquired += 1))(_ =>
+        Coeval {
+          assertEquals(acquired, 1)
+          acquired -= 1
+        })
+      .flatMap(_ => Iterant[Coeval].empty[Int])
 
     val r = (empty ++ resource).retryIfEmpty(Some(2)).toListL.value()
     assertEquals(r, Nil)
     assertEquals(cycles, 3)
     assertEquals(acquired, 0)
+  }
+
+  test("iterant.retryIfEmpty actually retries until source emits something") { _ =>
+    var cycles = 10
+    val iterant = Iterant[Coeval].suspend(Coeval {
+      cycles -= 1
+      if (cycles == 0)
+        Iterant[Coeval].pure(1)
+      else
+        Iterant[Coeval].empty[Int]
+    })
+
+    val r = iterant.retryIfEmpty(Some(9)).toListL.value()
+    assertEquals(r, List(1))
+  }
+
+  test("iterant.retryIfEmpty gives up after maxRetries") { _ =>
+    var cycles = 10
+    val iterant = Iterant[Coeval].suspend(Coeval {
+      cycles -= 1
+      if (cycles == 0)
+        Iterant[Coeval].pure(1)
+      else
+        Iterant[Coeval].empty[Int]
+    })
+
+    val r = iterant.retryIfEmpty(Some(8)).toListL.value()
+    assertEquals(r, Nil)
+  }
+
+  test("iterant.retryIfEmpty(None) repeats until it succeeds") { _ =>
+    import scala.util.Random
+    val stream = Iterant[Coeval].suspend(Coeval {
+      val nr = Random.nextInt()
+      if (nr % 10 != 0)
+        Iterant[Coeval].empty[Int]
+      else
+        Iterant[Coeval].of(1, 2, 3)
+    })
+
+    val r = stream.retryIfEmpty(None).toListL.value()
+    assertEquals(r, List(1, 2, 3))
+  }
+
+  test("iterant.retryIfEmpty(None) repeats until the end of time") { implicit sc =>
+    val f = Iterant[Task]
+      .suspend(Iterant.empty[Task, Int])
+      .retryIfEmpty(None)
+      .toListL
+      .runToFuture
+
+    var count = 1000
+    while (count > 0) {
+      count -= 1
+      assert(sc.tickOne(), "sc.tickOne()")
+      assert(!f.isCompleted, "!f.isCompleted")
+    }
+
+    f.cancel()
+    sc.tick()
   }
 }


### PR DESCRIPTION
See #938 for the bug description.

This PR fixes `iterant.repeat` to handle resources (`Scope`) correctly.

Because `repeat` returns empty on empty streams, this PR also adds a new `retryIfEmpty` operator:

```scala
import scala.util.Random

val stream = Iterant[Coeval].suspend(Coeval {
  val nr = Random.nextInt()
  if (nr % 10 != 0)
    Iterant[Coeval].empty[Int]
  else
    Iterant[Coeval].of(1, 2, 3)
})

stream.retryIfEmpty(None).repeat
```