### PR TITLE
Feature/transformer

### DIFF
--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -4664,6 +4664,12 @@ abstract class Observable[+A] extends Serializable { self =>
     Task.create { (s, onFinish) =>
       unsafeSubscribeFn(new ForeachSubscriber[A](cb, onFinish, s))
     }
+
+  final def transform[B](transformer: Observable[A] => Observable[B]): Observable[B] = {
+    transformer(this)
+  }
+
+
 }
 
 /** Observable builders.

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -19,20 +19,7 @@ package monix.reactive
 
 import java.io.{BufferedReader, InputStream, PrintStream, Reader}
 
-import cats.{
-  ~>,
-  Alternative,
-  Applicative,
-  Apply,
-  CoflatMap,
-  Eq,
-  FlatMap,
-  Functor,
-  FunctorFilter,
-  Monoid,
-  NonEmptyParallel,
-  Order
-}
+import cats.{Alternative, Applicative, Apply, CoflatMap, Eq, FlatMap, Functor, FunctorFilter, Monoid, NonEmptyParallel, Order, ~>}
 import cats.effect.{Bracket, Effect, ExitCase, Resource}
 import monix.eval.{Coeval, Task, TaskLift, TaskLike}
 import monix.eval.Task.defaultOptions
@@ -4665,6 +4652,7 @@ abstract class Observable[+A] extends Serializable { self =>
       unsafeSubscribeFn(new ForeachSubscriber[A](cb, onFinish, s))
     }
 
+
   final def transform[B](transformer: Observable[A] => Observable[B]): Observable[B] = {
     transformer(this)
   }
@@ -4712,6 +4700,8 @@ object Observable extends ObservableDeprecatedBuilders {
     * See [[Observable.liftByOperator]].
     */
   type Operator[-I, +O] = Subscriber[O] => Subscriber[I]
+
+  type Transformation[A, B] = Observable[A] => Observable[B]
 
   /** Given a sequence of elements, builds an observable from it. */
   def apply[A](elems: A*): Observable[A] =

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Transformer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Transformer.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.reactive
+
+import monix.reactive.Transformer.Transformer
+
+abstract class TransformerBuilder[A, B](first: Option[TransformerBuilder[_, _]]) extends Transformer[A, B] {
+
+
+ /* def a(observable: Observable[A]) = {
+    new Transformer(observable)
+  }*/
+
+  var nextT: Option[TransformerBuilder[B, *]] = None
+
+  val firstT = if(first.isEmpty) this else first.get
+
+  def chain[B, C](observable: Observable[A]): Observable[_] = {
+    nextT match {
+      //case Some(nextTransformation) => nextTransformation.apply(this.apply)
+      case Some(nextTransformation) => nextTransformation.chain(this.apply(observable))
+      case None => this.apply(observable)
+    }
+  }
+
+  def chainTransformation[B, C](nextTransformation: Transformer.Transformer[B, C]): Observable[C] =
+   nextTransformation(this.apply)
+
+  def map[A, B](f: A => B): TransformerMap[A, B] = {
+    val mapTransformer = new TransformerMap[A, B](f, Some(this))
+    nextT = Some(mapTransformer)
+    mapTransformer
+  }
+
+/*  def build(observable: Observable[A]) = {
+    firstT.chainTransformation()
+//    transformationChain.fold(observable)((state: Observable[_], next: Transformer[_, _]) => this.chainTransformation(next))
+  }*/
+
+
+}
+
+class TransformerMap[A, B](f: A => B, first: Option[TransformerBuilder[_, _]]) extends TransformerBuilder[A, B](first) {
+
+  override def apply(v1: Observable[A]): Observable[B] = {
+    v1.map(f)
+  }
+
+}
+
+
+
+object Transformer {
+  type Transformer[A, B] = (Observable[A] => Observable[B])
+
+ // def apply[A](observable: Observable[A]): Transformer[A, A] = new Transformer(observable)
+  def map[A, B](f: A => B) = new TransformerMap[A, B](f, None)
+
+}
+

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/transformer/BufferTumblingTransformer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/transformer/BufferTumblingTransformer.scala
@@ -20,10 +20,10 @@ package monix.reactive.internal.transformer
 import monix.reactive.{Observable, Transformer}
 
 
-class MapTransformer[A, B, I](f: A => B, previous: ChainableT[_, A, I]) extends Transformer[A, B, I](previous) {
+class BufferTumblingTransformer[A, I](n: Int, previous: ChainableT[_, A, I]) extends Transformer[A, Seq[A], I](previous) {
 
-  override def apply(v1: Observable[A]): Observable[B] = {
-    v1.map(f)
+  override def apply(ob: Observable[A]): Observable[Seq[A]] = {
+    ob.bufferTumbling(n)
   }
 
 }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/transformer/ChainableT.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/transformer/ChainableT.scala
@@ -17,14 +17,9 @@
 
 package monix.reactive.internal.transformer
 
-import monix.reactive.{Observable, Transformer}
+import monix.reactive.Observable
+import monix.reactive.Observable.Transformation
 
-
-class MapTransformer[A, B, I](f: A => B, previous: ChainableT[_, A, I]) extends Transformer[A, B, I](previous) {
-
-  override def apply(v1: Observable[A]): Observable[B] = {
-    v1.map(f)
-  }
-
+trait ChainableT[A, B, I] extends Transformation[A, B] {
+  def chainPrevious(observable: Observable[I]): Observable[B]
 }
-

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/transformer/FlatMapTransformer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/transformer/FlatMapTransformer.scala
@@ -20,10 +20,10 @@ package monix.reactive.internal.transformer
 import monix.reactive.{Observable, Transformer}
 
 
-class MapTransformer[A, B, I](f: A => B, previous: ChainableT[_, A, I]) extends Transformer[A, B, I](previous) {
+class FlatMapTransformer[A, B, I](f: A => Observable[B], previous: ChainableT[_, A, I]) extends Transformer[A, B, I](previous) {
 
   override def apply(v1: Observable[A]): Observable[B] = {
-    v1.map(f)
+    v1.flatMap(f)
   }
 
 }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/transformer/MapTransformer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/transformer/MapTransformer.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.reactive.internal.transformer
+
+import monix.reactive.Observable.Transformation
+import monix.reactive.{Observable, Transformer}
+
+
+class MapTransformer[A, B, I](f: A => B, previous: Transformer[_, A, I]) extends Transformer[A, B, I](previous) with Transformation[A, B] {
+
+  override def apply(v1: Observable[A]): Observable[B] = {
+    v1.map(f)
+  }
+
+}
+

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/transformer/TransformerIdentity.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/transformer/TransformerIdentity.scala
@@ -17,14 +17,12 @@
 
 package monix.reactive.internal.transformer
 
-import monix.reactive.{Observable, Transformer}
+import monix.reactive.Observable
 
+trait TransformerIdentity extends ChainableT[Any, Any, Any] {
 
-class MapTransformer[A, B, I](f: A => B, previous: ChainableT[_, A, I]) extends Transformer[A, B, I](previous) {
+  override def chainPrevious(ob: Observable[Any]): Observable[Any] = ob
 
-  override def apply(v1: Observable[A]): Observable[B] = {
-    v1.map(f)
-  }
-
+  override def apply(ob: Observable[Any]): Observable[Any] = ob
 }
 

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/transformer/BufferTumblingTransformerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/transformer/BufferTumblingTransformerSuite.scala
@@ -15,36 +15,36 @@
  * limitations under the License.
  */
 
-package monix.reactive.observables
+package monix.reactive.internal.transformer
 
 import minitest.TestSuite
 import monix.execution.schedulers.TestScheduler
-import monix.reactive.Observable.Transformation
 import monix.reactive.{Observable, Transformer}
+import monix.reactive.Observable.Transformation
 
-import scala.concurrent.duration._
 import scala.concurrent.Await
+import scala.concurrent.duration._
 
-object TransformerSuite extends TestSuite[TestScheduler] {
+
+object BufferTumblingTransformerSuite extends TestSuite[TestScheduler] {
   def setup(): TestScheduler = TestScheduler()
   def tearDown(s: TestScheduler): Unit = {
     assert(s.state.tasks.isEmpty, "TestScheduler should have no pending tasks")
   }
 
-  test("transform should accept any transformation ") { implicit s =>
-    def transformerA(obA: Observable[Int]): Observable[String] = obA.map(_.toString)
-    val transformerB: Transformation[Int, String] = Transformer.map[String](i => i.toString)
+  test("should expose bufferTumbling transformations") { implicit s =>
+    val transformer: Transformation[Int, Seq[String]] =
+      Transformer
+        .map[String](s => s.toString)
+        .bufferTumbling(2)
+        .chain
+
 
     s.tick()
+    val f = Observable.now(1).transform(transformer).headL.runToFuture
+    val r = Await.result(f, 1.seconds)
 
-    val f1 = Observable.now(1).transform(transformerA).headL.runToFuture
-    val f2 = Observable.now(1).transform(transformerB).headL.runToFuture
-
-    val r1 = Await.result(f1, 1.seconds)
-    val r2 = Await.result(f2, 1.seconds)
-    assertEquals(r1, "1")
-    assertEquals(r2, "1")
-
+    assertEquals(r, "1")
   }
 
 }

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/transformer/MapTransformerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/transformer/MapTransformerSuite.scala
@@ -15,36 +15,46 @@
  * limitations under the License.
  */
 
-package monix.reactive.observables
+package monix.reactive.internal.transformer
 
 import minitest.TestSuite
 import monix.execution.schedulers.TestScheduler
-import monix.reactive.Observable.Transformation
 import monix.reactive.{Observable, Transformer}
+import monix.reactive.Observable.Transformation
 
-import scala.concurrent.duration._
 import scala.concurrent.Await
+import scala.concurrent.duration._
 
-object TransformerSuite extends TestSuite[TestScheduler] {
+object MapTransformerSuite extends TestSuite[TestScheduler] {
   def setup(): TestScheduler = TestScheduler()
   def tearDown(s: TestScheduler): Unit = {
     assert(s.state.tasks.isEmpty, "TestScheduler should have no pending tasks")
   }
 
-  test("transform should accept any transformation ") { implicit s =>
-    def transformerA(obA: Observable[Int]): Observable[String] = obA.map(_.toString)
-    val transformerB: Transformation[Int, String] = Transformer.map[String](i => i.toString)
+  test("should expose map transformation") { implicit s =>
+    val transformer: Transformation[Int, String] =
+      Transformer.map[String](i => i.toString)
 
     s.tick()
 
-    val f1 = Observable.now(1).transform(transformerA).headL.runToFuture
-    val f2 = Observable.now(1).transform(transformerB).headL.runToFuture
+    val f = Observable.now(1).transform(transformer).headL.runToFuture
+    val r = Await.result(f, 1.seconds)
 
-    val r1 = Await.result(f1, 1.seconds)
-    val r2 = Await.result(f2, 1.seconds)
-    assertEquals(r1, "1")
-    assertEquals(r2, "1")
+    assertEquals(r, "1")
+  }
 
+  test("should allow chaining multiple map transformations") { implicit s =>
+    val transformer: Transformation[Int, String] = Transformer
+      .map[String](i => i.toString)
+      .map[String](s => s + s)
+      .chain
+
+    s.tick()
+
+    val f = Observable.now(1).transform(transformer).headL.runToFuture
+    val r = Await.result(f, 1.seconds)
+
+    assertEquals(r, "11")
   }
 
 }

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observables/TransformerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observables/TransformerSuite.scala
@@ -32,9 +32,9 @@ object TransformerSuite extends TestSuite[TestScheduler] {
     val transformer = Transformer.map[Int, String](i => i.toString)
 
 
-    val r = Observable.from(1, 2, 3).transform(transformer).toListL.runSyncUnsafe()
+    val r = Observable.now(1).transform(transformer).headL.runSyncUnsafe()
 
-    assertEquals(r, List("1", "2", "3"))
+    assertEquals(r, "1")
   }
 
 

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observables/TransformerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observables/TransformerSuite.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.reactive.observables
+
+import minitest.TestSuite
+import monix.execution.schedulers.TestScheduler
+import monix.reactive.{Observable, Transformer}
+
+
+object TransformerSuite extends TestSuite[TestScheduler] {
+  def setup(): TestScheduler = TestScheduler()
+  def tearDown(s: TestScheduler): Unit = {
+    assert(s.state.tasks.isEmpty, "TestScheduler should have no pending tasks")
+  }
+
+  test("transformer ") { implicit s =>
+    val transformer = Transformer.map[Int, String](i => i.toString)
+
+
+    val r = Observable.from(1, 2, 3).transform(transformer).toListL.runSyncUnsafe()
+
+    assertEquals(r, List("1", "2", "3"))
+  }
+
+
+}


### PR DESCRIPTION
**Draft, to gather feedback**

This PR was aimed to brought back the observable's `.transform` signature https://github.com/monix/monix/issues/891 , but while doing it, some ideas came up and just wanted to see how fare they could go. 

From the actual implementation you could have a broadly idea what this would be, but it has not been fully implemented since not really sure if people would like / approve it .

So, with the original idea to bring back the `transform(O[A] => O[B])`, being `Transformation[A, B]` an alias of `O[A] => O[B]`.  

A new builder that would create the `transformer`  was introduced (being similar to the creation of akka `Flow`), allowing then to construct transformations in a more idiomatic way while still being compatible with the same transform signature.

The following code better shows both examples:

```
def transformer(observable: Observable[Int]): Observable[Seq[String]] = {
  observable
     .map(i => i.toString)
     .bufferTumbling(n)
}
```  

The next example shows how transformer would be constructed using `Transformer` builder.
```
val transformer = {
  Transformer  
     .map(i => i.toString)
     .bufferTumbling(n)
     .chain
}
```  

Finally, both example could be used in the same way from on `transform` signature. 

```
val ob: Observable[Int] = ???
ob.transform(transformer)
```  

Again, this builder would just be a different way to do so. I will be comprensible if people don't like it, just to know if its worth to do more work on it :) 
 