### PR TITLE
Fix memory leak

### DIFF
--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskBracket.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskBracket.scala
@@ -190,7 +190,7 @@ private[monix] object TaskBracket {
                 val fb =
                   try use(value)
                   catch { case NonFatal(e) => Task.raiseError(e) }
-                fb.flatMap(releaseFrame)
+                fb.flatMap(releaseFrame).flatMap(r => Task { conn.pop(); r })
               }
 
               Task.unsafeStartNow(onNext, ctx, cb)

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskConnection.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskConnection.scala
@@ -56,7 +56,7 @@ private[eval] sealed abstract class TaskConnection extends CancelableF[Task] {
 
   /**
     * Pushes a cancelable token on the stack, to be
-    * popped or canceled later in FIFO order.
+    * popped or canceled later in LIFO order.
     *
     * The function needs a [[monix.execution.Scheduler Scheduler]]
     * to work because in case the connection was already cancelled,
@@ -66,7 +66,7 @@ private[eval] sealed abstract class TaskConnection extends CancelableF[Task] {
 
   /**
     * Pushes a [[monix.execution.Cancelable]] on the stack, to be
-    * popped or canceled later in FIFO order.
+    * popped or canceled later in LIFO order.
     *
     * The function needs a [[monix.execution.Scheduler Scheduler]]
     * to work because in case the connection was already cancelled,
@@ -76,7 +76,7 @@ private[eval] sealed abstract class TaskConnection extends CancelableF[Task] {
 
   /**
     * Pushes a [[monix.catnap.CancelableF]] on the stack, to be
-    * popped or canceled later in FIFO order.
+    * popped or canceled later in LIFO order.
     *
     * The function needs a [[monix.execution.Scheduler Scheduler]]
     * to work because in case the connection was already cancelled,
@@ -94,7 +94,7 @@ private[eval] sealed abstract class TaskConnection extends CancelableF[Task] {
   def pushConnections(seq: CancelableF[Task]*)(implicit s: Scheduler): Unit
 
   /**
-    * Removes a cancelable reference from the stack in FIFO order.
+    * Removes a cancelable reference from the stack in LIFO order.
     *
     * @return the cancelable reference that was removed.
     */


### PR DESCRIPTION
After upgrading Monix to the latest version I found a memory leak related to the new bracket implementation.

Git bisect shows the culprit commit: 
https://github.com/monix/monix/pull/1120

Below is a simple piece of code that reproduces the issue:
`F.guarantee(F.unit)(F.unit).foreverM` - it fails with OutOfMemoryError on monix.eval.Task, but works fine with cats.effect.IO

I'm not sure if this is a correct fix of the issue and I need help to write a test on this case