### PR TITLE
Fix performance regression in bufferSliding

### DIFF
--- a/benchmarks/shared/src/main/scala/monix/benchmarks/ChunkedEvalFilterMapSumBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/ChunkedEvalFilterMapSumBenchmark.scala
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.benchmarks
+
+import java.util.concurrent.TimeUnit
+
+import monix.eval.{Task => MonixTask}
+import monix.reactive.{Observable => MonixObservable}
+import monix.tail.Iterant
+import org.openjdk.jmh.annotations._
+
+import scala.collection.immutable.IndexedSeq
+
+/**
+  * Benchmark designed to execute these operations:
+  *
+  *  1. iteration over an iterable
+  *  2. sliding window of fixed size
+  *  3. mapEval / flatMap
+  *  4. filter
+  *  5. map
+  *  6. foldLeft
+  *
+  * If the benchmark does not execute these and exactly these operations,
+  * then the measurement is not measuring the same thing across the board.
+  *
+  * To run the benchmarks and record results:
+  *
+  *     ./run-benchmark ChunkedEvalFilterMapSumBenchmark
+  *
+  * This will generate results in `./results`.
+  *
+  * Or to run the benchmark from within SBT:
+  *
+  *     jmh:run -i 10 -wi 10 -f 2 -t 1 monix.benchmarks.ChunkedEvalFilterMapSumBenchmark
+  *
+  * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread".
+  * Please note that benchmarks should be usually executed at least in
+  * 10 iterations (as a rule of thumb), but more is better.
+  */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class ChunkedEvalFilterMapSumBenchmark {
+  @Param(Array("1000"))
+  var chunkCount: Int = _
+
+  @Param(Array("1000"))
+  var chunkSize: Int = _
+
+  // All events that need to be streamed
+  var allElements: IndexedSeq[Int] = _
+  // For ensuring we get the result we expect
+  var expectedSum: Long = _
+
+  @Setup
+  def setup(): Unit = {
+    val chunks = (1 to chunkCount).map(i => Array.fill(chunkSize)(i))
+    allElements = chunks.flatten
+    expectedSum = allElements.sum
+  }
+
+  @Benchmark
+  def fs2Stream = {
+    val stream = FS2Stream
+      // 1: iteration
+      .apply(allElements:_*)
+      // 2: collect buffers
+      .chunkN(chunkSize)
+      // 3: eval map
+      .evalMap[MonixTask, Int](chunk => MonixTask(chunk.foldLeft(0)(_ + _)))
+      // 4: filter
+      .filter(_ > 0)
+      // 5: map
+      .map(_.toLong)
+      .compile
+      // 6: foldLeft
+      .fold(0L)(_ + _)
+
+    testResult(stream.runSyncUnsafe())
+  }
+
+  @Benchmark
+  def monixIterant: Long = {
+    val stream = Iterant[MonixTask]
+      // 1: iteration
+      .fromSeq(allElements)
+      // 2: collect buffers
+      .bufferTumbling(chunkSize)
+      // 3: eval map
+      .mapEval(seq => MonixTask(sumIntScala(seq)))
+      // 4: filter
+      .filter(_ > 0)
+      // 5: map
+      .map(_.toLong)
+      // 6: foldLeft
+      .foldLeftL(0L)(_ + _)
+
+    testResult(stream.runSyncUnsafe())
+  }
+
+  @Benchmark
+  def monixObservable(): Unit = {
+    // N.B. chunks aren't needed for Monix's Observable ;-)
+    val stream = MonixObservable
+      // 1: iteration
+      .fromIterable(allElements)
+      // 2: collect buffers
+      .bufferTumbling(chunkSize)
+      // 3: eval map
+      .mapEval[Int](seq => MonixTask(sumIntScala(seq)))
+      // 4: filter
+      .filter(_ > 0)
+      // 5: map
+      .map(_.toLong)
+      // 6: foldLeft
+      .foldLeftL(0L)(_ + _)
+
+    testResult(stream.runSyncUnsafe())
+  }
+
+  def testResult(r: Long): Long = {
+    if (r == 0 || r != expectedSum) {
+      throw new RuntimeException(s"received: $r != expected: $expectedSum")
+    }
+    r
+  }
+
+  def sumIntScala(seq: Iterable[Int]): Int = {
+    val cursor = seq.iterator
+    var sum = 0
+    while (cursor.hasNext) {
+      sum += cursor.next()
+    }
+    sum
+  }
+}

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalAttemptBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalAttemptBenchmark.scala
@@ -58,7 +58,7 @@ class CoevalAttemptBenchmark {
       if (i < size) Coeval.pure(i + 1).attempt.flatMap(_.fold(Coeval.raiseError, loop))
       else Coeval.pure(i)
 
-    loop(0).value
+    loop(0).value()
   }
 
   @Benchmark
@@ -75,6 +75,6 @@ class CoevalAttemptBenchmark {
       else
         Coeval.pure(i)
 
-    loop(0).value
+    loop(0).value()
   }
 }

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalDeepBindBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalDeepBindBenchmark.scala
@@ -60,7 +60,7 @@ class CoevalDeepBindBenchmark {
         _ <- if(j > size) Coeval.pure(j) else loop(j + 1)
       } yield j
 
-    loop(0).value
+    loop(0).value()
   }
 
   @Benchmark
@@ -71,6 +71,6 @@ class CoevalDeepBindBenchmark {
         _ <- if(j > size) Coeval(j) else loop(j + 1)
       } yield j
 
-    loop(0).value
+    loop(0).value()
   }
 }

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalHandleErrorBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalHandleErrorBenchmark.scala
@@ -62,7 +62,7 @@ class CoevalHandleErrorBenchmark {
       else
         Coeval.pure(i)
 
-    loop(0).value
+    loop(0).value()
   }
 
   @Benchmark
@@ -78,6 +78,6 @@ class CoevalHandleErrorBenchmark {
       else
         Coeval.pure(i)
 
-    loop(0).value
+    loop(0).value()
   }
 }

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalMapCallsBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalMapCallsBenchmark.scala
@@ -73,7 +73,7 @@ object CoevalMapCallsBenchmark {
     var sum = 0L
     var i = 0
     while (i < iterations) {
-      sum += io.value
+      sum += io.value()
       i += 1
     }
     sum

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalMapStreamBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalMapStreamBenchmark.scala
@@ -71,7 +71,7 @@ object CoevalMapStreamBenchmark {
       stream = mapStream(addOne)(stream)
       i += 1
     }
-    sum(0)(stream).value
+    sum(0)(stream).value()
   }
 
   final case class Stream(value: Int, next: Coeval[Option[Stream]])

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalShallowBindBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalShallowBindBenchmark.scala
@@ -59,7 +59,7 @@ class CoevalShallowBindBenchmark {
       if (i < size) Coeval.now(i + 1).flatMap(loop)
       else Coeval.now(i)
 
-    Coeval.now(0).flatMap(loop).value
+    Coeval.now(0).flatMap(loop).value()
   }
 
   @Benchmark
@@ -70,6 +70,6 @@ class CoevalShallowBindBenchmark {
       if (i < size) Coeval.eval(i + 1).flatMap(loop)
       else Coeval.eval(i)
 
-    Coeval.eval(0).flatMap(loop).value
+    Coeval.eval(0).flatMap(loop).value()
   }
 }

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/IterantMapFoldBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/IterantMapFoldBenchmark.scala
@@ -54,11 +54,11 @@ class IterantMapFoldBenchmark {
 
   @Benchmark
   def granular(): Long =
-    granularRef.map(_ + 1).foldLeftL(0L)(_ + _).value
+    granularRef.map(_ + 1).foldLeftL(0L)(_ + _).value()
 
   @Benchmark
   def batched(): Long =
-    batchedRef.map(_ + 1).foldLeftL(0L)(_ + _).value
+    batchedRef.map(_ + 1).foldLeftL(0L)(_ + _).value()
 }
 
 object IterantMapFoldBenchmark {

--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,14 @@ ThisBuild/catsEffectVersion := {
   }
 }
 
+lazy val fs2Version = settingKey[String]("fs2 version")
+ThisBuild/catsEffectVersion := {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, 11)) => "2.1.0"
+    case _ => "2.4.0"
+  }
+}
+
 val jcToolsVersion = "2.1.2"
 val reactiveStreamsVersion = "1.0.3"
 val minitestVersion = "2.8.2"
@@ -72,8 +80,8 @@ lazy val warnUnusedImport = Seq(
 
 lazy val sharedSettings = warnUnusedImport ++ Seq(
   organization := "io.monix",
-  scalaVersion := "2.13.1",
-  crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.1"),
+  scalaVersion := "2.13.3",
+  crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.3"),
 
   scalacOptions ++= Seq(
     // warnings
@@ -107,7 +115,6 @@ lazy val sharedSettings = warnUnusedImport ++ Seq(
     // Enables linter options
     "-Xlint:adapted-args", // warn if an argument list is modified to match the receiver
     "-Xlint:nullary-unit", // warn when nullary methods return Unit
-    "-Xlint:nullary-override", // warn when non-nullary `def f()' overrides nullary `def f'
     "-Xlint:infer-any", // warn when a type argument is inferred to be `Any`
     "-Xlint:missing-interpolator", // a string literal appears to be missing an interpolator id
     "-Xlint:doc-detached", // a ScalaDoc comment appears to be detached from its element
@@ -497,7 +504,8 @@ lazy val benchmarksPrev = project.in(file("benchmarks/vprev"))
   .settings(
     libraryDependencies ++= Seq(
       "io.monix" %% "monix" % "3.2.0",
-      "dev.zio" %% "zio" % "1.0.0-RC18-2"
+      "dev.zio" %% "zio" % "1.0.0-RC18-2",
+      "co.fs2" %% "fs2-core" % fs2Version
   ))
 
 lazy val benchmarksNext = project.in(file("benchmarks/vnext"))
@@ -509,7 +517,8 @@ lazy val benchmarksNext = project.in(file("benchmarks/vnext"))
   .settings(doNotPublishArtifact)
   .settings(
     libraryDependencies ++= Seq(
-      "dev.zio" %% "zio" % "1.0.0-RC18-2"
+      "dev.zio" %% "zio" % "1.0.0-RC18-2",
+      "co.fs2" %% "fs2-core" % fs2Version
     ))
 
 //------------- For Release

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ ThisBuild/catsEffectVersion := {
 }
 
 lazy val fs2Version = settingKey[String]("fs2 version")
-ThisBuild/catsEffectVersion := {
+ThisBuild/fs2Version := {
   CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((2, 11)) => "2.1.0"
     case _ => "2.4.0"
@@ -81,7 +81,7 @@ lazy val warnUnusedImport = Seq(
 lazy val sharedSettings = warnUnusedImport ++ Seq(
   organization := "io.monix",
   scalaVersion := "2.13.3",
-  crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.3"),
+  crossScalaVersions := Seq("2.11.12", "2.12.11", "2.13.3"),
 
   scalacOptions ++= Seq(
     // warnings
@@ -503,9 +503,9 @@ lazy val benchmarksPrev = project.in(file("benchmarks/vprev"))
   .settings(doNotPublishArtifact)
   .settings(
     libraryDependencies ++= Seq(
-      "io.monix" %% "monix" % "3.2.0",
-      "dev.zio" %% "zio" % "1.0.0-RC18-2",
-      "co.fs2" %% "fs2-core" % fs2Version
+      "io.monix" %% "monix" % "3.2.2",
+      "dev.zio" %% "zio-streams" % "1.0.0-RC21-2",
+      "co.fs2" %% "fs2-core" % fs2Version.value
   ))
 
 lazy val benchmarksNext = project.in(file("benchmarks/vnext"))
@@ -517,8 +517,8 @@ lazy val benchmarksNext = project.in(file("benchmarks/vnext"))
   .settings(doNotPublishArtifact)
   .settings(
     libraryDependencies ++= Seq(
-      "dev.zio" %% "zio" % "1.0.0-RC18-2",
-      "co.fs2" %% "fs2-core" % fs2Version
+      "dev.zio" %% "zio-streams" % "1.0.0-RC21-2",
+      "co.fs2" %% "fs2-core" % fs2Version.value
     ))
 
 //------------- For Release

--- a/monix-eval/shared/src/main/scala/monix/eval/Coeval.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Coeval.scala
@@ -981,7 +981,7 @@ object Coeval extends CoevalInstancesLevel0 {
     * Alias of [[eval]].
     */
   def apply[A](f: => A): Coeval[A] =
-    Always(f _)
+    Always(() => f)
 
   /** Returns a `Coeval` that on execution is always successful, emitting
     * the given strict value.
@@ -1014,7 +1014,7 @@ object Coeval extends CoevalInstancesLevel0 {
     * $unsafeMemoize
     */
   def evalOnce[A](a: => A): Coeval[A] =
-    Suspend(LazyVal(a _, cacheErrors = true))
+    Suspend(LazyVal(() => a, cacheErrors = true))
 
   /** Promote a non-strict value to a `Coeval`, catching exceptions in the
     * process.
@@ -1022,7 +1022,7 @@ object Coeval extends CoevalInstancesLevel0 {
     * Note that since `Coeval` is not memoized, this will recompute the
     * value each time the `Coeval` is executed.
     */
-  def eval[A](a: => A): Coeval[A] = Always(a _)
+  def eval[A](a: => A): Coeval[A] = Always(() => a)
 
   /** Alias for [[eval]]. */
   def delay[A](a: => A): Coeval[A] = eval(a)

--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -2604,7 +2604,7 @@ object Task extends TaskInstancesLevel1 {
     * same type.
     */
   def defer[A](fa: => Task[A]): Task[A] =
-    Suspend(fa _)
+    Suspend(() => fa)
 
   /** Defers the creation of a `Task` by using the provided
     * function, which has the ability to inject a needed
@@ -2692,7 +2692,7 @@ object Task extends TaskInstancesLevel1 {
 
   /** Alias for [[defer]]. */
   def suspend[A](fa: => Task[A]): Task[A] =
-    Suspend(fa _)
+    Suspend(() => fa)
 
   /** Promote a non-strict value to a Task that is memoized on the first
     * evaluation, the result being then available on subsequent evaluations.
@@ -2711,7 +2711,7 @@ object Task extends TaskInstancesLevel1 {
     * @param a is the thunk to process on evaluation
     */
   def eval[A](a: => A): Task[A] =
-    Eval(a _)
+    Eval(() => a)
 
   /** Lifts a non-strict value, a thunk, to a `Task` that will trigger a logical
     * fork before evaluation.
@@ -2724,7 +2724,7 @@ object Task extends TaskInstancesLevel1 {
     * @param a is the thunk to process on evaluation
     */
   def evalAsync[A](a: => A): Task[A] =
-    TaskEvalAsync(a _)
+    TaskEvalAsync(() => a)
 
   /** Alias for [[eval]]. */
   def delay[A](a: => A): Task[A] = eval(a)

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskConnection.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskConnection.scala
@@ -164,7 +164,7 @@ private[eval] object TaskConnection {
     }
 
     def isCanceled: Boolean =
-      state.get._1 eq null
+      state.get()._1 eq null
 
     def push(token: CancelToken[Task])(implicit s: Scheduler): Unit =
       pushAny(token)

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskMapBoth.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskMapBoth.scala
@@ -70,7 +70,7 @@ private[eval] object TaskMapBoth {
 
       // Guarding the contract of the callback, as we cannot send an error
       // if an error has already happened because of the other task
-      state.get match {
+      state.get() match {
         case Stop =>
           // We've got nowhere to send the error, so report it
           s.reportFailure(ex)
@@ -102,7 +102,7 @@ private[eval] object TaskMapBoth {
         context1,
         new Callback[Throwable, A1] {
           @tailrec def onSuccess(a1: A1): Unit =
-            state.get match {
+            state.get() match {
               case null => // null means this is the first task to complete
                 if (!state.compareAndSet(null, Left(a1))) onSuccess(a1)
               case Right(a2) => // the other task completed, so we can send
@@ -126,7 +126,7 @@ private[eval] object TaskMapBoth {
         context2,
         new Callback[Throwable, A2] {
           @tailrec def onSuccess(a2: A2): Unit =
-            state.get match {
+            state.get() match {
               case null => // null means this is the first task to complete
                 if (!state.compareAndSet(null, Right(a2))) onSuccess(a2)
               case Left(a1) => // the other task completed, so we can send

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/Atomic.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/Atomic.scala
@@ -195,11 +195,11 @@ object Atomic {
         if (util.isClean(cb)) {
           q"""
           val $self = $selfExpr
-          var $current = $self.get
+          var $current = $self.get()
           var $update = $cb($current)
 
           while (!$self.compareAndSet($current, $update)) {
-            $current = $self.get
+            $current = $self.get()
             $update = $cb($current)
           }
           """
@@ -209,11 +209,11 @@ object Atomic {
           val $self = $selfExpr
           val $fn = $cb
 
-          var $current = $self.get
+          var $current = $self.get()
           var $update = $fn($current)
 
           while (!$self.compareAndSet($current, $update)) {
-            $current = $self.get
+            $current = $self.get()
             $update = $fn($current)
           }
           """
@@ -235,11 +235,11 @@ object Atomic {
         if (util.isClean(cb)) {
           q"""
           val $self = $selfExpr
-          var $current = $self.get
+          var $current = $self.get()
           var $update = $cb($current)
 
           while (!$self.compareAndSet($current, $update)) {
-            $current = $self.get
+            $current = $self.get()
             $update = $cb($current)
           }
 
@@ -250,11 +250,11 @@ object Atomic {
           q"""
           val $self = $selfExpr
           val $fn = $cb
-          var $current = $self.get
+          var $current = $self.get()
           var $update = $fn($current)
 
           while (!$self.compareAndSet($current, $update)) {
-            $current = $self.get
+            $current = $self.get()
             $update = $fn($current)
           }
 
@@ -278,11 +278,11 @@ object Atomic {
         if (util.isClean(cb)) {
           q"""
           val $self = $selfExpr
-          var $current = $self.get
+          var $current = $self.get()
           var $update = $cb($current)
 
           while (!$self.compareAndSet($current, $update)) {
-            $current = $self.get
+            $current = $self.get()
             $update = $cb($current)
           }
 
@@ -293,11 +293,11 @@ object Atomic {
           q"""
           val $self = $selfExpr
           val $fn = $cb
-          var $current = $self.get
+          var $current = $self.get()
           var $update = $fn($current)
 
           while (!$self.compareAndSet($current, $update)) {
-            $current = $self.get
+            $current = $self.get()
             $update = $fn($current)
           }
 
@@ -325,11 +325,11 @@ object Atomic {
         if (util.isClean(cb)) {
           q"""
           val $self = $selfExpr
-          var $current = $self.get
+          var $current = $self.get()
           var ($resultVar, $updateVar) = $cb($current)
 
           while (!$self.compareAndSet($current, $updateVar)) {
-            $current = $self.get
+            $current = $self.get()
             val ($resultTmp, $updateTmp) = $cb($current)
             $updateVar = $updateTmp
             $resultVar = $resultTmp
@@ -343,11 +343,11 @@ object Atomic {
           val $self = $selfExpr
           val $fn = $cb
 
-          var $current = $self.get
+          var $current = $self.get()
           var ($resultVar, $updateVar) = $fn($current)
 
           while (!$self.compareAndSet($current, $updateVar)) {
-            $current = $self.get
+            $current = $self.get()
             val ($resultTmp, $updateTmp) = $fn($current)
             $updateVar = $updateTmp
             $resultVar = $resultTmp
@@ -383,7 +383,7 @@ object Atomic {
 
     def applyMacro[A: c.WeakTypeTag](): c.Expr[A] = {
       val selfExpr = c.Expr[Atomic[A]](c.prefix.tree)
-      val tree = q"""$selfExpr.get"""
+      val tree = q"""$selfExpr.get()"""
       inlineAndReset[A](tree)
     }
 

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicBoolean.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicBoolean.scala
@@ -48,7 +48,7 @@ final class AtomicBoolean private (private[this] val ref: BoxedInt) extends Atom
     ref.lazySet(if (update) 1 else 0)
 
   override def toString: String =
-    s"AtomicBoolean($get)"
+    s"AtomicBoolean(${get()})"
 }
 
 /** @define createDesc Constructs an [[AtomicBoolean]] reference, allowing

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicDouble.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicDouble.scala
@@ -45,7 +45,7 @@ final class AtomicDouble private (val ref: BoxedLong) extends AtomicNumber[Doubl
 
   @tailrec
   def increment(v: Int = 1): Unit = {
-    val current = get
+    val current = get()
     val update = incrementOp(current, v)
     if (!compareAndSet(current, update))
       increment(v)
@@ -53,7 +53,7 @@ final class AtomicDouble private (val ref: BoxedLong) extends AtomicNumber[Doubl
 
   @tailrec
   def add(v: Double): Unit = {
-    val current = get
+    val current = get()
     val update = plusOp(current, v)
     if (!compareAndSet(current, update))
       add(v)
@@ -61,7 +61,7 @@ final class AtomicDouble private (val ref: BoxedLong) extends AtomicNumber[Doubl
 
   @tailrec
   def incrementAndGet(v: Int = 1): Double = {
-    val current = get
+    val current = get()
     val update = incrementOp(current, v)
     if (!compareAndSet(current, update))
       incrementAndGet(v)
@@ -71,7 +71,7 @@ final class AtomicDouble private (val ref: BoxedLong) extends AtomicNumber[Doubl
 
   @tailrec
   def addAndGet(v: Double): Double = {
-    val current = get
+    val current = get()
     val update = plusOp(current, v)
     if (!compareAndSet(current, update))
       addAndGet(v)
@@ -81,7 +81,7 @@ final class AtomicDouble private (val ref: BoxedLong) extends AtomicNumber[Doubl
 
   @tailrec
   def getAndIncrement(v: Int = 1): Double = {
-    val current = get
+    val current = get()
     val update = incrementOp(current, v)
     if (!compareAndSet(current, update))
       getAndIncrement(v)
@@ -91,7 +91,7 @@ final class AtomicDouble private (val ref: BoxedLong) extends AtomicNumber[Doubl
 
   @tailrec
   def getAndAdd(v: Double): Double = {
-    val current = get
+    val current = get()
     val update = plusOp(current, v)
     if (!compareAndSet(current, update))
       getAndAdd(v)
@@ -101,7 +101,7 @@ final class AtomicDouble private (val ref: BoxedLong) extends AtomicNumber[Doubl
 
   @tailrec
   def subtract(v: Double): Unit = {
-    val current = get
+    val current = get()
     val update = minusOp(current, v)
     if (!compareAndSet(current, update))
       subtract(v)
@@ -109,7 +109,7 @@ final class AtomicDouble private (val ref: BoxedLong) extends AtomicNumber[Doubl
 
   @tailrec
   def subtractAndGet(v: Double): Double = {
-    val current = get
+    val current = get()
     val update = minusOp(current, v)
     if (!compareAndSet(current, update))
       subtractAndGet(v)
@@ -119,7 +119,7 @@ final class AtomicDouble private (val ref: BoxedLong) extends AtomicNumber[Doubl
 
   @tailrec
   def getAndSubtract(v: Double): Double = {
-    val current = get
+    val current = get()
     val update = minusOp(current, v)
     if (!compareAndSet(current, update))
       getAndSubtract(v)

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicFloat.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicFloat.scala
@@ -45,7 +45,7 @@ final class AtomicFloat private (private[this] val ref: BoxedInt) extends Atomic
 
   @tailrec
   def increment(v: Int = 1): Unit = {
-    val current = get
+    val current = get()
     val update = incrementOp(current, v)
     if (!compareAndSet(current, update))
       increment(v)
@@ -53,7 +53,7 @@ final class AtomicFloat private (private[this] val ref: BoxedInt) extends Atomic
 
   @tailrec
   def add(v: Float): Unit = {
-    val current = get
+    val current = get()
     val update = plusOp(current, v)
     if (!compareAndSet(current, update))
       add(v)
@@ -61,7 +61,7 @@ final class AtomicFloat private (private[this] val ref: BoxedInt) extends Atomic
 
   @tailrec
   def incrementAndGet(v: Int = 1): Float = {
-    val current = get
+    val current = get()
     val update = incrementOp(current, v)
     if (!compareAndSet(current, update))
       incrementAndGet(v)
@@ -71,7 +71,7 @@ final class AtomicFloat private (private[this] val ref: BoxedInt) extends Atomic
 
   @tailrec
   def addAndGet(v: Float): Float = {
-    val current = get
+    val current = get()
     val update = plusOp(current, v)
     if (!compareAndSet(current, update))
       addAndGet(v)
@@ -81,7 +81,7 @@ final class AtomicFloat private (private[this] val ref: BoxedInt) extends Atomic
 
   @tailrec
   def getAndIncrement(v: Int = 1): Float = {
-    val current = get
+    val current = get()
     val update = incrementOp(current, v)
     if (!compareAndSet(current, update))
       getAndIncrement(v)
@@ -91,7 +91,7 @@ final class AtomicFloat private (private[this] val ref: BoxedInt) extends Atomic
 
   @tailrec
   def getAndAdd(v: Float): Float = {
-    val current = get
+    val current = get()
     val update = plusOp(current, v)
     if (!compareAndSet(current, update))
       getAndAdd(v)
@@ -101,7 +101,7 @@ final class AtomicFloat private (private[this] val ref: BoxedInt) extends Atomic
 
   @tailrec
   def subtract(v: Float): Unit = {
-    val current = get
+    val current = get()
     val update = minusOp(current, v)
     if (!compareAndSet(current, update))
       subtract(v)
@@ -109,7 +109,7 @@ final class AtomicFloat private (private[this] val ref: BoxedInt) extends Atomic
 
   @tailrec
   def subtractAndGet(v: Float): Float = {
-    val current = get
+    val current = get()
     val update = minusOp(current, v)
     if (!compareAndSet(current, update))
       subtractAndGet(v)
@@ -119,7 +119,7 @@ final class AtomicFloat private (private[this] val ref: BoxedInt) extends Atomic
 
   @tailrec
   def getAndSubtract(v: Float): Float = {
-    val current = get
+    val current = get()
     val update = minusOp(current, v)
     if (!compareAndSet(current, update))
       getAndSubtract(v)

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicNumberAny.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicNumberAny.scala
@@ -50,14 +50,14 @@ final class AtomicNumberAny[A <: AnyRef: Numeric] private (private[this] val ref
 
   @tailrec
   def increment(v: Int = 1): Unit = {
-    val current = get
+    val current = get()
     if (!compareAndSet(current, ev.plus(current, ev.fromInt(v))))
       increment(v)
   }
 
   @tailrec
   def incrementAndGet(v: Int = 1): A = {
-    val current = get
+    val current = get()
     val update = ev.plus(current, ev.fromInt(v))
     if (!compareAndSet(current, update))
       incrementAndGet(v)
@@ -67,7 +67,7 @@ final class AtomicNumberAny[A <: AnyRef: Numeric] private (private[this] val ref
 
   @tailrec
   def getAndIncrement(v: Int = 1): A = {
-    val current = get
+    val current = get()
     val update = ev.plus(current, ev.fromInt(v))
     if (!compareAndSet(current, update))
       getAndIncrement(v)
@@ -77,7 +77,7 @@ final class AtomicNumberAny[A <: AnyRef: Numeric] private (private[this] val ref
 
   @tailrec
   def getAndAdd(v: A): A = {
-    val current = get
+    val current = get()
     val update = ev.plus(current, v)
     if (!compareAndSet(current, update))
       getAndAdd(v)
@@ -87,7 +87,7 @@ final class AtomicNumberAny[A <: AnyRef: Numeric] private (private[this] val ref
 
   @tailrec
   def addAndGet(v: A): A = {
-    val current = get
+    val current = get()
     val update = ev.plus(current, v)
     if (!compareAndSet(current, update))
       addAndGet(v)
@@ -97,7 +97,7 @@ final class AtomicNumberAny[A <: AnyRef: Numeric] private (private[this] val ref
 
   @tailrec
   def add(v: A): Unit = {
-    val current = get
+    val current = get()
     val update = ev.plus(current, v)
     if (!compareAndSet(current, update))
       add(v)
@@ -105,7 +105,7 @@ final class AtomicNumberAny[A <: AnyRef: Numeric] private (private[this] val ref
 
   @tailrec
   def subtract(v: A): Unit = {
-    val current = get
+    val current = get()
     val update = ev.minus(current, v)
     if (!compareAndSet(current, update))
       subtract(v)
@@ -113,7 +113,7 @@ final class AtomicNumberAny[A <: AnyRef: Numeric] private (private[this] val ref
 
   @tailrec
   def getAndSubtract(v: A): A = {
-    val current = get
+    val current = get()
     val update = ev.minus(current, v)
     if (!compareAndSet(current, update))
       getAndSubtract(v)
@@ -123,7 +123,7 @@ final class AtomicNumberAny[A <: AnyRef: Numeric] private (private[this] val ref
 
   @tailrec
   def subtractAndGet(v: A): A = {
-    val current = get
+    val current = get()
     val update = ev.minus(current, v)
     if (!compareAndSet(current, update))
       subtractAndGet(v)

--- a/monix-execution/jvm/src/main/scala/monix/execution/cancelables/ChainedCancelable.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/cancelables/ChainedCancelable.scala
@@ -116,7 +116,7 @@ final class ChainedCancelable private (private val state: AtomicAny[AnyRef]) ext
     val state = this.state
 
     while (true) {
-      state.get match {
+      state.get() match {
         case Canceled =>
           value.cancel()
           return
@@ -172,7 +172,7 @@ final class ChainedCancelable private (private val state: AtomicAny[AnyRef]) ext
       while (continue) {
         // Short-circuit if we discover a cycle
         if (cursor eq this) return
-        cursor.state.get match {
+        cursor.state.get() match {
           case ref2: WeakReference[_] =>
             cursor = ref2.get.asInstanceOf[CC]
             if (cursor eq null) {

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/forkJoin/DynamicWorkerThreadFactory.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/forkJoin/DynamicWorkerThreadFactory.scala
@@ -37,13 +37,13 @@ private[monix] final class DynamicWorkerThreadFactory(
   private[this] val currentNumberOfThreads = AtomicInt(0)
 
   @tailrec private def reserveThread(): Boolean =
-    currentNumberOfThreads.get match {
+    currentNumberOfThreads.get() match {
       case `maxThreads` | Int.`MaxValue` => false
       case other => currentNumberOfThreads.compareAndSet(other, other + 1) || reserveThread()
     }
 
   @tailrec private def deregisterThread(): Boolean =
-    currentNumberOfThreads.get match {
+    currentNumberOfThreads.get() match {
       case 0 => false
       case other => currentNumberOfThreads.compareAndSet(other, other - 1) || deregisterThread()
     }

--- a/monix-execution/shared/src/main/scala/monix/execution/Callback.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/Callback.scala
@@ -424,7 +424,7 @@ object Callback {
     }
 
     override final def run(): Unit = {
-      state.get match {
+      state.get() match {
         case 1 =>
           val v = value
           value = null.asInstanceOf[A]

--- a/monix-execution/shared/src/main/scala/monix/execution/CancelablePromise.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/CancelablePromise.scala
@@ -193,10 +193,10 @@ object CancelablePromise {
       unsafeSubscribe(cb)
 
     override def isCompleted: Boolean =
-      state.get.isInstanceOf[Try[_]]
+      state.get().isInstanceOf[Try[_]]
 
     override def future: CancelableFuture[A] =
-      state.get match {
+      state.get() match {
         case ref: Try[A] @unchecked =>
           CancelableFuture.fromTry(ref)
         case queue: MapQueue[AnyRef] @unchecked =>
@@ -212,7 +212,7 @@ object CancelablePromise {
 
     @tailrec
     override def tryComplete(result: Try[A]): Boolean = {
-      state.get match {
+      state.get() match {
         case queue: MapQueue[AnyRef] @unchecked =>
           if (!state.compareAndSet(queue, result)) {
             // Failed, retry...
@@ -256,7 +256,7 @@ object CancelablePromise {
       }
 
     @tailrec def unsafeSubscribe(cb: AnyRef): Cancelable =
-      state.get match {
+      state.get() match {
         case ref: Try[A] @unchecked =>
           call(cb, ref)
           Cancelable.empty
@@ -269,7 +269,7 @@ object CancelablePromise {
 
     private final class IdCancelable(id: Long) extends Cancelable {
       @tailrec def cancel(): Unit =
-        state.get match {
+        state.get() match {
           case queue: MapQueue[_] =>
             if (!state.compareAndSet(queue, queue.dequeue(id)))
               cancel()

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/BooleanCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/BooleanCancelable.scala
@@ -74,7 +74,7 @@ object BooleanCancelable {
   private final class BooleanCancelableTask(cb: () => Unit) extends BooleanCancelable {
 
     private[this] val callbackRef = AtomicAny(cb)
-    def isCanceled: Boolean = callbackRef.get eq null
+    def isCanceled: Boolean = callbackRef.get() eq null
 
     def cancel(): Unit = {
       // Setting the callback to null with a `getAndSet` is solving

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/CompositeCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/CompositeCancelable.scala
@@ -77,10 +77,10 @@ final class CompositeCancelable private (stateRef: AtomicAny[CompositeCancelable
   import CompositeCancelable.{Active, Cancelled}
 
   override def isCanceled: Boolean =
-    stateRef.get eq Cancelled
+    stateRef.get() eq Cancelled
 
   @tailrec override def cancel(): Unit =
-    stateRef.get match {
+    stateRef.get() match {
       case Cancelled => ()
       case current @ Active(set) =>
         if (stateRef.compareAndSet(current, Cancelled))
@@ -101,7 +101,7 @@ final class CompositeCancelable private (stateRef: AtomicAny[CompositeCancelable
 
   /** $addOp */
   @tailrec def add(other: Cancelable): this.type =
-    stateRef.get match {
+    stateRef.get() match {
       case Cancelled =>
         other.cancel()
         this
@@ -125,7 +125,7 @@ final class CompositeCancelable private (stateRef: AtomicAny[CompositeCancelable
   /** $addAllOp */
   def addAll(that: Iterable[Cancelable]): this.type = {
     @tailrec def loop(that: Iterable[Cancelable]): this.type =
-      stateRef.get match {
+      stateRef.get() match {
         case Cancelled =>
           Cancelable.cancelAll(that)
           this
@@ -150,7 +150,7 @@ final class CompositeCancelable private (stateRef: AtomicAny[CompositeCancelable
 
   /** $removeOp */
   @tailrec def remove(s: Cancelable): this.type =
-    stateRef.get match {
+    stateRef.get() match {
       case Cancelled => this
       case current @ Active(set) =>
         if (stateRef.compareAndSet(current, Active(set - s))) {
@@ -172,7 +172,7 @@ final class CompositeCancelable private (stateRef: AtomicAny[CompositeCancelable
   /** $removeAllOp */
   def removeAll(that: Iterable[Cancelable]): this.type = {
     @tailrec def loop(that: Iterable[Cancelable]): this.type =
-      stateRef.get match {
+      stateRef.get() match {
         case Cancelled => this
         case current @ Active(set) =>
           if (stateRef.compareAndSet(current, Active(set -- that))) {
@@ -191,7 +191,7 @@ final class CompositeCancelable private (stateRef: AtomicAny[CompositeCancelable
     * otherwise leaves it in the canceled state.
     */
   @tailrec def reset(): this.type =
-    stateRef.get match {
+    stateRef.get() match {
       case Cancelled => this
       case current @ Active(_) =>
         if (stateRef.compareAndSet(current, Active(Set.empty))) {
@@ -208,7 +208,7 @@ final class CompositeCancelable private (stateRef: AtomicAny[CompositeCancelable
     */
   def getAndSet(that: Iterable[Cancelable]): Set[Cancelable] = {
     @tailrec def loop(that: Set[Cancelable]): Set[Cancelable] =
-      stateRef.get match {
+      stateRef.get() match {
         case Cancelled =>
           Cancelable.cancelAll(that)
           Set.empty

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/MultiAssignCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/MultiAssignCancelable.scala
@@ -54,7 +54,7 @@ final class MultiAssignCancelable private (initial: Cancelable) extends Assignab
   }
 
   override def isCanceled: Boolean =
-    state.get match {
+    state.get() match {
       case null => true
       case _ => false
     }
@@ -67,7 +67,7 @@ final class MultiAssignCancelable private (initial: Cancelable) extends Assignab
   }
 
   @tailrec def `:=`(value: Cancelable): this.type =
-    state.get match {
+    state.get() match {
       case null =>
         value.cancel()
         this
@@ -99,7 +99,7 @@ final class MultiAssignCancelable private (initial: Cancelable) extends Assignab
     * dummy references.
     */
   @tailrec def clear(): Cancelable = {
-    val current: Cancelable = state.get
+    val current: Cancelable = state.get()
     if ((current ne null) && !current.isInstanceOf[IsDummy]) {
       if (state.compareAndSet(current, Cancelable.empty)) {
         current

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/OrderedCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/OrderedCancelable.scala
@@ -72,7 +72,7 @@ final class OrderedCancelable private (initial: Cancelable) extends AssignableCa
   }
 
   override def isCanceled: Boolean =
-    state.get match {
+    state.get() match {
       case Cancelled => true
       case _ => false
     }
@@ -82,7 +82,7 @@ final class OrderedCancelable private (initial: Cancelable) extends AssignableCa
     * reference is shared.
     */
   def currentOrder: Long =
-    state.get match {
+    state.get() match {
       case Cancelled => 0
       case Active(_, order) => order
     }
@@ -96,7 +96,7 @@ final class OrderedCancelable private (initial: Cancelable) extends AssignableCa
   }
 
   @tailrec def `:=`(value: Cancelable): this.type =
-    state.get match {
+    state.get() match {
       case Cancelled =>
         value.cancel()
         this
@@ -118,7 +118,7 @@ final class OrderedCancelable private (initial: Cancelable) extends AssignableCa
     * Useful to force ordering for concurrent updates.
     */
   @tailrec def orderedUpdate(value: Cancelable, order: Long): this.type =
-    state.get match {
+    state.get() match {
       case Cancelled =>
         value.cancel()
         this

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/RefCountCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/RefCountCancelable.scala
@@ -38,13 +38,13 @@ import scala.annotation.tailrec
   */
 final class RefCountCancelable private (onCancel: () => Unit) extends BooleanCancelable {
   def isCanceled: Boolean =
-    state.get.isCanceled
+    state.get().isCanceled
 
   /** Acquires a new [[monix.execution.Cancelable Cancelable]]. */
   @tailrec
   def acquire(): Cancelable = {
     @tailrec def decrementCounter(): State = {
-      val oldState = state.get
+      val oldState = state.get()
       val newState = oldState.copy(activeCounter = oldState.activeCounter - 1)
       if (state.compareAndSet(oldState, newState)) {
         newState
@@ -55,7 +55,7 @@ final class RefCountCancelable private (onCancel: () => Unit) extends BooleanCan
       }
     }
 
-    val oldState = state.get
+    val oldState = state.get()
     if (oldState.isCanceled) {
       Cancelable.empty
     } else if (!state.compareAndSet(oldState, oldState.copy(activeCounter = oldState.activeCounter + 1))) {
@@ -72,7 +72,7 @@ final class RefCountCancelable private (onCancel: () => Unit) extends BooleanCan
   }
 
   override def cancel(): Unit = {
-    val oldState = state.get
+    val oldState = state.get()
     if (!oldState.isCanceled)
       if (state.compareAndSet(oldState, oldState.copy(isCanceled = true))) {
         if (oldState.activeCounter == 0)

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/SerialCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/SerialCancelable.scala
@@ -46,7 +46,7 @@ final class SerialCancelable private (initial: Cancelable) extends AssignableCan
   }
 
   override def isCanceled: Boolean =
-    state.get match {
+    state.get() match {
       case null => true
       case _ => false
     }
@@ -58,7 +58,7 @@ final class SerialCancelable private (initial: Cancelable) extends AssignableCan
     }
 
   @tailrec def `:=`(value: Cancelable): this.type =
-    state.get match {
+    state.get() match {
       case null =>
         value.cancel()
         this

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/SingleAssignCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/SingleAssignCancelable.scala
@@ -42,7 +42,7 @@ final class SingleAssignCancelable private (extra: Cancelable) extends Assignabl
   import State._
 
   override def isCanceled: Boolean =
-    state.get match {
+    state.get() match {
       case IsEmptyCanceled | IsCanceled =>
         true
       case _ =>
@@ -64,7 +64,7 @@ final class SingleAssignCancelable private (extra: Cancelable) extends Assignabl
     // Optimistic CAS, no loop needed
     if (state.compareAndSet(Empty, IsActive(value))) this
     else {
-      state.get match {
+      state.get() match {
         case IsEmptyCanceled =>
           state.getAndSet(IsCanceled) match {
             case IsEmptyCanceled =>
@@ -87,7 +87,7 @@ final class SingleAssignCancelable private (extra: Cancelable) extends Assignabl
 
   @tailrec
   override def cancel(): Unit = {
-    state.get match {
+    state.get() match {
       case IsCanceled | IsEmptyCanceled => ()
       case IsActive(s) =>
         state.set(IsCanceled)

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/StackedCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/StackedCancelable.scala
@@ -129,7 +129,7 @@ object StackedCancelable {
       AtomicAny.withPadding(initial, PaddingStrategy.LeftRight128)
 
     override def isCanceled: Boolean =
-      state.get == null
+      state.get() == null
 
     override def cancel(): Unit = {
       // Using getAndSet, which on Java 8 should be faster than
@@ -141,7 +141,7 @@ object StackedCancelable {
     }
 
     @tailrec def popAndPushList(list: List[Cancelable]): Cancelable = {
-      state.get match {
+      state.get() match {
         case null =>
           Cancelable.cancelAll(list)
           Cancelable.empty
@@ -165,7 +165,7 @@ object StackedCancelable {
     }
 
     @tailrec def popAndPush(value: Cancelable): Cancelable = {
-      state.get match {
+      state.get() match {
         case null =>
           value.cancel()
           Cancelable.empty
@@ -190,7 +190,7 @@ object StackedCancelable {
     }
 
     @tailrec def pushList(list: List[Cancelable]): Unit = {
-      state.get match {
+      state.get() match {
         case null =>
           Cancelable.cancelAll(list)
         case current =>
@@ -210,7 +210,7 @@ object StackedCancelable {
       } else {
         val update = value :: current
         if (!state.compareAndSet(current, update))
-          pushLoop(state.get, value) // retry
+          pushLoop(state.get(), value) // retry
         else
           cache = update
       }
@@ -224,13 +224,13 @@ object StackedCancelable {
       current match {
         case null | Nil =>
           if (isFresh) Cancelable.empty
-          else popLoop(state.get, isFresh = true)
+          else popLoop(state.get(), isFresh = true)
         case ref @ (head :: tail) =>
           if (state.compareAndSet(ref, tail)) {
             cache = tail
             head
           } else {
-            popLoop(state.get, isFresh = true) // retry
+            popLoop(state.get(), isFresh = true) // retry
           }
       }
     }

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/RunnableAction.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/RunnableAction.scala
@@ -27,7 +27,7 @@ private[monix] final class RunnableAction private (action: () => Unit) extends R
 private[monix] object RunnableAction {
   /** Builder for [[RunnableAction]] */
   def apply(action: => Unit): Runnable =
-    new RunnableAction(action _)
+    new RunnableAction(() => action)
 
   /** Builder for [[RunnableAction]] */
   def from(f: () => Unit): Runnable =

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/math.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/math.scala
@@ -56,7 +56,7 @@ private[monix] object math {
     */
   def roundToPowerOf2(nr: Long) = {
     require(nr >= 0, "nr must be positive")
-    val bit = round(log2(nr))
+    val bit = round(log2(nr.toDouble))
     1L << (if (bit > 62) 62 else bit.toInt)
   }
 
@@ -84,7 +84,7 @@ private[monix] object math {
     */
   def nextPowerOf2(nr: Long) = {
     require(nr >= 0, "nr must be positive")
-    val bit = ceil(log2(nr))
+    val bit = ceil(log2(nr.toDouble))
     1L << (if (bit > 62) 62 else bit.toInt)
   }
 }

--- a/monix-execution/shared/src/main/scala/monix/execution/misc/Local.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/misc/Local.scala
@@ -67,7 +67,7 @@ object Local extends LocalCompanionDeprecated {
 
   /** Return the state of the current Local state. */
   def getContext(): Context =
-    localContext.get
+    localContext.get()
 
   /** Restore the Local state to a given Context. */
   def setContext(ctx: Context): Unit =

--- a/monix-execution/shared/src/main/scala/monix/execution/rstreams/SingleAssignSubscription.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/rstreams/SingleAssignSubscription.scala
@@ -40,7 +40,7 @@ final class SingleAssignSubscription private () extends Subscription {
   def :=(s: org.reactivestreams.Subscription): Unit = set(s)
 
   def set(s: org.reactivestreams.Subscription): Unit = {
-    val current = state.get
+    val current = state.get()
 
     current match {
       case Empty =>
@@ -69,7 +69,7 @@ final class SingleAssignSubscription private () extends Subscription {
 
   @tailrec
   def cancel(): Unit = {
-    val current = state.get
+    val current = state.get()
 
     current match {
       case Empty =>
@@ -93,7 +93,7 @@ final class SingleAssignSubscription private () extends Subscription {
 
   @tailrec
   def request(n: Long): Unit = {
-    val current = state.get
+    val current = state.get()
 
     current match {
       case Empty =>

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/TestScheduler.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/TestScheduler.scala
@@ -134,10 +134,10 @@ final class TestScheduler private (
     * Returns the internal state of the `TestScheduler`, useful for testing
     * that certain execution conditions have been met.
     */
-  def state: State = stateRef.get
+  def state: State = stateRef.get()
 
   override def clockRealTime(unit: TimeUnit): Long = {
-    val d: FiniteDuration = stateRef.get.clock
+    val d: FiniteDuration = stateRef.get().clock
     unit.convert(d.length, d.unit)
   }
 
@@ -146,7 +146,7 @@ final class TestScheduler private (
 
   @tailrec
   override def scheduleOnce(initialDelay: Long, unit: TimeUnit, r: Runnable): Cancelable = {
-    val current: State = stateRef.get
+    val current: State = stateRef.get()
     val (cancelable, newState) = TestScheduler.scheduleOnce(current, FiniteDuration(initialDelay, unit), r, cancelTask)
 
     if (stateRef.compareAndSet(current, newState)) cancelable
@@ -156,14 +156,14 @@ final class TestScheduler private (
 
   @tailrec
   protected override def executeAsync(r: Runnable): Unit = {
-    val current: State = stateRef.get
+    val current: State = stateRef.get()
     val update = TestScheduler.execute(current, r)
     if (!stateRef.compareAndSet(current, update)) executeAsync(r)
   }
 
   @tailrec
   override def reportFailure(t: Throwable): Unit = {
-    val current: State = stateRef.get
+    val current: State = stateRef.get()
     val update = current.copy(lastReportedError = t)
     if (!stateRef.compareAndSet(current, update)) reportFailure(t)
   }
@@ -196,7 +196,7 @@ final class TestScheduler private (
     *        was executed, or `false` otherwise
     */
   @tailrec def tickOne(): Boolean = {
-    val current = stateRef.get
+    val current = stateRef.get()
 
     // extracting one task by taking the immediate tasks
     extractOneTask(current, current.clock) match {
@@ -264,7 +264,7 @@ final class TestScheduler private (
   def tick(time: FiniteDuration = Duration.Zero, maxImmediateTasks: Option[Int] = None): Unit = {
     @tailrec
     def loop(time: FiniteDuration, iterCount: Int, maxIterCount: Int): Unit = {
-      val current: State = stateRef.get
+      val current: State = stateRef.get()
       val currentClock = current.clock + time
 
       extractOneTask(current, currentClock) match {
@@ -302,7 +302,7 @@ final class TestScheduler private (
 
   @tailrec
   private def cancelTask(t: Task): Unit = {
-    val current: State = stateRef.get
+    val current: State = stateRef.get()
     val update = current.copy(tasks = current.tasks - t)
     if (!stateRef.compareAndSet(current, update)) cancelTask(t)
   }

--- a/monix-execution/shared/src/main/scala_2.13+/monix/execution/compat.scala
+++ b/monix-execution/shared/src/main/scala_2.13+/monix/execution/compat.scala
@@ -31,5 +31,8 @@ object compat {
     def hasDefiniteSize[X](i: IterableOnce[X]): Boolean = i.knownSize >= 0
 
     def newBuilder[From, A, C](bf: BuildFrom[From, A, C], from: From): mutable.Builder[A, C] = bf.newBuilder(from)
+
+    @inline def toSeq[A](array: Array[AnyRef]): Seq[A] =
+      new scala.collection.immutable.ArraySeq.ofRef(array).asInstanceOf[Seq[A]]
   }
 }

--- a/monix-execution/shared/src/main/scala_2.13-/monix/execution/compat.scala
+++ b/monix-execution/shared/src/main/scala_2.13-/monix/execution/compat.scala
@@ -31,5 +31,8 @@ object compat {
     def hasDefiniteSize[X](i: IterableOnce[X]): Boolean = i.hasDefiniteSize
 
     def newBuilder[From, A, C](bf: BuildFrom[From, A, C], from: From): mutable.Builder[A, C] = bf.apply(from)
+
+    @inline def toSeq[A](array: Array[AnyRef]): Seq[A] =
+      new scala.collection.mutable.WrappedArray.ofRef(array).toSeq.asInstanceOf[Seq[A]]
   }
 }

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/DropNewBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/DropNewBufferedSubscriber.scala
@@ -174,7 +174,7 @@ private[observers] final class DropNewBufferedSubscriber[A] private (
           val next = {
             // Do we have an overflow message to send?
             val overflowMessage =
-              if (onOverflow == null || droppedCount.get == 0)
+              if (onOverflow == null || droppedCount.get() == 0)
                 null.asInstanceOf[A]
               else
                 onOverflow(droppedCount.getAndSet(0)).value() match {
@@ -228,7 +228,7 @@ private[observers] final class DropNewBufferedSubscriber[A] private (
             // visible, then the queue should be fully published because
             // there's a clear happens-before relationship between
             // queue.offer() and upstreamIsComplete=true
-            if (queue.isEmpty && (onOverflow == null || droppedCount.get == 0)) {
+            if (queue.isEmpty && (onOverflow == null || droppedCount.get() == 0)) {
               // ending loop
               downstreamIsComplete = true
 

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/EvictingBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/EvictingBufferedSubscriber.scala
@@ -254,7 +254,7 @@ private[observers] abstract class AbstractEvictingBufferedSubscriber[-A](
           val next: A = {
             // Do we have an overflow message to send?
             val overflowMessage =
-              if (onOverflow == null || droppedCount.get == 0)
+              if (onOverflow == null || droppedCount.get() == 0)
                 null.asInstanceOf[A]
               else
                 onOverflow(droppedCount.getAndSet(0)).value() match {
@@ -315,7 +315,7 @@ private[observers] abstract class AbstractEvictingBufferedSubscriber[-A](
             // there's a clear happens-before relationship between
             // queue.offer() and upstreamIsComplete=true
             currentQueue = queue.drain()
-            if (currentQueue.isEmpty && (onOverflow == null || droppedCount.get == 0)) {
+            if (currentQueue.isEmpty && (onOverflow == null || droppedCount.get() == 0)) {
               // ending loop
               downstreamIsComplete = true
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Consumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Consumer.scala
@@ -250,7 +250,7 @@ object Consumer {
     *        emitted value by the stream, for accumulating state
     */
   def foldLeft[S, A](initial: => S)(f: (S, A) => S): Consumer.Sync[A, S] =
-    new FoldLeftConsumer[A, S](initial _, f)
+    new FoldLeftConsumer[A, S](() => initial, f)
 
   /** Given a fold function and an initial state value, applies the
     * fold function to every element of the stream and finally signaling
@@ -270,7 +270,7 @@ object Consumer {
     *        execution.
     */
   def foldLeftEval[F[_], S, A](initial: => S)(f: (S, A) => F[S])(implicit F: TaskLike[F]): Consumer[A, S] =
-    new FoldLeftTaskConsumer[A, S](initial _, (s, a) => F(f(s, a)))
+    new FoldLeftTaskConsumer[A, S](() => initial, (s, a) => F(f(s, a)))
 
   /** Given a fold function and an initial state value, applies the
     * fold function to every element of the stream and finally signaling
@@ -286,7 +286,7 @@ object Consumer {
     *        returning a `Task` capable of asynchronous execution.
     */
   def foldLeftTask[S, A](initial: => S)(f: (S, A) => Task[S]): Consumer[A, S] =
-    new FoldLeftTaskConsumer[A, S](initial _, f)
+    new FoldLeftTaskConsumer[A, S](() => initial, f)
 
   /** A consumer that will produce the first streamed value on
     * `onNext` after which the streaming gets cancelled.

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -1039,7 +1039,7 @@ abstract class Observable[+A] extends Serializable { self =>
     * the source completes after emitting no items.
     */
   final def defaultIfEmpty[B >: A](default: => B): Observable[B] =
-    self.liftByOperator(new DefaultIfEmptyOperator[B](default _))
+    self.liftByOperator(new DefaultIfEmptyOperator[B](() => default))
 
   /** Delays emitting the final `onComplete` event by the specified amount. */
   final def delayOnComplete(delay: FiniteDuration): Observable[A] =
@@ -1835,7 +1835,7 @@ abstract class Observable[+A] extends Serializable { self =>
     * @see [[flatScan0]] for the version that emits seed element at the beginning
     */
   final def flatScan[R](seed: => R)(op: (R, A) => Observable[R]): Observable[R] =
-    new FlatScanObservable[A, R](self, seed _, op, delayErrors = false)
+    new FlatScanObservable[A, R](self, () => seed, op, delayErrors = false)
 
   /** Applies a binary operator to a start value and to elements
     * produced by the source observable, going from left to right,
@@ -1854,7 +1854,7 @@ abstract class Observable[+A] extends Serializable { self =>
     * @see [[flatScan]]
     */
   final def flatScanDelayErrors[R](seed: => R)(op: (R, A) => Observable[R]): Observable[R] =
-    new FlatScanObservable[A, R](self, seed _, op, delayErrors = true)
+    new FlatScanObservable[A, R](self, () => seed, op, delayErrors = true)
 
   /** Version of [[flatScan0]] that delays the errors from the emitted
     * streams until the source completes.
@@ -2905,7 +2905,7 @@ abstract class Observable[+A] extends Serializable { self =>
     * @see [[scan0]] for the version that emits seed element at the beginning
     */
   final def scan[S](seed: => S)(op: (S, A) => S): Observable[S] =
-    new ScanObservable[A, S](self, seed _, op)
+    new ScanObservable[A, S](self, () => seed, op)
 
   /**
     * Applies a binary operator to a start value and all elements of
@@ -2918,7 +2918,7 @@ abstract class Observable[+A] extends Serializable { self =>
     * the returned observable.
     */
   final def mapAccumulate[S, R](seed: => S)(op: (S, A) => (S, R)): Observable[R] =
-    new MapAccumulateObservable[A, S, R](self, seed _, op)
+    new MapAccumulateObservable[A, S, R](self, () => seed, op)
 
   /** Applies a binary operator to a start value and all elements of
     * this Observable, going left to right and returns a new
@@ -4054,7 +4054,7 @@ abstract class Observable[+A] extends Serializable { self =>
     *         is empty
     */
   final def foldWhileLeft[S](seed: => S)(op: (S, A) => Either[S, S]): Observable[S] =
-    new FoldWhileLeftObservable[A, S](self, seed _, op)
+    new FoldWhileLeftObservable[A, S](self, () => seed, op)
 
   /** Folds the source observable, from start to finish, until the
     * source completes, or until the operator short-circuits the
@@ -4267,7 +4267,7 @@ abstract class Observable[+A] extends Serializable { self =>
     *        observable, returning the next state
     */
   final def foldLeft[R](seed: => R)(op: (R, A) => R): Observable[R] =
-    new FoldLeftObservable[A, R](self, seed _, op)
+    new FoldLeftObservable[A, R](self, () => seed, op)
 
   /** Applies a binary operator to a start value and all elements of
     * the source, going left to right and returns a new `Task` that
@@ -4743,7 +4743,7 @@ object Observable extends ObservableDeprecatedBuilders {
     * emits a single element.
     */
   def eval[A](a: => A): Observable[A] =
-    new builders.EvalAlwaysObservable(a _)
+    new builders.EvalAlwaysObservable(() => a)
 
   /** Lifts a non-strict value into an observable that emits a single element,
     * but upon subscription delay its evaluation by the specified timespan
@@ -5338,7 +5338,7 @@ object Observable extends ObservableDeprecatedBuilders {
     * given factory on each subscription.
     */
   def defer[A](fa: => Observable[A]): Observable[A] =
-    new builders.DeferObservable(fa _)
+    new builders.DeferObservable(() => fa)
 
   /** Builds a new observable from a strict `head` and a lazily
     * evaluated tail.

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/FirstStartedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/FirstStartedObservable.scala
@@ -75,7 +75,7 @@ private[reactive] final class FirstStartedObservable[A](source: Observable[A]*) 
       private[this] var finishLineCache = -1
 
       private def shouldStream(): Boolean = {
-        if (finishLineCache != idx) finishLineCache = finishLine.get
+        if (finishLineCache != idx) finishLineCache = finishLine.get()
         if (finishLineCache == idx)
           true
         else if (finishLineCache >= 0 || !finishLine.compareAndSet(-1, idx))

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/LoadBalanceConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/LoadBalanceConsumer.scala
@@ -301,11 +301,11 @@ private[reactive] object LoadBalanceConsumer {
     }
 
     def activeCount: Int =
-      stateRef.get.activeCount
+      stateRef.get().activeCount
 
     @tailrec
     def offer(value: IndexedSubscriber[In]): Unit =
-      stateRef.get match {
+      stateRef.get() match {
         case current @ Available(queue, canceledIDs, ac) =>
           if (ac > 0 && !canceledIDs(value.id)) {
             val update = Available(queue.enqueue(value), canceledIDs, ac)
@@ -325,7 +325,7 @@ private[reactive] object LoadBalanceConsumer {
 
     @tailrec
     def poll(): Future[IndexedSubscriber[In]] =
-      stateRef.get match {
+      stateRef.get() match {
         case current @ Available(queue, canceledIDs, ac) =>
           if (ac <= 0)
             Future.successful(null)
@@ -350,7 +350,7 @@ private[reactive] object LoadBalanceConsumer {
 
     @tailrec
     def deactivateAll(): Unit =
-      stateRef.get match {
+      stateRef.get() match {
         case current @ Available(_, canceledIDs, _) =>
           val update: State[In] = Available(Queue.empty, canceledIDs, 0)
           if (!stateRef.compareAndSet(current, update))
@@ -365,7 +365,7 @@ private[reactive] object LoadBalanceConsumer {
 
     @tailrec
     def deactivate(ref: IndexedSubscriber[In]): Boolean =
-      stateRef.get match {
+      stateRef.get() match {
         case current @ Available(queue, canceledIDs, count) =>
           if (count <= 0) true
           else {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferSlidingOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferSlidingOperator.scala
@@ -22,7 +22,7 @@ import monix.execution.Ack.{Continue, Stop}
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
 import scala.concurrent.Future
-import scala.collection.mutable.WrappedArray
+import monix.execution.compat.internal.toSeq
 
 private[reactive] final class BufferSlidingOperator[A](count: Int, skip: Int) extends Operator[A, Seq[A]] {
 
@@ -42,10 +42,6 @@ private[reactive] final class BufferSlidingOperator[A](count: Int, skip: Int) ex
       private[this] var buffer = new Array[AnyRef](count)
       private[this] var dropped = 0
       private[this] var length = 0
-
-      @inline
-      private def toSeq(array: Array[AnyRef]): Seq[A] =
-        new WrappedArray.ofRef(array).toSeq.asInstanceOf[Seq[A]]
 
       def onNext(elem: A): Future[Ack] = {
         if (isDone)

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ConcatMapObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ConcatMapObservable.scala
@@ -113,7 +113,7 @@ private[reactive] final class ConcatMapObservable[A, B](
     }
 
     @tailrec private def cancelState(): Unit = {
-      stateRef.get match {
+      stateRef.get() match {
         case current @ Active(ref) =>
           if (stateRef.compareAndSet(current, Cancelled)) {
             ref.cancel()
@@ -154,7 +154,7 @@ private[reactive] final class ConcatMapObservable[A, B](
       // WARN: Concurrent cancellation might have happened, due
       // to the `Cancelled` state being thread-unsafe because of
       // the logic using `lazySet` below; hence the extra check
-      if (!isActive.get) {
+      if (!isActive.get()) {
         // If we have a `release` specified, this is `bracket`, so we still
         // need to ensure that release happens before stopping the stream
         if (release eq null) {
@@ -212,7 +212,7 @@ private[reactive] final class ConcatMapObservable[A, B](
               // `isActive == false` here b/c it was updated before `stateRef` (JMM);
               // And if `stateRef = Cancelled` happened afterwards, then we should
               // see it in the outer match statement
-              if (isActive.get) {
+              if (isActive.get()) {
                 asyncUpstreamAck.future.syncTryFlatten
               } else {
                 cancelState()
@@ -256,7 +256,7 @@ private[reactive] final class ConcatMapObservable[A, B](
       // the only race condition that can happen is for the child to
       // set this to `null` between this `get` and the upcoming
       // `getAndSet`, which is totally fine
-      val childRef = stateRef.get match {
+      val childRef = stateRef.get() match {
         case Active(ref) => ref
         case WaitComplete(_, ref) => ref
         case _ => null
@@ -284,7 +284,7 @@ private[reactive] final class ConcatMapObservable[A, B](
           // `Cancelled` state is thread unsafe, we need a second check.
           // Assumption is that `isActive = false` would be visible in case of
           // a race condition!
-          if (!isActive.get) cancelState()
+          if (!isActive.get()) cancelState()
 
         case WaitComplete(_, _) =>
           // This branch happens if the child has triggered the completion
@@ -319,7 +319,7 @@ private[reactive] final class ConcatMapObservable[A, B](
     private def sendOnComplete(): Unit = {
       if (!delayErrors) out.onComplete()
       else
-        this.errors.get match {
+        this.errors.get() match {
           case Nil => out.onComplete()
           case list => out.onError(CompositeException(list))
         }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FlatScanObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FlatScanObservable.scala
@@ -100,7 +100,7 @@ private[reactive] final class FlatScanObservable[A, R](
     }
 
     @tailrec private def cancelState(): Unit = {
-      stateRef.get match {
+      stateRef.get() match {
         case current @ Active(ref) =>
           if (stateRef.compareAndSet(current, Cancelled)) {
             ref.cancel()
@@ -141,7 +141,7 @@ private[reactive] final class FlatScanObservable[A, R](
       // WARN: Concurrent cancellation might have happened, due
       // to the `Cancelled` state being thread-unsafe because of
       // the logic using `lazySet` below; hence the extra check
-      if (!isActive.get) {
+      if (!isActive.get()) {
         Stop
       } else
         try {
@@ -186,7 +186,7 @@ private[reactive] final class FlatScanObservable[A, R](
               // `isActive == false` here b/c it was updated before `stateRef` (JMM);
               // And if `stateRef = Cancelled` happened afterwards, then we should
               // see it in the outer match statement
-              if (isActive.get) {
+              if (isActive.get()) {
                 asyncUpstreamAck.future.syncTryFlatten
               } else {
                 cancelState()
@@ -230,7 +230,7 @@ private[reactive] final class FlatScanObservable[A, R](
       // the only race condition that can happen is for the child to
       // set this to `null` between this `get` and the upcoming
       // `getAndSet`, which is totally fine
-      val childRef = stateRef.get match {
+      val childRef = stateRef.get() match {
         case Active(ref) => ref
         case WaitComplete(_, ref) => ref
         case _ => null
@@ -258,7 +258,7 @@ private[reactive] final class FlatScanObservable[A, R](
           // `Cancelled` state is thread unsafe, we need a second check.
           // Assumption is that `isActive = false` would be visible in case of
           // a race condition!
-          if (!isActive.get) cancelState()
+          if (!isActive.get()) cancelState()
 
         case WaitComplete(_, _) =>
           // This branch happens if the child has triggered the completion
@@ -293,7 +293,7 @@ private[reactive] final class FlatScanObservable[A, R](
     private def sendOnComplete(): Unit = {
       if (!delayErrors) out.onComplete()
       else
-        this.errors.get match {
+        this.errors.get() match {
           case Nil => out.onComplete()
           case list => out.onError(CompositeException(list))
         }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapTaskObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapTaskObservable.scala
@@ -102,7 +102,7 @@ private[reactive] final class MapTaskObservable[A, B](source: Observable[A], f: 
     }
 
     @tailrec private def cancelState(): Unit =
-      stateRef.get match {
+      stateRef.get() match {
         case current @ Active(ref) =>
           if (stateRef.compareAndSet(current, Cancelled)) {
             ref.cancel()
@@ -142,7 +142,7 @@ private[reactive] final class MapTaskObservable[A, B](source: Observable[A], f: 
       // WARN: Concurrent cancellation might have happened, due
       // to the `Cancelled` state being thread-unsafe because of
       // the logic using `lazySet` below; hence the extra check
-      if (!isActive.get) {
+      if (!isActive.get()) {
         Stop
       } else
         try {
@@ -185,7 +185,7 @@ private[reactive] final class MapTaskObservable[A, B](source: Observable[A], f: 
               // `isActive == false` here b/c it was updated before `stateRef` (JMM);
               // And if `stateRef = Cancelled` happened afterwards, then we should
               // see it in the outer match statement
-              if (isActive.get) {
+              if (isActive.get()) {
                 ack
               } else {
                 cancelState()
@@ -286,7 +286,7 @@ private[reactive] final class MapTaskObservable[A, B](source: Observable[A], f: 
       // the only race condition that can happen is for the child to
       // set this to `null` between this `get` and the upcoming
       // `getAndSet`, which is totally fine
-      val childRef = stateRef.get match {
+      val childRef = stateRef.get() match {
         case Active(ref) => ref
         case WaitComplete(_, ref) => ref
         case _ => null
@@ -328,7 +328,7 @@ private[reactive] final class MapTaskObservable[A, B](source: Observable[A], f: 
           // `Cancelled` state is thread unsafe, we need a second check.
           // Assumption is that `isActive = false` would be visible in case of
           // a race condition!
-          if (!isActive.get) cancelState()
+          if (!isActive.get()) cancelState()
 
         case WaitActiveTask =>
           // Something is screwed up in our state machine :-(

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/rstreams/ReactiveSubscriberAsMonixSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/rstreams/ReactiveSubscriberAsMonixSubscriber.scala
@@ -122,7 +122,7 @@ private[reactive] object ReactiveSubscriberAsMonixSubscriber {
 
     @tailrec
     def await(): Future[Long] = {
-      state.get match {
+      state.get() match {
         case CancelledState =>
           Future.successful(0)
 
@@ -154,7 +154,7 @@ private[reactive] object ReactiveSubscriberAsMonixSubscriber {
         "n must be strictly positive, according to " +
           "the Reactive Streams contract, rule 3.9")
 
-      state.get match {
+      state.get() match {
         case CancelledState =>
           () // do nothing
 
@@ -183,7 +183,7 @@ private[reactive] object ReactiveSubscriberAsMonixSubscriber {
 
     @tailrec
     def cancel(): Unit = {
-      state.get match {
+      state.get() match {
         case CancelledState =>
           () // do nothing
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observables/RefCountObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observables/RefCountObservable.scala
@@ -39,7 +39,7 @@ final class RefCountObservable[+A] private (source: ConnectableObservable[A]) ex
 
   @tailrec
   def unsafeSubscribeFn(subscriber: Subscriber[A]): Cancelable = {
-    val current = refs.get
+    val current = refs.get()
     val update = current match {
       case x if x < 0 => 1
       case 0 => 0
@@ -89,7 +89,7 @@ final class RefCountObservable[+A] private (source: ConnectableObservable[A]) ex
     }
 
   @tailrec
-  private[this] def countDownToConnectionCancel(): Unit = refs.get match {
+  private[this] def countDownToConnectionCancel(): Unit = refs.get() match {
     case x if x > 0 =>
       val update = x - 1
       if (!refs.compareAndSet(x, update))

--- a/monix-reactive/shared/src/main/scala/monix/reactive/subjects/BehaviorSubject.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/subjects/BehaviorSubject.scala
@@ -44,12 +44,12 @@ final class BehaviorSubject[A] private (initialValue: A) extends Subject[A, A] {
     Atomic(BehaviorSubject.State[A](initialValue))
 
   def size: Int =
-    stateRef.get.subscribers.size
+    stateRef.get().subscribers.size
 
   @tailrec
   def unsafeSubscribeFn(subscriber: Subscriber[A]): Cancelable = {
     import subscriber.scheduler
-    val state = stateRef.get
+    val state = stateRef.get()
 
     if (state.errorThrown != null) {
       subscriber.onError(state.errorThrown)
@@ -80,7 +80,7 @@ final class BehaviorSubject[A] private (initialValue: A) extends Subject[A, A] {
 
   @tailrec
   def onNext(elem: A): Future[Ack] = {
-    val state = stateRef.get
+    val state = stateRef.get()
 
     if (state.isDone) Stop
     else {
@@ -143,7 +143,7 @@ final class BehaviorSubject[A] private (initialValue: A) extends Subject[A, A] {
 
   @tailrec
   private def onCompleteOrError(ex: Throwable): Unit = {
-    val state = stateRef.get
+    val state = stateRef.get()
 
     if (!state.isDone) {
       if (!stateRef.compareAndSet(state, state.markDone(ex)))
@@ -164,7 +164,7 @@ final class BehaviorSubject[A] private (initialValue: A) extends Subject[A, A] {
 
   @tailrec
   private def removeSubscriber(s: ConnectableSubscriber[A]): Unit = {
-    val state = stateRef.get
+    val state = stateRef.get()
     val newState = state.removeSubscriber(s)
     if (!stateRef.compareAndSet(state, newState))
       removeSubscriber(s)

--- a/monix-reactive/shared/src/main/scala/monix/reactive/subjects/PublishSubject.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/subjects/PublishSubject.scala
@@ -53,7 +53,7 @@ final class PublishSubject[A] private () extends Subject[A, A] { self =>
   }
 
   def size: Int =
-    stateRef.get.subscribers.size
+    stateRef.get().subscribers.size
 
   /*
    * NOTE: onSubscribe is in contention with onNext, onComplete and onError,
@@ -64,7 +64,7 @@ final class PublishSubject[A] private () extends Subject[A, A] { self =>
    */
   @tailrec
   def unsafeSubscribeFn(subscriber: Subscriber[A]): Cancelable = {
-    val state = stateRef.get
+    val state = stateRef.get()
     val subscribers = state.subscribers
 
     if (subscribers eq null) {
@@ -83,7 +83,7 @@ final class PublishSubject[A] private () extends Subject[A, A] { self =>
   }
 
   def onNext(elem: A): Future[Ack] = {
-    val state = stateRef.get
+    val state = stateRef.get()
     val subscribersArray = state.cache
 
     if (subscribersArray eq null) {
@@ -154,7 +154,7 @@ final class PublishSubject[A] private () extends Subject[A, A] { self =>
 
   @tailrec
   private def sendOnCompleteOrError(ex: Throwable): Unit = {
-    val state = stateRef.get
+    val state = stateRef.get()
     val set = state.subscribers
     val subscribers: Iterable[Subscriber[A]] =
       if (state.cache ne null) state.cache.toSeq else set
@@ -180,7 +180,7 @@ final class PublishSubject[A] private () extends Subject[A, A] { self =>
 
   @tailrec
   private def unsubscribe(subscriber: Subscriber[A]): Ack = {
-    val state = stateRef.get
+    val state = stateRef.get()
     val subscribers = state.subscribers
 
     if (subscribers eq null) Continue

--- a/monix-reactive/shared/src/main/scala/monix/reactive/subjects/PublishToOneSubject.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/subjects/PublishToOneSubject.scala
@@ -52,13 +52,13 @@ final class PublishToOneSubject[A] private () extends Subject[A, A] with Boolean
   val subscription = subscriptionP.future
 
   def size: Int =
-    ref.get match {
+    ref.get() match {
       case null | `pendingCompleteState` | `canceledState` => 0
       case _ => 1
     }
 
   def unsafeSubscribeFn(subscriber: Subscriber[A]): Cancelable =
-    ref.get match {
+    ref.get() match {
       case null =>
         if (!ref.compareAndSet(null, subscriber))
           unsafeSubscribeFn(subscriber) // retry
@@ -86,7 +86,7 @@ final class PublishToOneSubject[A] private () extends Subject[A, A] with Boolean
     }
 
   def onNext(elem: A): Future[Ack] =
-    ref.get match {
+    ref.get() match {
       case null => Continue
       case subscriber =>
         subscriber.onNext(elem)
@@ -101,7 +101,7 @@ final class PublishToOneSubject[A] private () extends Subject[A, A] with Boolean
     signalComplete()
 
   @tailrec private def signalComplete(): Unit = {
-    ref.get match {
+    ref.get() match {
       case null =>
         if (!ref.compareAndSet(null, pendingCompleteState))
           signalComplete() // retry
@@ -118,7 +118,7 @@ final class PublishToOneSubject[A] private () extends Subject[A, A] with Boolean
   }
 
   def isCanceled: Boolean =
-    ref.get eq canceledState
+    ref.get() eq canceledState
 
   def cancel(): Unit =
     ref.set(canceledState)

--- a/monix-reactive/shared/src/main/scala/monix/reactive/subjects/ReplaySubject.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/subjects/ReplaySubject.scala
@@ -37,7 +37,7 @@ final class ReplaySubject[A] private (initialState: ReplaySubject.State[A]) exte
   private[this] val stateRef = Atomic(initialState)
 
   def size: Int =
-    stateRef.get.subscribers.size
+    stateRef.get().subscribers.size
 
   @tailrec
   def unsafeSubscribeFn(subscriber: Subscriber[A]): Cancelable = {
@@ -62,7 +62,7 @@ final class ReplaySubject[A] private (initialState: ReplaySubject.State[A]) exte
         })
     }
 
-    val state = stateRef.get
+    val state = stateRef.get()
     val buffer = state.buffer
 
     if (state.isDone) {
@@ -91,7 +91,7 @@ final class ReplaySubject[A] private (initialState: ReplaySubject.State[A]) exte
 
   @tailrec
   def onNext(elem: A): Future[Ack] = {
-    val state = stateRef.get
+    val state = stateRef.get()
 
     if (state.isDone) Stop
     else {
@@ -155,7 +155,7 @@ final class ReplaySubject[A] private (initialState: ReplaySubject.State[A]) exte
 
   @tailrec
   private def onCompleteOrError(ex: Throwable): Unit = {
-    val state = stateRef.get
+    val state = stateRef.get()
 
     if (!state.isDone) {
       if (!stateRef.compareAndSet(state, state.markDone(ex)))
@@ -176,7 +176,7 @@ final class ReplaySubject[A] private (initialState: ReplaySubject.State[A]) exte
 
   @tailrec
   private def removeSubscriber(s: ConnectableSubscriber[A]): Unit = {
-    val state = stateRef.get
+    val state = stateRef.get()
     val newState = state.removeSubscriber(s)
     if (!stateRef.compareAndSet(state, newState))
       removeSubscriber(s)

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantAttempt.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantAttempt.scala
@@ -196,7 +196,7 @@ private[tail] object IterantAttempt {
 
     @tailrec
     private def pushError(ref: Atomic[Throwable], e: Throwable): Unit = {
-      val current = ref.get
+      val current = ref.get()
       val update = current match {
         case null => e
         case e0 => Platform.composeErrors(e0, e)

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantConcat.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantConcat.scala
@@ -105,7 +105,7 @@ private[tail] object IterantConcat {
       }
 
     private def evalNextCursor(ref: NextCursor[F, A], cursor: BatchCursor[A], rest: F[Iterant[F, A]]) = {
-      if (!cursor.hasNext) {
+      if (!cursor.hasNext()) {
         Suspend(rest.map(loop))
       } else {
         val item = cursor.next()

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFromReactivePublisher.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFromReactivePublisher.scala
@@ -98,7 +98,7 @@ private[tail] object IterantFromReactivePublisher {
       else toReceive
 
     @tailrec def onNext(a: A): Unit =
-      state.get match {
+      state.get() match {
         case Uninitialized =>
           initialize()
           onNext(a)
@@ -123,7 +123,7 @@ private[tail] object IterantFromReactivePublisher {
       }
 
     @tailrec private def finish(fa: Iterant[F, A]): Unit =
-      state.get match {
+      state.get() match {
         case Uninitialized =>
           initialize()
           finish(fa)
@@ -163,7 +163,7 @@ private[tail] object IterantFromReactivePublisher {
       finish(Iterant.empty)
 
     @tailrec private def take(cb: Either[Throwable, Iterant[F, A]] => Unit): Unit =
-      state.get match {
+      state.get() match {
         case Uninitialized =>
           initialize()
           take(cb)

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantMapEval.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantMapEval.scala
@@ -74,7 +74,7 @@ private[tail] object IterantMapEval {
       Iterant.raiseError(e)
 
     private def processCursor(ref: NextCursor[F, A], cursor: BatchCursor[A], rest: F[Iterant[F, A]]) = {
-      if (!cursor.hasNext) {
+      if (!cursor.hasNext()) {
         Suspend[F, B](rest.map(this))
       } else {
         val head = cursor.next()

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantOnErrorHandleWith.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantOnErrorHandleWith.scala
@@ -177,7 +177,7 @@ private[tail] object IterantOnErrorHandleWith {
 
     @tailrec
     private def pushError(ref: Atomic[Throwable], e: Throwable): Unit = {
-      val current = ref.get
+      val current = ref.get()
       val update = current match {
         case null => e
         case e0 => Platform.composeErrors(e0, e)

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantScanEval.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantScanEval.scala
@@ -58,7 +58,7 @@ private[tail] object IterantScanEval {
 
     def visit(ref: NextCursor[F, A]): Iterant[F, S] = {
       val cursor = ref.cursor
-      if (!cursor.hasNext)
+      if (!cursor.hasNext())
         Suspend[F, S](ref.rest.map(this))
       else {
         val head = cursor.next()

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantToReactivePublisher.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantToReactivePublisher.scala
@@ -77,7 +77,7 @@ private[tail] object IterantToReactivePublisher {
     def request(n: Long): Unit = {
       // Tail-recursive function modifying `requested`
       @tailrec def loop(n: Long): Unit =
-        state.get match {
+        state.get() match {
           case null =>
             if (!state.compareAndSet(null, Request(n)))
               loop(n)
@@ -117,7 +117,7 @@ private[tail] object IterantToReactivePublisher {
       cancelWithSignal(None)
 
     @tailrec def cancelWithSignal(signal: Option[Throwable]): Unit = {
-      state.get match {
+      state.get() match {
         case current @ (null | Request(_)) =>
           if (!state.compareAndSet(current, Interrupt(signal)))
             cancelWithSignal(signal)
@@ -194,7 +194,7 @@ private[tail] object IterantToReactivePublisher {
         while (continue) {
           continue = false
 
-          ref.get match {
+          ref.get() match {
             case current @ Request(n) =>
               if (n > 0) {
                 if (n < Long.MaxValue) {

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantZipMap.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantZipMap.scala
@@ -245,7 +245,7 @@ private[tail] object IterantZipMap {
         rhStackPop() match {
           case null =>
             val NextCursor(itemsA, restA) = lhRef
-            if (!itemsA.hasNext)
+            if (!itemsA.hasNext())
               Suspend(restA.map(lhLoop))
             else {
               val a = itemsA.next()
@@ -364,7 +364,7 @@ private[tail] object IterantZipMap {
       loop: Iterant.Visitor[F, B, Iterant[F, C]]): Iterant[F, C] = {
 
       val NextCursor(itemsB, restB) = refB
-      if (!itemsB.hasNext)
+      if (!itemsB.hasNext())
         Suspend(restB.map(loop))
       else
         processPair(a, restA, itemsB.next(), F.pure(refB))
@@ -373,7 +373,7 @@ private[tail] object IterantZipMap {
     def processSeqAOneB(refA: NextCursor[F, A], rh: Iterant[F, B], b: B, restB: F[Iterant[F, B]]): Iterant[F, C] = {
 
       val NextCursor(itemsA, restA) = refA
-      if (!itemsA.hasNext)
+      if (!itemsA.hasNext())
         Suspend(restA.map(lhLoop.withRh(rh)))
       else
         processPair(itemsA.next(), F.pure(refA), b, restB)
@@ -431,9 +431,9 @@ private[tail] object IterantZipMap {
           // We are not done, continue loop
           NextBatch(Batch.fromArray(array).asInstanceOf[Batch[C]], F.delay(loop(refA, refB)))
         }
-      } else if (!itemsA.hasNext)
+      } else if (!itemsA.hasNext())
         Suspend(restA.map(lhLoop.withRh(refB)))
-      else if (!itemsB.hasNext)
+      else if (!itemsB.hasNext())
         Suspend(restB.map(loop(refA, _)))
       else {
         val a = itemsA.next()


### PR DESCRIPTION
I also updated to Scala 2.13.3 - sorry for the noise

2.12:

```
Benchmark                                         (chunkCount)  (chunkSize)   Mode  Cnt   Score   Error  Units
ChunkedEvalFilterMapSumBenchmark.monixObservable          1000         1000  thrpt   20  66.211 ± 2.483  ops/s
```

2.13, before the change:
```
Benchmark                                         (chunkCount)  (chunkSize)   Mode  Cnt   Score   Error  Units
ChunkedEvalFilterMapSumBenchmark.monixObservable          1000         1000  thrpt   20  35.212 ± 3.410  ops/s (2.13 before)
```

2.13, after the change:
```
Benchmark                                         (chunkCount)  (chunkSize)   Mode  Cnt   Score   Error  Units
ChunkedEvalFilterMapSumBenchmark.monixObservable          1000         1000  thrpt   20  72.209 ± 3.425  ops/s (2.13 after)
```