### PR TITLE
Fix 'MatchError: null' in Iterant.fromReactivePublisher

### DIFF
--- a/monix-tail/shared/src/test/scala/monix/tail/IterantFromReactivePublisherSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantFromReactivePublisherSuite.scala
@@ -110,6 +110,18 @@ object IterantFromReactivePublisherSuite extends BaseTestSuite {
     }
   }
 
+  test("fromReactivePublisher handles immediate completion") { implicit s =>
+    val publisher = new Publisher[Unit] {
+      def subscribe(subscriber: Subscriber[_ >: Unit]): Unit = {
+        subscriber.onComplete()
+      }
+    }
+    val f = Iterant[Task].fromReactivePublisher(publisher).completedL.runToFuture
+
+    s.tick()
+    assertEquals(f.value, Some(Success(())))
+  }
+
   class RangePublisher(from: Int, until: Int, step: Int, finish: Option[Throwable], onCancel: Promise[Unit])(
     implicit sc: Scheduler)
     extends Publisher[Int] {


### PR DESCRIPTION
`Iterant.fromReactivePublisher` could encounter `MatchError: null` if the publisher completed the subscription (or I supposed raised an error) before the subscriber could have been initialised.

The PR introduces an `Uninitialized` state to make sure the individual methods matching on it handle the situation.

Fixes https://github.com/monix/monix/issues/1180