### PR TITLE
Fix GroupByOperator#onError to use onError for groups

### DIFF
--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/GroupBySuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/GroupBySuite.scala
@@ -110,7 +110,7 @@ object GroupBySuite extends BaseOperatorSuite {
   }
 
   test("on error groups should also error") { implicit s =>
-    var groupsCompleted = 0
+    var groupsErrored = 0
 
     val observable =
       Observable(1, 2, 3)
@@ -119,11 +119,11 @@ object GroupBySuite extends BaseOperatorSuite {
           case _ => Task.raiseError(new RuntimeException)
         }
         .groupBy(identity)
-        .mapEval(_.completedL >> Task(groupsCompleted += 1))
+        .mapEval(_.completedL.onErrorHandleWith(_ => Task(groupsErrored += 1)))
         .runAsyncGetLast
 
     s.tick()
-    assertEquals(groupsCompleted, 0)
+    assertEquals(groupsErrored, 2)
   }
 
   override def cancelableObservables() = {


### PR DESCRIPTION
`GroupByOperator#onError` currently calls `onComplete` for its groups, rather than `onError` as expected. This behaviour can cause groups to believe they have all elements, when in fact they might not. This can in turn lead to effects being executed on incomplete data in case of errors.