### PR TITLE
"simple push and pull"  test fix - ConcurrentChannelSuite

### DIFF
--- a/monix-catnap/shared/src/test/scala/monix/catnap/ConcurrentChannelSuite.scala
+++ b/monix-catnap/shared/src/test/scala/monix/catnap/ConcurrentChannelSuite.scala
@@ -103,12 +103,14 @@ abstract class BaseConcurrentChannelSuite[S <: Scheduler] extends TestSuite[S] {
           assertEquals(r4, Left(0))
         }
       }
-      _ <- consume.start
+      fiber <- consume.start
+      _ <- chan.awaitConsumers(1)
       _ <- chan.push(1)
       _ <- chan.push(2)
       _ <- chan.push(3)
       _ <- chan.halt(0)
-    } yield ()
+      r <- fiber.join
+    } yield r
   }
 
   testIO("consumers can receive push", times = repeatForFastTests) { implicit ec =>


### PR DESCRIPTION
noticed that the test was passing with random data provided (or no data at all)