### PR TITLE
Issue #1177: Fix doAfterSubscribe popping cancelables in the wrong order

### DIFF
--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnSubscribeObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnSubscribeObservable.scala
@@ -103,7 +103,7 @@ private[reactive] object DoOnSubscribeObservable {
       )
 
       val ref = SingleAssignCancelable()
-      val conn = StackedCancelable(List(cancelable, ref))
+      val conn = StackedCancelable(List(ref, cancelable))
 
       ref := task.runAsync(new Callback[Throwable, Unit] {
         def onSuccess(value: Unit): Unit = {


### PR DESCRIPTION
Fixes #1177 