### PR TITLE
Remove `blocking` around reading each element

### DIFF
--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CharsReaderObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CharsReaderObservable.scala
@@ -66,8 +66,10 @@ private[reactive] final class CharsReaderObservable(in: Reader, chunkSize: Int) 
     ack.onComplete {
       case Success(next) =>
         // Should we continue, or should we close the stream?
-        if (next == Continue && !c.isCanceled)
-          fastLoop(b, out, c, em, 0)
+        if (next == Continue && !c.isCanceled) {
+          // Using Scala's BlockContext, since this is potentially a blocking call
+          blocking(fastLoop(b, out, c, em, 0))
+        }
       // else stop
       case Failure(ex) =>
         reportFailure(ex)
@@ -89,8 +91,7 @@ private[reactive] final class CharsReaderObservable(in: Reader, chunkSize: Int) 
     var streamErrors = true
 
     try {
-      // Using Scala's BlockContext, since this is potentially a blocking call
-      val length = blocking(in.read(buffer))
+      val length = in.read(buffer)
       // From this point on, whatever happens is a protocol violation
       streamErrors = false
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/InputStreamObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/InputStreamObservable.scala
@@ -65,8 +65,10 @@ private[reactive] final class InputStreamObservable(in: InputStream, chunkSize: 
     ack.onComplete {
       case Success(next) =>
         // Should we continue, or should we close the stream?
-        if (next == Continue && !c.isCanceled)
-          fastLoop(b, out, c, em, 0)
+        if (next == Continue && !c.isCanceled) {
+          // Using Scala's BlockContext, since this is potentially a blocking call
+          blocking(fastLoop(b, out, c, em, 0))
+        }
       // else stop
       case Failure(ex) =>
         reportFailure(ex)
@@ -94,8 +96,7 @@ private[reactive] final class InputStreamObservable(in: InputStream, chunkSize: 
     var streamErrors = true
 
     try {
-      // Using Scala's BlockContext, since this is potentially a blocking call
-      val length = blocking(in.read(buffer))
+      val length = in.read(buffer)
       // From this point on, whatever happens is a protocol violation
       streamErrors = false
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/LinesReaderObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/LinesReaderObservable.scala
@@ -64,8 +64,10 @@ private[reactive] final class LinesReaderObservable(reader: Reader) extends Obse
     ack.onComplete {
       case Success(next) =>
         // Should we continue, or should we close the stream?
-        if (next == Continue && !c.isCanceled)
-          fastLoop(out, c, em, 0)
+        if (next == Continue && !c.isCanceled) {
+          // Using Scala's BlockContext, since this is potentially a blocking call
+          blocking(fastLoop(out, c, em, 0))
+        }
       // else stop
       case Failure(ex) =>
         reportFailure(ex)
@@ -83,8 +85,7 @@ private[reactive] final class LinesReaderObservable(reader: Reader) extends Obse
     var streamErrors = true
 
     try {
-      // Using Scala's BlockContext, since this is potentially a blocking call
-      val next = blocking(in.readLine())
+      val next = in.readLine()
       // From this point on, whatever happens is a protocol violation
       streamErrors = false
 


### PR DESCRIPTION
Removed `blocking` around reading each element in CharsReaderObservable, InputStreamObservable and LinesReaderObservable because it has a big performance overhead.

In a test that reads 3GB, 95M lines file `LinesReaderObservable` did ~400K lines per seconds before this fix, and ~7M lines per second after the fix (~17 times faster).