### PR TITLE
Fix #1056: ensure boundary in TaskCreate if LCP enabled

### DIFF
--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskCreate.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskCreate.scala
@@ -226,10 +226,11 @@ private[eval] object TaskCreate {
       if (shouldPop) ctx.connection.pop()
       // Optimization — if the callback was called on the same thread
       // where it was created, then we are not going to fork
+      // This is not safe to do when localContextPropagation enabled
       isSameThread = Platform.currentThreadId() == threadId
       try {
         ctx.scheduler.execute(
-          if (isSameThread)
+          if (isSameThread && !ctx.options.localContextPropagation)
             this
           else
             StartAsyncBatchRunnable(this, ctx.scheduler)

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskLocalSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskLocalSuite.scala
@@ -19,11 +19,14 @@ package monix.eval
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
+
 import minitest.SimpleTestSuite
-import monix.execution.Scheduler
+import monix.execution.{BufferCapacity, CancelablePromise, Scheduler}
 import monix.execution.exceptions.DummyException
 import monix.execution.misc.Local
 import cats.implicits._
+import monix.catnap.{ConcurrentChannel, ConsumerF}
+import monix.execution.ExecutionModel.SynchronousExecution
 
 object TaskLocalSuite extends SimpleTestSuite {
   implicit val ec: Scheduler = monix.execution.Scheduler.Implicits.global
@@ -263,6 +266,45 @@ object TaskLocalSuite extends SimpleTestSuite {
       r  <- f.join
       _ = assertEquals(r._1, 0)
       _ = assertEquals(r._2, 5)
+    } yield ()
+
+    t.runToFutureOpt
+  }
+
+  testAsync("TaskLocal.isolate with ConcurrentChannel") {
+    val bufferSize = 16
+
+    class Test(
+      l: TaskLocal[String],
+      ch: ConcurrentChannel[Task, Unit, Int]
+    ) {
+      private[this] def produceLoop(n: Int): Task[Unit] =
+        if (n == 0) Task.unit else ch.push(n) >> l.read.flatMap { s =>
+          Task(assertEquals(s, "producer"))
+        } >> produceLoop(n - 1)
+
+      def produce: Task[Unit] =
+        for {
+          _ <- ch.awaitConsumers(1)
+          _ <- l.write("producer")
+          _ <- produceLoop(bufferSize * 2)
+          _ <- ch.halt(())
+        } yield ()
+
+      def consume: Task[Unit] = ch.consume.use { c =>
+        c.pull.delayResult(1.milli).flatMap { x =>
+          l.write(x.toString).as(x)
+        }.iterateWhile(_.isRight).void
+      }
+    }
+
+    val t = for {
+      tl <- TaskLocal("undefined")
+      ch <- ConcurrentChannel[Task].withConfig[Unit, Int](ConsumerF.Config(
+        capacity = BufferCapacity.Bounded(bufferSize).some
+      ))
+      test = new Test(tl, ch)
+      _  <- TaskLocal.isolate(test.produce) &> TaskLocal.isolate(test.consume)
     } yield ()
 
     t.runToFutureOpt


### PR DESCRIPTION
The optimization bypassing the async boundary can break Local isolation.