### PR TITLE
Issue#804 Add Observable.toInputStream

### DIFF
--- a/monix-reactive/jvm/src/test/scala/monix/reactive/internal/builders/ToInputStreamSuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/internal/builders/ToInputStreamSuite.scala
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.reactive.internal.builders
+
+import minitest.SimpleTestSuite
+import monix.eval.{Coeval, Task}
+import monix.execution.schedulers.TestScheduler
+import monix.reactive.Observable
+
+import scala.concurrent.duration._
+import scala.util.Random
+
+object ToInputStreamSuite extends SimpleTestSuite {
+
+  test("InputStream reads all bytes one by one") {
+    implicit val s = TestScheduler()
+    val observable = Observable.fromIterable(Seq(1.toByte, 2.toByte, 3.toByte)).map(Array(_))
+
+    s.tick()
+    val inputStream = Observable.toInputStream(observable).runToFuture.value.get.get
+    s.tick()
+
+    assertEquals(inputStream.read(), 1.toByte)
+    assertEquals(inputStream.read(), 2.toByte)
+    assertEquals(inputStream.read(), 3.toByte)
+    assertEquals(inputStream.read(), -1.toByte)
+    assertEquals(inputStream.read(), -1.toByte)
+  }
+
+  test("InputStream reads delayed bytes one by one") {
+    import monix.execution.Scheduler.Implicits.global
+
+    val observable = Observable
+      .fromIterable(Seq(1.toByte, 2.toByte, 3.toByte))
+      .map(Array(_))
+      .delayOnNext(100.millis)
+
+    val inputStream = Observable.toInputStream(observable).runToFuture.value.get.get
+
+    assertEquals(inputStream.read(), 1.toByte)
+    assertEquals(inputStream.read(), 2.toByte)
+    assertEquals(inputStream.read(), 3.toByte)
+    assertEquals(inputStream.read(), -1.toByte)
+    assertEquals(inputStream.read(), -1.toByte)
+  }
+
+  test("InputStream waits until enough bytes are available") {
+    implicit val s = TestScheduler()
+    val array1 = randomByteArrayOfSize(10)
+    val array2 = randomByteArrayOfSize(5)
+    val array3 = randomByteArrayOfSize(5)
+    val observable = Observable.fromIterable(Seq(array1, array2, array3))
+    val result = new Array[Byte](20)
+
+    s.tick()
+    val inputStream = Observable.toInputStream(observable).runToFuture.value.get.get
+    s.tick()
+    inputStream.read(result)
+
+    assertEquals(result.toList, (array1 ++ array2 ++ array3).toList)
+    assertEquals(inputStream.read(), -1.toByte)
+  }
+
+  test("InputStream reads the amount of bytes that is available") {
+    implicit val s = TestScheduler()
+    val array1 = randomByteArrayOfSize(10)
+    val array2 = randomByteArrayOfSize(5)
+    val array3 = randomByteArrayOfSize(5)
+    val observable = Observable.fromIterable(Seq(array1, array2, array3))
+    val result = new Array[Byte](200)
+
+    s.tick()
+    val inputStream = Observable.toInputStream(observable).runToFuture.value.get.get
+    s.tick()
+    inputStream.read(result, 0, 30)
+
+    val (filledBytes, emptyBytes) = result.splitAt(20)
+    assertEquals(filledBytes.toList, (array1 ++ array2 ++ array3).toList)
+    assertEquals(emptyBytes.toList, List.fill(180)(0))
+    assertEquals(inputStream.read(), -1.toByte)
+  }
+
+  test("Observable completes when the input stream is closed") {
+    implicit val s = TestScheduler()
+    var completed = false
+    val observable = Observable
+      .fromIterable(Seq(1.toByte, 2.toByte, 3.toByte))
+      .map(Array(_))
+      .doOnCompleteF(Coeval { completed = true })
+
+    s.tick()
+    val inputStream = Observable.toInputStream(observable).runToFuture.value.get.get
+    s.tick()
+
+    assertEquals(inputStream.read(), 1.toByte)
+    inputStream.close()
+    assert(completed, "The Observable is not completed")
+    assertEquals(inputStream.read(), -1.toByte)
+  }
+
+  test("InputStream reads all bytes one until error occurs") {
+    implicit val s = TestScheduler()
+    val observable = Observable
+      .fromIterable(
+        Seq(
+          Task.eval(Array(1.toByte)),
+          Task.eval(Array(2.toByte)),
+          Task.raiseError(new RuntimeException("Expected exception")),
+          Task.eval(Array(3.toByte))
+        )
+      )
+      .mapEvalF(identity)
+
+    s.tick()
+    val inputStream = Observable.toInputStream(observable).runToFuture.value.get.get
+    s.tick()
+
+    assertEquals(inputStream.read(), 1.toByte)
+    assertEquals(inputStream.read(), 2.toByte)
+    assertEquals(inputStream.read(), -1.toByte)
+  }
+
+  def randomByteArrayOfSize(size: Int): Array[Byte] = {
+    val bytes = new Array[Byte](size)
+    Random.nextBytes(bytes)
+    bytes
+  }
+
+}

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/internal/builders/ToInputStreamSuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/internal/builders/ToInputStreamSuite.scala
@@ -17,13 +17,14 @@
 
 package monix.reactive.internal.builders
 
+import java.io.IOException
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 
 import minitest.SimpleTestSuite
 import monix.eval.Task
 import monix.reactive.Observable
 
-import scala.concurrent.{TimeoutException, blocking}
+import scala.concurrent.blocking
 import scala.concurrent.duration._
 import scala.util.Random
 
@@ -172,12 +173,13 @@ object ToInputStreamSuite extends SimpleTestSuite {
       .map { inputStream =>
         assertEquals(inputStream.read(), 1.toByte)
         assertEquals(inputStream.read(), 2.toByte)
-        assertEquals(inputStream.read(), -1.toByte)
-      }
-      .onErrorRecover {
-        case _: IllegalArgumentException =>
-          fail()
-        case _: Throwable => fail()
+        try {
+          inputStream.read()
+          ()
+        } catch {
+          case _: IOException => ()
+          case _: Throwable => fail()
+        }
       }
       .runToFuture(monix.execution.Scheduler.global)
   }
@@ -193,7 +195,7 @@ object ToInputStreamSuite extends SimpleTestSuite {
           inputStream.read()
           ()
         } catch {
-          case _: TimeoutException => ()
+          case _: IOException => ()
           case _: Throwable => fail()
         }
       }

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/internal/builders/ToInputStreamSuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/internal/builders/ToInputStreamSuite.scala
@@ -30,6 +30,8 @@ import scala.util.Random
 
 object ToInputStreamSuite extends SimpleTestSuite {
 
+  implicit val s = monix.execution.Scheduler.io()
+
   testAsync("InputStream reads all bytes one by one") {
     var completed = false
     val observable = Observable.fromIterable(Seq(1.toByte, 2.toByte, 3.toByte))
@@ -49,7 +51,7 @@ object ToInputStreamSuite extends SimpleTestSuite {
 
         assert(completed)
       }
-      .runToFuture(monix.execution.Scheduler.global)
+      .runToFuture
   }
 
   testAsync("InputStream reads delayed bytes one by one") {
@@ -72,7 +74,7 @@ object ToInputStreamSuite extends SimpleTestSuite {
 
         assert(completed)
       }
-      .runToFuture(monix.execution.Scheduler.global)
+      .runToFuture
   }
 
   testAsync("InputStream waits until enough bytes are available") {
@@ -94,7 +96,7 @@ object ToInputStreamSuite extends SimpleTestSuite {
         assertEquals(inputStream.read(), -1.toByte)
         assert(completed)
       }
-      .runToFuture(monix.execution.Scheduler.global)
+      .runToFuture
   }
 
   testAsync("InputStream reads the amount of bytes that is available") {
@@ -118,7 +120,7 @@ object ToInputStreamSuite extends SimpleTestSuite {
         assertEquals(inputStream.read(), -1.toByte)
         assert(completed)
       }
-      .runToFuture(monix.execution.Scheduler.global)
+      .runToFuture
   }
 
   testAsync("Observable cancels when the input stream is closed") {
@@ -136,7 +138,7 @@ object ToInputStreamSuite extends SimpleTestSuite {
         blocking(latch.await(1, TimeUnit.SECONDS))
         assertEquals(latch.getCount, 0)
       }
-      .runToFuture(monix.execution.Scheduler.global)
+      .runToFuture
   }
 
   testAsync("Observable cancels when the input stream is closed without reading anything") {
@@ -154,7 +156,7 @@ object ToInputStreamSuite extends SimpleTestSuite {
         assertEquals(latch.getCount, 0)
         assertEquals(inputStream.read(), -1.toByte)
       }
-      .runToFuture(monix.execution.Scheduler.global)
+      .runToFuture
   }
 
   testAsync("InputStream reads all bytes one until error occurs") {
@@ -177,7 +179,7 @@ object ToInputStreamSuite extends SimpleTestSuite {
           inputStream.read()
         }
       }
-      .runToFuture(monix.execution.Scheduler.global)
+      .runToFuture
   }
 
   testAsync("InputStream should throw an exception if element does not array before timeout") {
@@ -187,11 +189,11 @@ object ToInputStreamSuite extends SimpleTestSuite {
 
     Observable.toInputStream(observable, 10.millis)
       .map { inputStream =>
-        intercept {
+        intercept[IOException] {
           inputStream.read()
         }
       }
-      .runToFuture(monix.execution.Scheduler.global)
+      .runToFuture
   }
 
   def randomByteArrayOfSize(size: Int): Array[Byte] = {

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/internal/builders/ToInputStreamSuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/internal/builders/ToInputStreamSuite.scala
@@ -173,12 +173,8 @@ object ToInputStreamSuite extends SimpleTestSuite {
       .map { inputStream =>
         assertEquals(inputStream.read(), 1.toByte)
         assertEquals(inputStream.read(), 2.toByte)
-        try {
+        intercept[IOException] {
           inputStream.read()
-          ()
-        } catch {
-          case _: IOException => ()
-          case _: Throwable => fail()
         }
       }
       .runToFuture(monix.execution.Scheduler.global)
@@ -191,12 +187,8 @@ object ToInputStreamSuite extends SimpleTestSuite {
 
     Observable.toInputStream(observable, 10.millis)
       .map { inputStream =>
-        try {
+        intercept {
           inputStream.read()
-          ()
-        } catch {
-          case _: IOException => ()
-          case _: Throwable => fail()
         }
       }
       .runToFuture(monix.execution.Scheduler.global)

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -5000,13 +5000,16 @@ object Observable extends ObservableDeprecatedBuilders {
    * The InputStream is not synchronized, a single-threaded usage is recommended.
    *
    * @param observable Observable that produces byte arrays
+   * @param waitForNextElement How much time to wait in `InputStream.read` method until an element of Observable arrives.
+   *                           Throws [[scala.concurrent.TimeoutException]] if exceeded.
+   *                           Default: Inf.
    * @param canBlock
    * @return Task with InputStream which can be used to read bytes from `observable`
    */
   @UnsafeBecauseImpure
   @UnsafeBecauseBlocking
-  def toInputStream(observable: Observable[Array[Byte]])(implicit canBlock: CanBlock): Task[InputStream] =
-    new builders.InputStreamResource(observable).toTask
+  def toInputStream(observable: Observable[Array[Byte]], waitForNextElement: Duration = Duration.Inf)(implicit canBlock: CanBlock): Task[InputStream] =
+    new builders.InputStreamResource(observable, waitForNextElement).toTask
 
   /** Safely converts a `java.io.Reader` into an observable that will
     * emit `Array[Char]` elements.

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -5001,15 +5001,16 @@ object Observable extends ObservableDeprecatedBuilders {
    *
    * @param observable Observable that produces byte arrays
    * @param waitForNextElement How much time to wait in `InputStream.read` method until an element of Observable arrives.
-   *                           Throws [[scala.concurrent.TimeoutException]] if exceeded.
+   *                           Throws [[java.io.IOException]] with the cause [[scala.concurrent.TimeoutException]] if exceeded.
    *                           Default: Inf.
    * @param canBlock
-   * @return Task with InputStream which can be used to read bytes from `observable`
+   * @return Resource with InputStream which can be used to read bytes from `observable`
    */
   @UnsafeBecauseImpure
   @UnsafeBecauseBlocking
-  def toInputStream(observable: Observable[Array[Byte]], waitForNextElement: Duration = Duration.Inf)(implicit canBlock: CanBlock): Task[InputStream] =
-    new builders.InputStreamResource(observable, waitForNextElement).toTask
+  def toInputStream(observable: Observable[Array[Byte]], waitForNextElement: Duration = Duration.Inf)
+                   (implicit canBlock: CanBlock): Resource[Task, InputStream] =
+    new builders.InputStreamResource(observable, waitForNextElement).toResource
 
   /** Safely converts a `java.io.Reader` into an observable that will
     * emit `Array[Char]` elements.

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/InputStreamResource.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/InputStreamResource.scala
@@ -26,7 +26,7 @@ import monix.reactive.Observable
 import monix.reactive.internal.builders.InputStreamResource.{Bytes, Completed, Failed, ObservableMessage}
 
 import scala.annotation.tailrec
-import scala.concurrent.Await
+import scala.concurrent.{Await, blocking}
 import scala.concurrent.duration.Duration
 
 private[reactive] class InputStreamResource(observable: Observable[Array[Byte]], waitForNextElement: Duration) {
@@ -115,7 +115,9 @@ private[reactive] class InputStreamResource(observable: Observable[Array[Byte]],
 
     private def takeNextElement(): ObservableMessage = {
       try {
-        Await.result(queue.take(), waitForNextElement)
+        blocking {
+          Await.result(queue.take(), waitForNextElement)
+        }
       } catch {
         case e: Throwable => throw new IOException(e)
       }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/InputStreamResource.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/InputStreamResource.scala
@@ -28,7 +28,7 @@ import scala.annotation.tailrec
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class InputStreamResource(observable: Observable[Array[Byte]]) {
+class InputStreamResource(observable: Observable[Array[Byte]], waitForNextElement: Duration) {
 
   private type Bytes = Array[Byte]
 
@@ -102,7 +102,7 @@ class InputStreamResource(observable: Observable[Array[Byte]]) {
       if (buffer.length >= requiredLength) {
         requiredLength
       } else {
-        Await.result(queue.take(), Duration.Inf) match {
+        Await.result(queue.take(), waitForNextElement) match {
           case Some(polledArray) =>
             buffer ++= polledArray
             ensureBufferSize(requiredLength)

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/InputStreamResource.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/InputStreamResource.scala
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.reactive.internal.builders
+
+import java.io.InputStream
+
+import monix.eval.Task
+import monix.execution.Ack.Continue
+import monix.execution.{Ack, AsyncVar, Cancelable, Scheduler}
+import monix.reactive.Observable
+import monix.reactive.observers.Subscriber
+
+import scala.annotation.tailrec
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+class InputStreamResource(observable: Observable[Array[Byte]]) {
+
+  private type Bytes = Array[Byte]
+
+  def toTask: Task[InputStream] = {
+    Task.create[InputStream] { (s, cb) =>
+      val (state, cancelable) = subscribe(s)
+      cb.onSuccess(new ObservableInputStream(state, cancelable))
+    }
+  }
+
+  private def subscribe(s: Scheduler): (AsyncVar[Option[Bytes]], Cancelable) = {
+    val state = AsyncVar.empty[Option[Bytes]]()
+
+    val cancelable = observable.executeAsync.unsafeSubscribeFn(new Subscriber.Sync[Array[Byte]] {
+      implicit val scheduler = s
+
+      override def onNext(elem: Array[Byte]): Ack = {
+        state.put(Some(elem)).value
+        Continue
+      }
+
+      def onComplete(): Unit = {
+        state.put(None).value
+      }
+
+      def onError(ex: Throwable): Unit = {
+        state.put(None).value
+      }
+
+    })
+
+    (state, cancelable)
+  }
+
+  private[this] class ObservableInputStream(queue: AsyncVar[Option[Bytes]], cancelable: Cancelable)
+    extends InputStream {
+    private[this] var buffer: Array[Byte] = new Array[Byte](0)
+    private[this] var isClosed: Boolean = false
+
+    override def read(): Int = {
+      val a = new Array[Byte](1)
+      read(a, 0, 1) match {
+        case 1 => a(0) & 0xff
+        case -1 => -1
+        case len => throw new IllegalStateException(s"There was '1' byte expected, but there were '$len' bytes read")
+      }
+    }
+
+    override def read(arr: Array[Byte], begin: Int, length: Int): Int = {
+      require(arr.length > 0, "array size must be >= 0")
+      require(begin >= 0, "begin must be >= 0")
+      require(length > 0, "length must be > 0")
+      require(begin + length <= arr.length, "begin + length must be smaller or equal to the array length")
+
+      if (isClosed) -1
+      else {
+        val availableBytes = ensureBufferSize(length)
+        val bytesWritten = if (availableBytes == length) {
+          buffer.copyToArray(arr, begin, availableBytes)
+          length
+        } else if (availableBytes > 0) {
+          buffer.copyToArray(arr, begin, availableBytes)
+          isClosed = true
+          availableBytes
+        } else {
+          isClosed = true
+          -1
+        }
+        buffer = buffer.drop(availableBytes)
+        bytesWritten
+      }
+    }
+
+    @tailrec
+    private def ensureBufferSize(requiredLength: Int): Int = {
+      if (buffer.length >= requiredLength) {
+        requiredLength
+      } else {
+        Await.result(queue.take(), Duration.Inf) match {
+          case Some(polledArray) =>
+            buffer ++= polledArray
+            ensureBufferSize(requiredLength)
+          case _ =>
+            buffer.length
+        }
+      }
+    }
+
+    override def close(): Unit = {
+      cancelable.cancel()
+      isClosed = true
+    }
+
+  }
+
+}


### PR DESCRIPTION
This change introduces a simple `toInputStream` method #804 

The simplifications:
1) The `read` on InputSteam is blocking without prefetch. So `AsyncVar` is used instead of a queue.
- fs has blocking queue with 1 element
[blocking call](https://github.com/functional-streams-for-scala/fs2/blob/series/1.0/io/src/main/scala/fs2/io/JavaInputOutputStream.scala#L105) ; [queue factory method](https://github.com/functional-streams-for-scala/fs2/blob/series/1.0/core/shared/src/main/scala/fs2/concurrent/Queue.scala#L173-L175)
- akka-streams has a configurable buffer size 
[queue creation](https://github.com/akka/akka/blob/master/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamSinkStage.scala#L53)
2) The blocking to wait for next element is infinite
- fs2 seems to block as well for infinite time
- akka has [a read timeout](https://github.com/akka/akka/blob/master/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamSinkStage.scala#L42)
3) this implementation is based on Task. I could also add [Cats Resource](https://typelevel.org/cats-effect/api/cats/effect/Resource.html) if the implementation would be considered sufficient and correct.   