### PR TITLE
Remove task.doOnCancel(cancelComposite) in Observable.mapParallel

### DIFF
--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapParallelOrderedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapParallelOrderedObservable.scala
@@ -60,8 +60,6 @@ private[reactive] final class MapParallelOrderedObservable[A, B](
     implicit val scheduler = out.scheduler
     // Ensures we don't execute more than a maximum number of tasks in parallel
     private[this] val semaphore = AsyncSemaphore(parallelism)
-    // everything gets canceled at once
-    private[this] val cancelComposite = Task.eval(composite.cancel())
     // Buffer with the supplied  overflow strategy.
     private[this] val buffer = BufferedSubscriber[B](out, overflowStrategy, MultiProducer)
 
@@ -142,7 +140,7 @@ private[reactive] final class MapParallelOrderedObservable[A, B](
       // we can no longer stream errors downstream
       var streamErrors = true
       try {
-        val task = f(elem).doOnCancel(cancelComposite)
+        val task = f(elem)
         // No longer allowed to stream errors downstream
         streamErrors = false
         // Start execution (forcing an async boundary)
@@ -236,5 +234,4 @@ private[reactive] final class MapParallelOrderedObservable[A, B](
       composite.cancel()
     }
   }
-
 }


### PR DESCRIPTION
@TapanVaishnav  I noticed that `doOnCancel(cancelComposite)` is redundant because a `Task` is a part of composite - so if it gets canceled then the other `Task` will as well. 

I didn't want to bother you because of my oversight :D