### PR TITLE
Expand Task.gatherN and wanderN scaladocs

### DIFF
--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -3502,8 +3502,8 @@ object Task extends TaskInstancesLevel1 {
     *     Task(1 + 1).delayExecution(1.second),
     *     Task(2 + 2).delayExecution(2.second),
     *     Task(3 + 3).delayExecution(3.second),
-    *     Task(4 + 4).delayExecution(4.second),
-    *     )
+    *     Task(4 + 4).delayExecution(4.second)
+    *    )
     *
     *   // Yields 2, 4, 6, 8 after around 6 seconds
     *   Task.gatherN(2)(tasks)

--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -3559,7 +3559,7 @@ object Task extends TaskInstancesLevel1 {
     *   val numbers = List(1, 2, 3, 4)
     *
     *   // Yields 2, 4, 6, 8 after around 6 seconds
-    *   Task.wanderN(2)(numbers)(n => Task(n + n).delayExecution(n))
+    *   Task.wanderN(2)(numbers)(n => Task(n + n).delayExecution(n.second))
     * }}}
     *
     * $parallelismAdvice

--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -3481,12 +3481,39 @@ object Task extends TaskInstancesLevel1 {
     * $parallelismAdvice
     *
     * $parallelismNote
+    *
+    * @see [[gatherN]] for a version that limits parallelism.
     */
   def gather[A, M[X] <: Iterable[X]](in: M[Task[A]])(implicit bf: BuildFrom[M[Task[A]], A, M[A]]): Task[M[A]] =
     TaskGather[A, M](in, () => newBuilder(bf, in))
 
-  /**
-    * Similar to `gather`, but bounded by specified parallelism.
+  /** Executes the given sequence of tasks in parallel, non-deterministically
+    * gathering their results, returning a task that will signal the sequence
+    * of results once all tasks are finished.
+    *
+    * Implementation ensure there are at most `n` (= `parallelism` parameter) tasks
+    * running concurrently and the results are returned in order.
+    *
+    * Example:
+    * {{{
+    *   import scala.concurrent.duration._
+    *
+    *   val tasks = List(
+    *     Task(1 + 1).delayExecution(1.second),
+    *     Task(2 + 2).delayExecution(2.second),
+    *     Task(3 + 3).delayExecution(3.second),
+    *     Task(4 + 4).delayExecution(4.second),
+    *     )
+    *
+    *   // Yields 2, 4, 6, 8 after around 6 seconds
+    *   Task.gatherN(2)(tasks)
+    * }}}
+    *
+    * $parallelismAdvice
+    *
+    * $parallelismNote
+    *
+    * @see [[gather]] for a version that does not limit parallelism.
     */
   def gatherN[A](parallelism: Int)(in: Iterable[Task[A]]): Task[List[A]] =
     TaskGatherN[A](parallelism, in)
@@ -3511,12 +3538,35 @@ object Task extends TaskInstancesLevel1 {
     * $parallelismAdvice
     *
     * $parallelismNote
+    *
+    * @see [[wanderN]] for a version that limits parallelism.
     */
   def wander[A, B, M[X] <: Iterable[X]](in: M[A])(f: A => Task[B])(implicit bf: BuildFrom[M[A], B, M[B]]): Task[M[B]] =
     Task.eval(in.map(f)).flatMap(col => TaskGather[B, M](col, () => newBuilder(bf, in)))
 
-  /**
-    * Similar to `wander`, but bounded by specified parallelism.
+  /** Given a `Iterable[A]` and a function `A => Task[B]`,
+    * nondeterministically apply the function to each element of the collection
+    * and return a task that will signal a collection of the results once all
+    * tasks are finished.
+    *
+    * Implementation ensure there are at most `n` (= `parallelism` parameter) tasks
+    * running concurrently and the results are returned in order.
+    *
+    * Example:
+    * {{{
+    *   import scala.concurrent.duration._
+    *
+    *   val numbers = List(1, 2, 3, 4)
+    *
+    *   // Yields 2, 4, 6, 8 after around 6 seconds
+    *   Task.wanderN(2)(numbers)(n => Task(n + n).delayExecution(n))
+    * }}}
+    *
+    * $parallelismAdvice
+    *
+    * $parallelismNote
+    *
+    * @see [[wander]] for a version that does not limit parallelism.
     */
   def wanderN[A, B](parallelism: Int)(in: Iterable[A])(f: A => Task[B]): Task[List[B]] =
     Task.suspend {

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskGatherN.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskGatherN.scala
@@ -39,7 +39,7 @@ private[eval] object TaskGatherN {
       for {
         error <- Deferred[Task, Throwable]
         queue <- ConcurrentQueue
-          .withConfig[Task, (Deferred[Task, A], Task[A])](BufferCapacity(itemSize), ChannelType.SPMC)
+          .withConfig[Task, (Deferred[Task, A], Task[A])](BufferCapacity.Bounded(itemSize), ChannelType.SPMC)
         pairs <- Task.traverse(in.toList)(task => Deferred[Task, A].map(p => (p, task)))
         _     <- queue.offerMany(pairs)
         workers = Task.gather(List.fill(parallelism.min(itemSize)) {


### PR DESCRIPTION
Just added more docs there and used Single Producer - Multi Consumer Queue instead