### PR TITLE
Observable.intervalAtFixedRate under-millisecond interval fix

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -66,3 +66,6 @@ https://github.com/mudsam
 
 Gabriel Claramunt
 https://github.com/gclaramunt
+
+Konrad Najder
+https://github.com/najder-k

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/IntervalFixedRateObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/IntervalFixedRateObservable.scala
@@ -38,21 +38,21 @@ private[reactive] final class IntervalFixedRateObservable(initialDelay: FiniteDu
     val task = MultiAssignCancelable()
 
     val runnable = new Runnable { self =>
-      private[this] val periodMillis = period.toMillis
+      private[this] val periodNanos = period.toNanos
       private[this] var counter = 0L
       private[this] var startedAt = 0L
 
       def scheduleNext(): Unit = {
         counter += 1
         val delay = {
-          val durationMillis = s.clockMonotonic(MILLISECONDS) - startedAt
-          val d = periodMillis - durationMillis
+          val durationNanos = s.clockMonotonic(NANOSECONDS) - startedAt
+          val d = periodNanos - durationNanos
           if (d >= 0L) d else 0L
         }
 
         // No need to synchronize, since we have a happens-before
         // relationship between scheduleOnce invocations.
-        task := s.scheduleOnce(delay, TimeUnit.MILLISECONDS, self)
+        task := s.scheduleOnce(delay, TimeUnit.NANOSECONDS, self)
       }
 
       def asyncScheduleNext(r: Future[Ack]): Unit =
@@ -64,7 +64,7 @@ private[reactive] final class IntervalFixedRateObservable(initialDelay: FiniteDu
         }
 
       def run(): Unit = {
-        startedAt = s.clockMonotonic(MILLISECONDS)
+        startedAt = s.clockMonotonic(NANOSECONDS)
         val ack = o.onNext(counter)
 
         if (ack == Continue)

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/IntervalObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/IntervalObservableSuite.scala
@@ -113,4 +113,35 @@ object IntervalObservableSuite extends SimpleTestSuite {
     s.tick(100.millis)
     assertEquals(received, 3)
   }
+
+  test("should do intervalAtFixedRate with nanosecond period") {
+    implicit val s = TestScheduler()
+    var received = 0
+
+    Observable
+      .intervalAtFixedRate(100.nanos)
+      .unsafeSubscribeFn(new Observer[Long] {
+        def onNext(elem: Long): Future[Ack] = {
+          received += 1
+          Future.delayedResult(10.nanos)(Continue)
+        }
+
+        def onError(ex: Throwable): Unit = ()
+        def onComplete(): Unit = ()
+      })
+
+    assertEquals(received, 1)
+
+    s.tick(90.nanos)
+    assertEquals(received, 1)
+
+    s.tick(10.nanos)
+    assertEquals(received, 2)
+
+    s.tick(90.nanos)
+    assertEquals(received, 2)
+
+    s.tick(10.nanos)
+    assertEquals(received, 3)
+  }
 }


### PR DESCRIPTION
Since the internal variables used for timekeeping in `IntervalFixedRateObservable` used millisecond precision, `Observable.intervalAtFixedRate(100.nanos)` would work the same as `Observable.intervalAtFixedRate(Duration.Zero)`. That makes it impossible to make an observable emitting more than 1000 elements per second (less than 1ms interval).

Seemed like an easy enough fix, although I don't know if there was a bigger reason behind using milliseconds for precision, or if that was just an oversight.