### PR TITLE
Add option to allow disabling isolating Local context on run

### DIFF
--- a/monix-eval/jvm/src/test/scala/monix/eval/TaskLocalJVMSuite.scala
+++ b/monix-eval/jvm/src/test/scala/monix/eval/TaskLocalJVMSuite.scala
@@ -277,4 +277,18 @@ object TaskLocalJVMSuite extends SimpleTestSuite {
 
     test.runToFuture
   }
+
+    testAsync("With disableLocalContextIsolateOnRun and enableLocalContextPropagation a Task local should retain its context when running the Task") {
+      import monix.execution.Scheduler.Implicits.global
+      implicit val opts = Task.defaultOptions.enableLocalContextPropagation.disableLocalContextIsolateOnRun
+
+      val local = Local(0)
+
+      val f = for {
+        _ <- Task { local := 50}.asyncBoundary.runToFutureOpt
+        v <- Future { local() }
+      } yield v
+
+      for (v <- f) yield assertEquals(v, 50)
+  }
 }

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskEffectInstanceSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskEffectInstanceSuite.scala
@@ -31,7 +31,8 @@ object TaskEffectInstanceSuite extends BaseTestSuite {
   test("Effect instance should make use of implicit TaskOptions") { implicit sc =>
     implicit val customOptions: Task.Options = Task.Options(
       autoCancelableRunLoops = true,
-      localContextPropagation = true
+      localContextPropagation = true,
+      localContextIsolateOnRun = true
     )
 
     var received: Task.Options = null

--- a/monix-execution/js/src/main/scala/monix/execution/internal/Platform.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/internal/Platform.scala
@@ -75,6 +75,12 @@ private[monix] object Platform {
   final val localContextPropagation: Boolean = false
 
   /**
+    * Isolating local context when running to Future is
+    * set to `true` by default.
+    */
+  final val localContextIsolateOnRun: Boolean = true
+
+  /**
     * Establishes the maximum stack depth for fused `.map` operations
     * for JavaScript.
     *

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/Platform.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/Platform.scala
@@ -132,6 +132,19 @@ private[monix] object Platform {
       .exists(v => v == "yes" || v == "true" || v == "1")
 
   /**
+    * Default value for isolating local context when running to a Future
+    * is set to true. On top of the JVM the default can be overridden by
+    * setting the following system property:
+    *
+    *  - `monix.environment.localContextIsolateOnRun`
+    *    (`true`, `yes` or `1` for enabling)
+    */
+  val localContextIsolateOnRun: Boolean =
+    Option(System.getProperty("monix.environment.localContextIsolateOnRun", ""))
+      .map(_.toLowerCase)
+      .forall(v => v != "no" && v != "false" && v != "0")
+
+  /**
     * Establishes the maximum stack depth for fused `.map` operations.
     *
     * The default is `128`, from which we subtract one as an


### PR DESCRIPTION
This PR adds an options to `Task.Options` which allows you to keep the current Local context when running to a Future, this solves the issue described here https://github.com/monix/monix/issues/848#issuecomment-568891708.

The new option is called `isolateLocalContextOnRun` and by default it is `true` (which keeps current behavior). If you set it to `false` then when running a `Task` to create a `Future`, the `Local` context propagation is not isolated so you can continue getting/setting values from the `Local` afterwards.

Note that a simple test was added to verify its working however some more tests may be needed? @Avasil @alexandru @oleg-py 