### PR TITLE
Enrich Observable Buffering scaladocs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -492,7 +492,7 @@ lazy val benchmarksPrev = project.in(file("benchmarks/vprev"))
   .settings(sharedSettings)
   .settings(doNotPublishArtifact)
   .settings(
-    libraryDependencies += "io.monix" %% "monix" % "3.0.0-RC1"
+    libraryDependencies += "io.monix" %% "monix" % "3.0.0"
   )
 
 lazy val benchmarksNext = project.in(file("benchmarks/vnext"))

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -814,10 +814,10 @@ abstract class Observable[+A] extends Serializable { self =>
     *   import scala.concurrent.duration._
     *
     *   Observable.range(1, 6)
-    *     .doOnNext(l => Task(println(s"Started $l")))
+    *     .doOnNext(l => Task(println(s"Started $$l")))
     *     .bufferIntrospective(maxSize = 2)
-    *     .doOnNext(l => Task(println(s"Emitted batch $l")))
-    *     .mapEval(l => Task(println(s"Processed batch $l")).delayExecution(500.millis))
+    *     .doOnNext(l => Task(println(s"Emitted batch $$l")))
+    *     .mapEval(l => Task(println(s"Processed batch $$l")).delayExecution(500.millis))
     *
     *   // Started 1
     *   // Emitted batch List(1)
@@ -3451,9 +3451,9 @@ abstract class Observable[+A] extends Serializable { self =>
     *   import scala.concurrent.duration._
     *
     *   Observable("A", "B", "C", "D")
-    *     .mapEval(i => Task { println(s"1: Processing $i"); i ++ i })
+    *     .mapEval(i => Task { println(s"1: Processing $$i"); i ++ i })
     *     .asyncBoundary(OverflowStrategy.Unbounded)
-    *     .mapEval(i => Task { println(s"2: Processing $i") }.delayExecution(100.millis))
+    *     .mapEval(i => Task { println(s"2: Processing $$i") }.delayExecution(100.millis))
     *
     *   // Without asyncBoundary it would process A, AA, B, BB, ...
     *   // 1: Processing A


### PR DESCRIPTION
I was documenting it for the website and added few basic usage examples to more operators

I also inlined `asyncBoundary` description because it's used in only 1 place. I often read scaladocs from my IDE so it is more convenient to me, not sure how other people approach it