### PR TITLE
Improve Observable.publishSelector scaladoc

### DIFF
--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -2695,10 +2695,10 @@ abstract class Observable[+A] extends Serializable { self =>
     *  import scala.concurrent.duration._
     *
     *  val obs = Observable(1, 2, 3)
-    *    .doOnNext(i => Task(println(s"Produced $i")).delayExecution(1.second))
+    *    .doOnNext(i => Task(println(s"Produced $$i")).delayExecution(1.second))
     *
     *  def consume(name: String, obs: Observable[Int]): Observable[Unit] =
-    *    obs.mapEval(i => Task(println(s"$name: got $i")))
+    *    obs.mapEval(i => Task(println(s"$$name: got $$i")))
     *
     *  obs.publishSelector { hot =>
     *    Observable(
@@ -2750,10 +2750,10 @@ abstract class Observable[+A] extends Serializable { self =>
     *  import scala.concurrent.duration._
     *
     *  val obs = Observable(1, 2, 3)
-    *    .doOnNext(i => Task(println(s"Produced $i")).delayExecution(1.second))
+    *    .doOnNext(i => Task(println(s"Produced $$i")).delayExecution(1.second))
     *
     *  def consume(name: String, obs: Observable[Int]): Observable[Unit] =
-    *    obs.mapEval(i => Task(println(s"$name: got $i")))
+    *    obs.mapEval(i => Task(println(s"$$name: got $$i")))
     *
     *  obs.pipeThroughSelector(Pipe.replay[Int], { hot: Observable[Int] =>
     *    Observable(


### PR DESCRIPTION
Example based on @oleg-py's snippet

@megri Please let me know what you think, any suggestions are welcome!
Also if you have any feedback regarding other scaladocs, it is useful as well. I feel like `monix-reactive` docs are below our standard compared to newer ones like `Task` or `Iterant` so would be nice to gradually improve them. :)