### PR TITLE
Bracket should not evaluate "use" if Task was canceled during "acquire"

### DIFF
--- a/monix-eval/jvm/src/test/scala/monix/eval/TaskExecuteWithLocalContextSuite.scala
+++ b/monix-eval/jvm/src/test/scala/monix/eval/TaskExecuteWithLocalContextSuite.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package monix.eval
 
 import scala.util.Success

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskBracketSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskBracketSuite.scala
@@ -216,4 +216,24 @@ object TaskBracketSuite extends BaseTestSuite {
     sc.tick()
     assertEquals(f.value, Some(Success(())))
   }
+
+  test("use is not evaluated on cancel") { implicit sc =>
+    import scala.concurrent.duration._
+    var use = false
+    var release = false
+
+    val task = Task
+      .sleep(2.second)
+      .bracket(_ => Task { use = true })(_ => Task { release = true })
+
+    val f = task.runToFuture
+    sc.tick()
+
+    f.cancel()
+    sc.tick(2.second)
+
+    assertEquals(f.value, None)
+    assertEquals(use, false)
+    assertEquals(release, true)
+  }
 }


### PR DESCRIPTION
see https://github.com/typelevel/cats-effect/pull/706