### PR TITLE
Cancel should always wait for the finalizer

### DIFF
--- a/monix-eval/shared/src/main/scala/monix/eval/internal/ForwardCancelable.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/ForwardCancelable.scala
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval.internal
+
+import java.util.concurrent.atomic.AtomicReference
+
+import cats.effect.CancelToken
+import monix.eval.Task
+import monix.execution.schedulers.TrampolineExecutionContext
+import monix.execution.{Callback, Scheduler}
+
+import scala.annotation.tailrec
+import scala.concurrent.ExecutionContext
+import scala.util.control.NonFatal
+
+/**
+  * A placeholder for a [[cats.effect.CancelToken]] that will be set at a later time,
+  * the equivalent of a `Deferred[Task, CancelToken]`.
+  *
+  * Used in the implementation of `bracket`, see [[TaskBracket]].
+  */
+final private[internal] class ForwardCancelable private () {
+  import ForwardCancelable._
+
+  private[this] val state = new AtomicReference[State](init)
+
+  val cancel: CancelToken[Task] = {
+    @tailrec def loop(ctx: Task.Context, cb: Callback[Throwable, Unit]): Unit =
+      state.get() match {
+        case current @ Empty(list) =>
+          if (!state.compareAndSet(current, Empty(cb :: list)))
+            loop(ctx, cb)
+
+        case Active(token) =>
+          state.lazySet(finished) // GC purposes
+          context.execute(new Runnable {
+            def run() =
+              Task.unsafeStartNow(token, ctx, cb)
+          })
+      }
+
+    Task.Async(loop)
+  }
+
+  def complete(value: CancelToken[Task])(implicit s: Scheduler): Unit =
+    state.get() match {
+      case current @ Active(_) =>
+        value.runAsyncAndForget
+        throw new IllegalStateException(current.toString)
+
+      case current @ Empty(stack) =>
+        if (current eq init) {
+          // If `init`, then `cancel` was not triggered yet
+          if (!state.compareAndSet(current, Active(value)))
+            complete(value)
+        } else {
+          if (!state.compareAndSet(current, finished))
+            complete(value)
+          else {
+            execute(value, stack)
+          }
+        }
+    }
+}
+
+private[internal] object ForwardCancelable {
+  /**
+    * Builds reference.
+    */
+  def apply(): ForwardCancelable =
+    new ForwardCancelable
+
+  /**
+    * Models the internal state of [[ForwardCancelable]]:
+    *
+    *  - on start, the state is [[Empty]] of `Nil`, aka [[init]]
+    *  - on `cancel`, if no token was assigned yet, then the state will
+    *    remain [[Empty]] with a non-nil `List[Callback]`
+    *  - if a `CancelToken` is provided without `cancel` happening,
+    *    then the state transitions to [[Active]] mode
+    *  - on `cancel`, if the state was [[Active]], or if it was [[Empty]],
+    *    regardless, the state transitions to `Active(IO.unit)`, aka [[finished]]
+    */
+  sealed abstract private class State
+
+  final private case class Empty(stack: List[Callback[Throwable, Unit]]) extends State
+  final private case class Active(token: CancelToken[Task]) extends State
+
+  private val init: State = Empty(Nil)
+  private val finished: State = Active(Task.unit)
+  private val context: ExecutionContext = TrampolineExecutionContext.immediate
+
+  private def execute(token: CancelToken[Task], stack: List[Callback[Throwable, Unit]])(implicit s: Scheduler): Unit =
+    context.execute(new Runnable {
+      def run(): Unit = {
+        token.runAsync { r =>
+          for (cb <- stack)
+            try {
+              cb(r)
+            } catch {
+              // $COVERAGE-OFF$
+              case NonFatal(e) => s.reportFailure(e)
+              // $COVERAGE-ON$
+            }
+        }
+      }
+    })
+}

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskBracket.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskBracket.scala
@@ -24,6 +24,8 @@ import monix.execution.Callback
 import monix.eval.Task
 import monix.execution.atomic.Atomic
 import monix.execution.internal.Platform
+
+import scala.concurrent.Promise
 import scala.util.control.NonFatal
 
 private[monix] object TaskBracket {
@@ -167,6 +169,9 @@ private[monix] object TaskBracket {
     protected def makeReleaseFrame(ctx: Context, value: A): BaseReleaseFrame[A, B]
 
     final def apply(ctx: Context, cb: Callback[Throwable, B]): Unit = {
+      // Placeholder for the future finalizer
+      val deferredRelease = ForwardCancelable()
+      ctx.connection.push(deferredRelease.cancel)(ctx.scheduler)
       // Async boundary needed, but it is guaranteed via Task.Async below;
       Task.unsafeStartNow(
         acquire,
@@ -177,7 +182,7 @@ private[monix] object TaskBracket {
             val conn = ctx.connection
 
             val releaseFrame = makeReleaseFrame(ctx, value)
-            conn.push(releaseFrame.cancel)
+            deferredRelease.complete(releaseFrame.cancel)
 
               // Check if Task wasn't already cancelled in acquire
               if (!conn.isCanceled) {
@@ -200,6 +205,7 @@ private[monix] object TaskBracket {
 
   private abstract class BaseReleaseFrame[A, B](ctx: Context, a: A) extends StackFrame[B, Task[B]] {
     private[this] val waitsForResult = Atomic(true)
+    private[this] val p: Promise[Unit] = Promise()
     protected def releaseOnSuccess(a: A, b: B): Task[Unit]
     protected def releaseOnError(a: A, e: Throwable): Task[Unit]
     protected def releaseOnCancel(a: A): Task[Unit]
@@ -233,27 +239,24 @@ private[monix] object TaskBracket {
     final def cancel: Task[Unit] =
       Task.suspend {
         if (waitsForResult.compareAndSet(expect = true, update = false))
-          releaseOnCancel(a)
+          releaseOnCancel(a).redeemWith(ex => Task(p.success(())).flatMap(_ => Task.raiseError(ex)), _ => Task(p.success(())))
         else
-          Task.unit
+          TaskFromFuture.strict(p.future)
       }
 
     private final def unsafeApply(b: B): Task[B] = {
-      if (waitsForResult.compareAndSet(expect = true, update = false)) {
-        ctx.connection.pop()
-        releaseOnSuccess(a, b).map(_ => b)
-      } else {
+      if (waitsForResult.compareAndSet(expect = true, update = false))
+        releaseOnSuccess(a, b).redeemWith(ex => Task(p.success(())).flatMap(_ => Task.raiseError(ex)), _ => Task{p.success(()); b})
+      else
         Task.never
-      }
+
     }
 
     private final def unsafeRecover(e: Throwable): Task[B] = {
-      if (waitsForResult.compareAndSet(expect = true, update = false)) {
-        ctx.connection.pop()
-        releaseOnError(a, e).flatMap(new ReleaseRecover(e))
-      } else {
+      if (waitsForResult.compareAndSet(expect = true, update = false))
+        releaseOnError(a, e).redeemWith(ex => Task(p.success(())).flatMap(_ => Task.raiseError(ex)), _ => Task{p.success(()); ()}).flatMap(new ReleaseRecover(e))
+      else
         Task.never
-      }
     }
 
     private final def makeUncancelable(task: Task[B]): Task[B] = {

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskConnection.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskConnection.scala
@@ -152,7 +152,7 @@ private[eval] object TaskConnection {
     val cancel = Task.suspend {
       state.transformAndExtract {
         case (Nil, p) =>
-          (Task(p.success(())), (null, p))
+          (Task[Unit](p.success(())), (null, p))
         case (null, p) => (TaskFromFuture.strict(p.future), (null, p))
         case (list, p) =>
           val task = UnsafeCancelUtils

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskConnection.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskConnection.scala
@@ -156,9 +156,6 @@ private[eval] object TaskConnection {
         case Nil => Task.unit
         case null => TaskFromFuture.strict(p.future)
         case list =>
-          // cancel in progress, state is null
-          // tryReactivate called, state is Nil
-          // new cancel ? -> doesn't wait - should be fine though
           UnsafeCancelUtils.cancelAllUnsafe(list)
             .redeemWith(ex => Task(p.success(())).flatMap(_ => Task.raiseError(ex)), _ => Task(p.success(())))
       }

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskConnection.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskConnection.scala
@@ -152,8 +152,7 @@ private[eval] object TaskConnection {
     val cancel = Task.suspend {
       state.transformAndExtract {
         case (Nil, p) =>
-          p.success(())
-          (Task.unit, (null, p))
+          (Task(p.success(())), (null, p))
         case (null, p) => (TaskFromFuture.strict(p.future), (null, p))
         case (list, p) =>
           val task = UnsafeCancelUtils

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskGather.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskGather.scala
@@ -92,10 +92,11 @@ private[eval] object TaskGather {
         if (isActive) {
           isActive = false
           // This should cancel our CompositeCancelable
-          mainConn.pop().runAsyncAndForget
-          tasks = null // GC relief
-          results = null // GC relief
-          finalCallback.onError(ex)
+          mainConn.pop().map { _ =>
+            tasks = null // GC relief
+            results = null // GC relief
+            finalCallback.onError(ex)
+          }.runAsyncAndForget
         } else {
           s.reportFailure(ex)
         }

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskMapBoth.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskMapBoth.scala
@@ -78,8 +78,7 @@ private[eval] object TaskMapBoth {
           if (!state.compareAndSet(other, Stop))
             sendError(mainConn, state, cb, ex)(s) // retry
           else {
-            mainConn.pop().runAsyncAndForget
-            cb.onError(ex)
+            mainConn.pop().map(_ => cb.onError(ex)).runAsyncAndForget
           }
       }
     }

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRace.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRace.scala
@@ -58,16 +58,18 @@ private[eval] object TaskRace {
         new Callback[Throwable, A] {
           def onSuccess(valueA: A): Unit =
             if (isActive.getAndSet(false)) {
-              connB.cancel.runAsyncAndForget
-              conn.pop()
-              cb.onSuccess(Left(valueA))
+              connB.cancel.map { _ =>
+                conn.pop()
+                cb.onSuccess(Left(valueA))
+              }.runAsyncAndForget
             }
 
           def onError(ex: Throwable): Unit =
             if (isActive.getAndSet(false)) {
-              conn.pop()
-              connB.cancel.runAsyncAndForget
-              cb.onError(ex)
+              connB.cancel.map { _ =>
+                conn.pop()
+                cb.onError(ex)
+              }.runAsyncAndForget
             } else {
               sc.reportFailure(ex)
             }
@@ -81,16 +83,18 @@ private[eval] object TaskRace {
         new Callback[Throwable, B] {
           def onSuccess(valueB: B): Unit =
             if (isActive.getAndSet(false)) {
-              connA.cancel.runAsyncAndForget
-              conn.pop()
-              cb.onSuccess(Right(valueB))
+              connA.cancel.map { _ =>
+                conn.pop()
+                cb.onSuccess(Right(valueB))
+              }.runAsyncAndForget
             }
 
           def onError(ex: Throwable): Unit =
             if (isActive.getAndSet(false)) {
-              conn.pop()
-              connA.cancel.runAsyncAndForget
-              cb.onError(ex)
+              connA.cancel.map { _ =>
+                conn.pop()
+                cb.onError(ex)
+              }.runAsyncAndForget
             } else {
               sc.reportFailure(ex)
             }

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRaceList.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRaceList.scala
@@ -17,6 +17,7 @@
 
 package monix.eval.internal
 
+import cats.effect.CancelToken
 import monix.catnap.CancelableF
 import monix.execution.Callback
 import monix.eval.Task
@@ -56,25 +57,23 @@ private[eval] object TaskRaceList {
           task,
           taskContext,
           new Callback[Throwable, A] {
-            private def popAndCancelRest(): Unit = {
+            private def popAndCancelRest(): CancelToken[Task] = {
               conn.pop()
               val arr2 = cancelableArray.collect {
                 case cc if cc ne taskCancelable =>
                   cc.cancel
               }
-              CancelableF.cancelAllTokens[Task](arr2.toIndexedSeq: _*).runAsyncAndForget
+              CancelableF.cancelAllTokens[Task](arr2.toIndexedSeq: _*)
             }
 
             def onSuccess(value: A): Unit =
               if (isActive.getAndSet(false)) {
-                popAndCancelRest()
-                callback.onSuccess(value)
+                popAndCancelRest().map(_ => callback.onSuccess(value)).runAsyncAndForget
               }
 
             def onError(ex: Throwable): Unit =
               if (isActive.getAndSet(false)) {
-                popAndCancelRest()
-                callback.onError(ex)
+                popAndCancelRest().map(_ => callback.onError(ex)).runAsyncAndForget
               } else {
                 s.reportFailure(ex)
               }

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRacePair.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRacePair.scala
@@ -75,9 +75,10 @@ private[eval] object TaskRacePair {
 
           def onError(ex: Throwable): Unit =
             if (isActive.getAndSet(false)) {
-              conn.pop()
-              connB.cancel.runAsyncAndForget
-              cb.onError(ex)
+              connB.cancel.map { _ =>
+                conn.pop()
+                cb.onError(ex)
+              }.runAsyncAndForget
             } else {
               pa.failure(ex)
             }
@@ -100,9 +101,10 @@ private[eval] object TaskRacePair {
 
           def onError(ex: Throwable): Unit =
             if (isActive.getAndSet(false)) {
-              conn.pop()
-              connA.cancel.runAsyncAndForget
-              cb.onError(ex)
+              connA.cancel.map { _ =>
+                conn.pop()
+                cb.onError(ex)
+              }.runAsyncAndForget
             } else {
               pb.failure(ex)
             }

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskBracketSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskBracketSuite.scala
@@ -17,12 +17,13 @@
 
 package monix.eval
 
+import cats.effect.concurrent.Deferred
 import cats.laws._
 import cats.laws.discipline._
 import cats.syntax.all._
 import monix.execution.exceptions.{CompositeException, DummyException}
 import monix.execution.internal.Platform
-
+import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
 object TaskBracketSuite extends BaseTestSuite {
@@ -235,5 +236,130 @@ object TaskBracketSuite extends BaseTestSuite {
     assertEquals(f.value, None)
     assertEquals(use, false)
     assertEquals(release, true)
+  }
+
+  test("cancel should wait for already started finalizers on success") { implicit sc =>
+
+    val fa = for {
+      pa <- Deferred[Task, Unit]
+      fiber <- Task.unit.guarantee(pa.complete(()) >> Task.sleep(1.second)).start
+      _ <- pa.get
+      _ <- fiber.cancel
+    } yield ()
+
+    val f = fa.runToFuture
+
+    sc.tick()
+    assertEquals(f.value, None)
+
+    sc.tick(1.second)
+    assertEquals(f.value, Some(Success(())))
+  }
+
+  test("cancel should wait for already started finalizers on failure") { implicit sc =>
+    val dummy = new RuntimeException("dummy")
+
+    val fa = for {
+      pa <- Deferred[Task, Unit]
+      fiber <- Task.unit.guarantee(pa.complete(()) >> Task.sleep(1.second) >> Task.raiseError(dummy)).start
+      _ <- pa.get
+      _ <- fiber.cancel
+    } yield ()
+
+    val f = fa.runToFuture
+
+    sc.tick()
+    assertEquals(f.value, None)
+
+    sc.tick(1.second)
+    assertEquals(f.value, Some(Success(())))
+  }
+
+  test("cancel should wait for already started use finalizers") { implicit sc =>
+
+    val fa = for {
+      pa <- Deferred[Task, Unit]
+      fibA <- Task.unit
+        .bracket(
+          _ => Task.unit.guarantee(pa.complete(()) >> Task.sleep(2.second))
+        )(_ => Task.unit)
+        .start
+      _ <- pa.get
+      _ <- fibA.cancel
+    } yield ()
+
+    val f = fa.runToFuture
+
+    sc.tick()
+    assertEquals(f.value, None)
+
+    sc.tick(2.second)
+    assertEquals(f.value, Some(Success(())))
+  }
+
+  test("second cancel should wait for use finalizers") { implicit sc =>
+
+    val fa = for {
+      pa <- Deferred[Task, Unit]
+      fiber <- Task.unit
+        .bracket(
+          _ => (pa.complete(()) >> Task.never).guarantee(Task.sleep(2.second))
+        )(_ => Task.unit)
+        .start
+      _ <- pa.get
+      _ <- Task.race(fiber.cancel, fiber.cancel)
+    } yield ()
+
+    val f = fa.runToFuture
+
+    sc.tick()
+    assertEquals(f.value, None)
+
+    sc.tick(2.second)
+    assertEquals(f.value, Some(Success(())))
+  }
+
+  test("second cancel during acquire should wait for it and finalizers to complete") { implicit sc =>
+
+    val fa = for {
+      pa <- Deferred[Task, Unit]
+      fiber <- (pa.complete(()) >> Task.sleep(1.second))
+        .bracket(_ => Task.unit)(_ => Task.sleep(1.second))
+        .start
+      _ <- pa.get
+      _ <- Task.race(fiber.cancel, fiber.cancel)
+    } yield ()
+
+    val f = fa.runToFuture
+
+    sc.tick()
+    assertEquals(f.value, None)
+
+    sc.tick(1.second)
+    assertEquals(f.value, None)
+
+    sc.tick(1.second)
+    assertEquals(f.value, Some(Success(())))
+  }
+
+  test("second cancel during acquire should wait for it and finalizers to complete (non-terminating)") {
+    implicit sc =>
+
+      val fa = for {
+        pa <- Deferred[Task, Unit]
+        fiber <- (pa.complete(()) >> Task.sleep(1.second))
+          .bracket(_ => Task.unit)(_ => Task.never)
+          .start
+        _ <- pa.get
+        _ <- Task.race(fiber.cancel, fiber.cancel)
+      } yield ()
+
+      val f = fa.runToFuture
+
+      sc.tick()
+      assertEquals(f.value, None)
+
+      sc.tick(1.day)
+      assertEquals(f.value, None)
   }
 }

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskBracketSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskBracketSuite.scala
@@ -362,4 +362,18 @@ object TaskBracketSuite extends BaseTestSuite {
       sc.tick(1.day)
       assertEquals(f.value, None)
   }
+
+  test("Multiple cancel should not hang") { implicit sc =>
+
+    val fa = for {
+      fiber <- Task.sleep(1.second).start
+      _ <- fiber.cancel
+      _ <- fiber.cancel
+    } yield ()
+
+    val f = fa.runToFuture
+
+    sc.tick()
+    assertEquals(f.value, Some(Success(())))
+  }
 }

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskConnectionSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskConnectionSuite.scala
@@ -22,6 +22,7 @@ import monix.execution.Cancelable
 import monix.execution.cancelables.BooleanCancelable
 import monix.execution.exceptions.{CompositeException, DummyException}
 import monix.execution.internal.Platform
+import scala.concurrent.duration._
 
 object TaskConnectionSuite extends BaseTestSuite {
   test("initial push") { implicit s =>
@@ -253,7 +254,7 @@ object TaskConnectionSuite extends BaseTestSuite {
     assertEquals(effect, 100)
   }
 
-  test("tryReactive ") { implicit s =>
+  test("tryReactivate") { implicit s =>
     val ref = TaskConnection()
     val c1 = BooleanCancelable()
     ref.push(c1)
@@ -270,7 +271,7 @@ object TaskConnectionSuite extends BaseTestSuite {
     ref.push(c2)
     assert(!ref.isCanceled, "!ref.isCanceled")
     ref.cancel.runAsyncAndForget; s.tick()
-    assert(c2.isCanceled, "c1.isCanceled")
+    assert(c2.isCanceled, "c2.isCanceled")
     assert(ref.isCanceled, "ref.isCanceled")
 
     assert(TaskConnection.uncancelable.tryReactivate())


### PR DESCRIPTION
Port of my change in https://github.com/typelevel/cats-effect/pull/727 but we also support `tryReactivate` to implement `onCancelRaiseError`. Prior to the PR we backpressured finalizers only for the first action

I'm not sure how to handle `def tryReactivate(): Boolean`, I did something that might work but any suggestions welcome. It doesn't wait for finalizers BUT the method is private and only exists for `onCancelRaiseError` in `conn.cancel.map(_ => ...)` so it shouldn't be an issue.


Fixes #1086 and fixes #1124 