### PR TITLE
Fix #870, #1023, #1033: fix scheduler decorators leaking ThreadLocalEntry's

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -319,7 +319,8 @@ lazy val cmdlineProfile =
 
 def mimaSettings(projectName: String) = Seq(
   mimaPreviousArtifacts := Set("io.monix" %% projectName % monixSeries),
-  mimaBinaryIssueFilters ++= MimaFilters.changesFor_3_0_0__RC5
+  mimaBinaryIssueFilters ++= MimaFilters.changesFor_3_0_0__RC5,
+  mimaBinaryIssueFilters ++= MimaFilters.changesFor_3_0_1
 )
 // https://github.com/lightbend/mima/pull/289
 mimaFailOnNoPrevious in ThisBuild := false

--- a/monix-eval/jvm/src/test/scala/monix/eval/TaskExecuteWithLocalContextSuite.scala
+++ b/monix-eval/jvm/src/test/scala/monix/eval/TaskExecuteWithLocalContextSuite.scala
@@ -1,0 +1,17 @@
+package monix.eval
+
+import scala.util.Success
+import cats.implicits._
+
+
+object TaskExecuteWithLocalContextSuite extends BaseTestSuite {
+  test("cats' parSequence with LCP is stack safe") { implicit sc =>
+    val f = List.fill(2000)(Task.unit).parSequence_
+      .executeWithOptions(_.enableLocalContextPropagation)
+      .runToFuture
+
+    sc.tick()
+
+    assertEquals(f.value, Some(Success(())))
+  }
+}

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskExecuteWithOptionsSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskExecuteWithOptionsSuite.scala
@@ -17,6 +17,7 @@
 
 package monix.eval
 
+import cats.implicits._
 import monix.execution.schedulers.TestScheduler
 import scala.util.Success
 
@@ -67,6 +68,16 @@ object TaskExecuteWithOptionsSuite extends BaseTestSuite {
 
     val f = loop(10000, 0).runToFuture; sc.tick()
     assertEquals(f.value, Some(Success(10000)))
+  }
+
+  test("cats' parSequence with LCP is stack safe") { implicit sc =>
+    val f = List.fill(2000)(Task.unit).parSequence_
+      .executeWithOptions(_.enableLocalContextPropagation)
+      .runToFuture
+
+    sc.tick()
+
+    assertEquals(f.value, Some(Success(())))
   }
 
 }

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskExecuteWithOptionsSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskExecuteWithOptionsSuite.scala
@@ -17,7 +17,6 @@
 
 package monix.eval
 
-import cats.implicits._
 import monix.execution.schedulers.TestScheduler
 import scala.util.Success
 
@@ -68,16 +67,6 @@ object TaskExecuteWithOptionsSuite extends BaseTestSuite {
 
     val f = loop(10000, 0).runToFuture; sc.tick()
     assertEquals(f.value, Some(Success(10000)))
-  }
-
-  test("cats' parSequence with LCP is stack safe") { implicit sc =>
-    val f = List.fill(2000)(Task.unit).parSequence_
-      .executeWithOptions(_.enableLocalContextPropagation)
-      .runToFuture
-
-    sc.tick()
-
-    assertEquals(f.value, Some(Success(())))
   }
 
 }

--- a/monix-execution/js/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
@@ -53,10 +53,10 @@ import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
   */
 final class TrampolineExecutionContext private (underlying: ExecutionContext) extends ExecutionContextExecutor {
 
-  private[this] val trampoline = new Trampoline(underlying)
+  private[this] val trampoline = new Trampoline
 
   override def execute(runnable: Runnable): Unit =
-    trampoline.execute(runnable)
+    trampoline.execute(runnable, underlying)
   override def reportFailure(t: Throwable): Unit =
     underlying.reportFailure(t)
 }

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
@@ -20,7 +20,7 @@ package monix.execution.schedulers
 import monix.execution.internal.Trampoline
 
 import scala.util.control.NonFatal
-import scala.concurrent.{BlockContext, CanAwait, ExecutionContext, ExecutionContextExecutor}
+import scala.concurrent.{BlockContext, ExecutionContext, ExecutionContextExecutor}
 
 /** A `scala.concurrentExecutionContext` implementation
   * that executes runnables immediately, on the current thread,
@@ -53,15 +53,8 @@ import scala.concurrent.{BlockContext, CanAwait, ExecutionContext, ExecutionCont
   *        to in case real asynchronous is needed
   */
 final class TrampolineExecutionContext private (underlying: ExecutionContext) extends ExecutionContextExecutor {
-
-  private[this] val trampoline =
-    new ThreadLocal[Trampoline]() {
-      override def initialValue(): Trampoline =
-        TrampolineExecutionContext.buildTrampoline(underlying)
-    }
-
   override def execute(runnable: Runnable): Unit =
-    trampoline.get().execute(runnable)
+    TrampolineExecutionContext.trampoline.get().execute(runnable, underlying)
   override def reportFailure(t: Throwable): Unit =
     underlying.reportFailure(t)
 }
@@ -118,49 +111,35 @@ object TrampolineExecutionContext {
     }
   }
 
-  private def buildTrampoline(underlying: ExecutionContext): Trampoline = {
+  private val trampoline =
+    new ThreadLocal[Trampoline]() {
+      override def initialValue(): Trampoline =
+        TrampolineExecutionContext.buildTrampoline()
+    }
+
+  private def buildTrampoline(): Trampoline = {
     if (localContext ne null)
-      new JVMOptimalTrampoline(underlying)
+      new JVMOptimalTrampoline()
     else
-      new JVMNormalTrampoline(underlying)
+      new JVMNormalTrampoline()
   }
 
-  private final class JVMOptimalTrampoline(underlying: ExecutionContext) extends Trampoline(underlying) {
-    private[this] val trampolineContext: BlockContext =
-      new BlockContext {
-        def blockOn[T](thunk: => T)(implicit permission: CanAwait): T = {
-          // In case of blocking, execute all scheduled local tasks on
-          // a separate thread, otherwise we could end up with a dead-lock
-          forkTheRest()
-          thunk
-        }
-      }
-
-    override def startLoop(runnable: Runnable): Unit = {
+  private final class JVMOptimalTrampoline extends Trampoline {
+    override def startLoop(runnable: Runnable, ec: ExecutionContext): Unit = {
       val parentContext = localContext.get()
-      localContext.set(trampolineContext)
+      localContext.set(trampolineContext(ec))
       try {
-        super.startLoop(runnable)
+        super.startLoop(runnable, ec)
       } finally {
         localContext.set(parentContext)
       }
     }
   }
 
-  private class JVMNormalTrampoline(underlying: ExecutionContext) extends Trampoline(underlying) {
-    private[this] val trampolineContext: BlockContext =
-      new BlockContext {
-        def blockOn[T](thunk: => T)(implicit permission: CanAwait): T = {
-          // In case of blocking, execute all scheduled local tasks on
-          // a separate thread, otherwise we could end up with a dead-lock
-          forkTheRest()
-          thunk
-        }
-      }
-
-    override def startLoop(runnable: Runnable): Unit = {
-      BlockContext.withBlockContext(trampolineContext) {
-        super.startLoop(runnable)
+  private class JVMNormalTrampoline extends Trampoline {
+    override def startLoop(runnable: Runnable, ec: ExecutionContext): Unit = {
+      BlockContext.withBlockContext(trampolineContext(ec)) {
+        super.startLoop(runnable, ec)
       }
     }
   }

--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -2,6 +2,12 @@ import com.typesafe.tools.mima.core.ProblemFilters.exclude
 import com.typesafe.tools.mima.core._
 
 object MimaFilters {
+  lazy val changesFor_3_0_1: Seq[ProblemFilter] = Seq(
+    // Signature changes in internal classes
+    exclude[DirectMissingMethodProblem]("monix.execution.internal.Trampoline.*"),
+    exclude[DirectMissingMethodProblem]("monix.execution.schedulers.TrampolineExecutionContext#JVMNormalTrampoline.*"),
+    exclude[DirectMissingMethodProblem]("monix.execution.schedulers.TrampolineExecutionContext#JVMOptimalTrampoline.*")
+  )
   lazy val changesFor_3_0_0__RC5: Seq[ProblemFilter] = Seq(
     // Incompatible signatures should not cause linking problems.
     exclude[IncompatibleSignatureProblem]("monix.reactive.Observable.observableNonEmptyParallel"),


### PR DESCRIPTION
Changed Trampoline to accept ECs as a parameter.
Changed TrampolineExecutionContext to use single ThreadLocal[Trampoline] on companion instead of one per instance.

See comment here for more details:
https://github.com/monix/monix/issues/870#issuecomment-545342047