### PR TITLE
Brings back transformer (#891)

### DIFF
--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -4712,7 +4712,10 @@ object Observable extends ObservableDeprecatedBuilders {
     */
   type Operator[-I, +O] = Subscriber[O] => Subscriber[I]
 
-  /** A `Transformer` is a function used for transforming observables */
+  /** A `Transformer` is a function used for transforming observables.
+    *
+    * See [[Observable.transform]]
+    */
   type Transformer[-A, +B] = Observable[A] => Observable[B]
 
   /** Given a sequence of elements, builds an observable from it. */

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -4666,7 +4666,7 @@ abstract class Observable[+A] extends Serializable { self =>
     }
 
   /** Transforms the source using the given transformer function. */
-  final def transform[B](transformer: Transformer[A, B]): Observable[B] =
+  def transform[B](transformer: Transformer[A, B]): Observable[B] =
     transformer(this)
 
 }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -42,7 +42,7 @@ import monix.execution._
 import monix.execution.annotations.{UnsafeBecauseImpure, UnsafeProtocol}
 import monix.execution.cancelables.{BooleanCancelable, SingleAssignCancelable}
 import monix.execution.exceptions.{DownstreamTimeoutException, UpstreamTimeoutException}
-import monix.reactive.Observable.Operator
+import monix.reactive.Observable.{Operator, Transformer}
 import monix.reactive.OverflowStrategy.Synchronous
 import monix.reactive.internal.builders
 import monix.reactive.internal.builders._
@@ -4664,6 +4664,11 @@ abstract class Observable[+A] extends Serializable { self =>
     Task.create { (s, onFinish) =>
       unsafeSubscribeFn(new ForeachSubscriber[A](cb, onFinish, s))
     }
+
+  /** Transforms the source using the given transformer function. */
+  final def transform[B](transformer: Transformer[A, B]): Observable[B] =
+    transformer(this)
+
 }
 
 /** Observable builders.
@@ -4706,6 +4711,9 @@ object Observable extends ObservableDeprecatedBuilders {
     * See [[Observable.liftByOperator]].
     */
   type Operator[-I, +O] = Subscriber[O] => Subscriber[I]
+
+  /** A `Transformer` is a function used for transforming observables */
+  type Transformer[-A, +B] = Observable[A] => Observable[B]
 
   /** Given a sequence of elements, builds an observable from it. */
   def apply[A](elems: A*): Observable[A] =

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TransformerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TransformerSuite.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.reactive.internal.operators
+
+import monix.execution.exceptions.DummyException
+import monix.reactive.Observable
+import monix.reactive.internal.operators.MapSuite.{count, sum}
+
+import scala.concurrent.duration.Duration.Zero
+import scala.util.Success
+import scala.concurrent.duration._
+
+object TransformerSuite extends BaseOperatorSuite {
+
+  def sum(sourceCount: Int): Long = (0 until sourceCount).sum.toLong * 2
+  def count(sourceCount: Int) = sourceCount
+
+  def dummyTransformer(ob: Observable[Long]): Observable[Long] = ob.map(_ * 2)
+
+  def aT(ob: Observable[Long]): Observable[Long] = ob.map(_ * 1)
+
+  def createObservable(sourceCount: Int) = Some {
+    val o =
+        Observable
+          .range(0, sourceCount)
+          .transform(dummyTransformer)
+
+    Sample(o, count(sourceCount), sum(sourceCount), Zero, Zero)
+  }
+
+  def observableInError(sourceCount: Int, ex: Throwable) = {
+    require(sourceCount > 0, "sourceCount should be strictly positive")
+    Some {
+      val ex = DummyException("dummy")
+      val o =
+        if (sourceCount == 1)
+          createObservableEndingInError(Observable.now(1L), ex).transform(dummyTransformer)
+        else
+          createObservableEndingInError(Observable.range(1, sourceCount + 1, 1), ex)
+              .transform(dummyTransformer)
+
+      Sample(o, count(sourceCount), sum(sourceCount), Zero, Zero)
+    }
+  }
+
+  def brokenUserCodeObservable(sourceCount: Int, ex: Throwable) = Option.empty
+
+  override def cancelableObservables(): Seq[Sample] = {
+    val obs = Observable.range(0, 1000).delayOnNext(1.second).map(_ + 1)
+    Seq(Sample(obs, 0, 0, 0.seconds, 0.seconds))
+  }
+
+  test("should transform the observable using the given transformer") { implicit s =>
+    val l = List(1L, 2, 3, 4)
+
+    val f = Observable.from(l).transform(dummyTransformer).toListL.runToFuture;
+
+    s.tick()
+    assertEquals(f.value, Some(Success(l.map(_ * 2))))
+  }
+}


### PR DESCRIPTION
Brings back `transform` signature and `type Transformer[+A, -B] = Observable[A] => Observable[B]`.

Some extra motivations of this PR are that the current `monix-dynamodb` already exposes this operator in its api, and it is also shown in the [documentation](https://monix.github.io/monix-connect/docs/dynamodb#transformer), which could create confusions.