### PR TITLE
Add mapConcat to Observable

### DIFF
--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -1759,7 +1759,7 @@ abstract class Observable[+A] extends Serializable { self =>
     *
     * ==Example==
     * {{{
-    *   Observable(1, 2, 3).mapConcat( x => Seq(x, x * 10, x * 100))
+    *   Observable(1, 2, 3).mapConcat( x => List(x, x * 10, x * 100))
     * }}}
     *
     * == Visual Example ==

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -55,6 +55,7 @@ import monix.reactive.subjects._
 import org.reactivestreams.{Publisher => RPublisher, Subscriber => RSubscriber}
 
 import scala.collection.mutable
+import scala.collection.immutable
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.concurrent.{Future, Promise}
 import scala.util.{Failure, Success, Try}
@@ -1750,6 +1751,28 @@ abstract class Observable[+A] extends Serializable { self =>
     */
   final def map[B](f: A => B): Observable[B] =
     self.liftByOperator(new MapOperator(f))
+
+  /** Applies a function that you supply to each item emitted by the
+    * source observable, where that function returns a sequence of elements, and
+    * then concatenating those resulting sequences and emitting the
+    * results of this concatenation.
+    *
+    * ==Example==
+    * {{{
+    *   Observable(1, 2, 3).mapConcat( x => Seq(x, x * 10, x * 100))
+    * }}}
+    *
+    * == Visual Example ==
+    *
+    * <pre>
+    * stream: 1 -- -- 2 -- -- 3 -- --
+    * result: 1, 10, 100, 2, 20, 200, 3, 30, 300
+    * </pre>
+    *
+    * @param f is a generator for the sequences being concatenated
+    */
+  final def mapConcat[B](f: A => immutable.Iterable[B]): Observable[B] =
+    self.liftByOperator(new MapConcatOperator(f))
 
   /** Alias for [[concatMap]].
     *

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapConcatOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapConcatOperator.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.reactive.internal.operators
+
+import monix.execution.Ack
+import monix.execution.Ack.{Continue, Stop}
+import monix.reactive.Observable.Operator
+import monix.reactive.observers.Subscriber
+
+import scala.collection.immutable
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+
+private[reactive] final class MapConcatOperator[-A, +B](f: A => immutable.Iterable[B]) extends Operator[A, B] {
+
+  def apply(out: Subscriber[B]): Subscriber[A] = {
+    new Subscriber[A] {
+      implicit val scheduler = out.scheduler
+      private[this] var isDone = false
+      private[this] var ack: Future[Ack] = Continue
+
+      def onNext(elem: A): Future[Ack] = {
+        // Protects calls to user code from within the operator and
+        // stream the error downstream if it happens, but if the
+        // error happens because of calls to `onNext` or other
+        // protocol calls, then the behavior should be undefined.
+        var streamError = true
+        try {
+          val next = f(elem)
+          streamError = false
+          ack = out.onNextAll(next)
+          ack
+        } catch {
+          case NonFatal(ex) if streamError =>
+            onError(ex)
+            ack = Stop
+            ack
+        }
+      }
+
+      def onError(ex: Throwable): Unit =
+        if (!isDone) {
+          isDone = true
+          out.onError(ex)
+        }
+
+      def onComplete(): Unit = {
+        if (!isDone) {
+          isDone = true
+          ack.syncOnComplete(_ => out.onComplete())
+        }
+      }
+    }
+  }
+}

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapConcatSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapConcatSuite.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.reactive.internal.operators
+
+import cats.laws._
+import cats.laws.discipline._
+import monix.execution.Ack
+import monix.execution.Ack.Continue
+import monix.execution.exceptions.DummyException
+import monix.reactive.{Observable, Observer}
+
+import scala.concurrent.duration.Duration.Zero
+import scala.concurrent.duration._
+import scala.concurrent.{Future, Promise}
+
+object MapConcatSuite extends BaseOperatorSuite {
+  def sum(sourceCount: Int): Long = (1 to sourceCount).flatMap(i => List(i, i * 10)).sum
+  def count(sourceCount: Int) = 2 * sourceCount
+
+  def createObservable(sourceCount: Int) = {
+    require(sourceCount > 0, "sourceCount should be strictly positive")
+    Some {
+      val o =
+        if (sourceCount == 1)
+          Observable.now(1L).mapConcat(i => List(i, i * 10))
+        else
+          Observable.range(1, sourceCount + 1, 1).mapConcat(i => List(i, i * 10))
+
+      Sample(o, count(sourceCount), sum(sourceCount), Zero, Zero)
+    }
+  }
+
+  def observableInError(sourceCount: Int, ex: Throwable) = {
+    require(sourceCount > 0, "sourceCount should be strictly positive")
+    Some {
+      val ex = DummyException("dummy")
+      val o =
+        if (sourceCount == 1)
+          createObservableEndingInError(Observable.now(1L), ex)
+            .mapConcat(i => List(i, i * 10))
+        else
+          createObservableEndingInError(Observable.range(1, sourceCount + 1, 1), ex)
+            .mapConcat(i => List(i, i * 10))
+
+      Sample(o, count(sourceCount), sum(sourceCount), Zero, Zero)
+    }
+  }
+
+  def brokenUserCodeObservable(sourceCount: Int, ex: Throwable) = {
+    require(sourceCount > 0, "sourceCount should be strictly positive")
+    Some {
+      val o =
+        if (sourceCount == 1)
+          Observable.now(1).mapConcat(_ => throw ex)
+        else
+          Observable.range(1, sourceCount + 1, 1).mapConcat { x =>
+            if (x == sourceCount)
+              throw ex
+            else
+              List(x, x * 10)
+          }
+
+      Sample(o, count(sourceCount - 1), sum(sourceCount - 1), Zero, Zero)
+    }
+  }
+
+  override def cancelableObservables(): Seq[Sample] = {
+    val obs = Observable.range(0, 1000).delayOnNext(1.second).mapConcat(i => List(i, i * 10))
+    Seq(Sample(obs, 0, 0, 0.seconds, 0.seconds))
+  }
+
+  test("should delay onComplete, for last element") { implicit s =>
+    val p = List(Promise[Ack](), Promise[Ack]())
+    var wasCompleted = false
+
+    createObservable(1) match {
+      case Some(Sample(obs, _, _, waitForFirst, waitForNext)) =>
+        var onNextReceived = 0
+
+        obs.unsafeSubscribeFn(new Observer[Long] {
+          def onNext(elem: Long): Future[Ack] = { onNextReceived += 1; p(onNextReceived - 1).future }
+          def onError(ex: Throwable): Unit = throw new IllegalStateException()
+          def onComplete(): Unit = wasCompleted = true
+        })
+
+        assert(!wasCompleted)
+        s.tick(waitForFirst)
+        assert(onNextReceived == 1)
+        p(0).success(Continue)
+        s.tick(waitForNext)
+        assert(onNextReceived == 2)
+        p(1).success(Continue)
+        s.tick(waitForNext)
+        assert(wasCompleted)
+    }
+  }
+
+  test("Observable.mapConcat is equivalent with Observable.flatMap + Observable.fromIterable") { implicit s =>
+    check1 { list: List[List[Int]] =>
+      val obs = Observable.fromIterable(list)
+      val resultViaMapConcat = obs.mapConcat(identity).reduce(_ + _).lastL
+      val resultViaFlatMap = obs.flatMap(Observable.fromIterable).reduce(_ + _).lastL
+
+      resultViaMapConcat <-> resultViaFlatMap
+    }
+  }
+}


### PR DESCRIPTION
Hello this PR adds
```scala
def [B] mapConcat(f: A: => Seq[B]) : Observable[B]
```
on Observable
which is a shorter version of
```scala
obs.flatMap(a => Observable.fromIterable(f(a))
```

I had to wait on the ack in the `onComplete` to make sure all elements from the last upstream `onNext` are properly propagated before completing our downstream.

Thank you
