### PR TITLE
Add Platform.getEnv that works on Node.js too, make CI=true work

### DIFF
--- a/monix-execution/js/src/main/scala/monix/execution/internal/Platform.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/internal/Platform.scala
@@ -20,11 +20,9 @@ package monix.execution.internal
 import monix.execution.UncaughtExceptionReporter
 import monix.execution.exceptions.CompositeException
 import monix.execution.schedulers.CanBlock
-
 import scala.concurrent.Awaitable
 import scala.concurrent.duration.Duration
 import scala.scalajs.js
-import scala.util.Try
 import scala.util.control.NonFatal
 
 private[monix] object Platform {
@@ -74,45 +72,27 @@ private[monix] object Platform {
     *   nr = (nr + 1) & modulus
     * }}}
     */
-  val recommendedBatchSize: Int = {
-    getEnv("monix.environment.batchSize")
-      .flatMap(s => Try(s.toInt).toOption)
-      .map(math.nextPowerOf2)
-      .getOrElse(512)
-  }
+  final val recommendedBatchSize: Int = 512
 
   /** Recommended chunk size in unbounded buffer implementations that are chunked,
     * or in chunked streams.
     *
     * Should be a power of 2.
     */
-  val recommendedBufferChunkSize: Int = {
-    getEnv("monix.environment.bufferChunkSize")
-      .flatMap(s => Try(s.toInt).toOption)
-      .map(math.nextPowerOf2)
-      .getOrElse(128)
-  }
+  final val recommendedBufferChunkSize: Int = 128
 
   /**
     * Auto cancelable run loops are set to `false` if Monix
     * is running on top of Scala.js.
     */
-  val autoCancelableRunLoops: Boolean = {
-    getEnv("monix.environment.autoCancelableRunLoops")
-      .map(_.toLowerCase)
-      .forall(v => v != "no" && v != "false" && v != "0")
-  }
+  final val autoCancelableRunLoops: Boolean = true
 
   /**
     * Local context propagation is set to `false` if Monix
     * is running on top of Scala.js given that it is single
     * threaded.
     */
-  val localContextPropagation: Boolean = {
-    getEnv("monix.environment.localContextPropagation")
-      .map(_.toLowerCase)
-      .exists(v => v == "yes" || v == "true" || v == "1")
-  }
+  final val localContextPropagation: Boolean = false
 
   /**
     * Establishes the maximum stack depth for fused `.map` operations
@@ -121,14 +101,7 @@ private[monix] object Platform {
     * The default for JavaScript is 32, from which we subtract 1
     * as an optimization.
     */
-  val fusionMaxStackDepth: Int = {
-    getEnv("monix.environment.fusionMaxStackDepth")
-      .filter(s => s != null && s.nonEmpty)
-      .flatMap(s => Try(s.toInt).toOption)
-      .filter(_ > 0)
-      .map(_ - 1)
-      .getOrElse(31)
-  }
+  final val fusionMaxStackDepth = 31
 
   /** Blocks for the result of `fa`.
     *

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/Platform.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/Platform.scala
@@ -36,6 +36,12 @@ private[monix] object Platform {
     */
   final val isJVM = true
 
+  /**
+    * Reads environment variable in a platform-specific way.
+    */
+  def getEnv(key: String): Option[String] =
+    Option(System.getenv(key)).map(_.trim).filter(_.nonEmpty)
+
   /** Recommended batch size used for breaking synchronous loops in
     * asynchronous batches. When streaming value from a producer to
     * a synchronous consumer it's recommended to break the streaming
@@ -58,8 +64,7 @@ private[monix] object Platform {
     * </pre>
     */
   val recommendedBatchSize: Int = {
-    Option(System.getProperty("monix.environment.batchSize", ""))
-      .filter(s => s != null && s.nonEmpty)
+    getEnv("monix.environment.batchSize")
       .flatMap(s => Try(s.toInt).toOption)
       .map(math.nextPowerOf2)
       .getOrElse(1024)
@@ -88,8 +93,7 @@ private[monix] object Platform {
     * Should be a power of 2 or it gets rounded to one.
     */
   val recommendedBufferChunkSize: Int = {
-    Option(System.getProperty("monix.environment.bufferChunkSize", ""))
-      .filter(s => s != null && s.nonEmpty)
+    getEnv("monix.environment.bufferChunkSize")
       .flatMap(s => Try(s.toInt).toOption)
       .map(math.nextPowerOf2)
       .getOrElse(256)
@@ -113,7 +117,7 @@ private[monix] object Platform {
     * of its type classes.
     */
   val autoCancelableRunLoops: Boolean = {
-    Option(System.getProperty("monix.environment.autoCancelableRunLoops", ""))
+    getEnv("monix.environment.autoCancelableRunLoops")
       .map(_.toLowerCase)
       .forall(v => v != "no" && v != "false" && v != "0")
   }
@@ -127,7 +131,7 @@ private[monix] object Platform {
     *    (`true`, `yes` or `1` for enabling)
     */
   val localContextPropagation: Boolean =
-    Option(System.getProperty("monix.environment.localContextPropagation", ""))
+    getEnv("monix.environment.localContextPropagation")
       .map(_.toLowerCase)
       .exists(v => v == "yes" || v == "true" || v == "1")
 
@@ -155,8 +159,7 @@ private[monix] object Platform {
     * </pre>
     */
   val fusionMaxStackDepth =
-    Option(System.getProperty("monix.environment.fusionMaxStackDepth"))
-      .filter(s => s != null && s.nonEmpty)
+    getEnv("monix.environment.fusionMaxStackDepth")
       .flatMap(s => Try(s.toInt).toOption)
       .filter(_ > 0)
       .map(_ - 1)

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/Platform.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/Platform.scala
@@ -18,7 +18,6 @@
 package monix.execution.internal
 
 import monix.execution.schedulers.CanBlock
-
 import scala.concurrent.{Await, Awaitable}
 import scala.concurrent.duration.Duration
 import scala.util.Try
@@ -64,7 +63,8 @@ private[monix] object Platform {
     * </pre>
     */
   val recommendedBatchSize: Int = {
-    getEnv("monix.environment.batchSize")
+    Option(System.getProperty("monix.environment.batchSize", ""))
+      .filter(s => s != null && s.nonEmpty)
       .flatMap(s => Try(s.toInt).toOption)
       .map(math.nextPowerOf2)
       .getOrElse(1024)
@@ -93,7 +93,8 @@ private[monix] object Platform {
     * Should be a power of 2 or it gets rounded to one.
     */
   val recommendedBufferChunkSize: Int = {
-    getEnv("monix.environment.bufferChunkSize")
+    Option(System.getProperty("monix.environment.bufferChunkSize", ""))
+      .filter(s => s != null && s.nonEmpty)
       .flatMap(s => Try(s.toInt).toOption)
       .map(math.nextPowerOf2)
       .getOrElse(256)
@@ -117,7 +118,7 @@ private[monix] object Platform {
     * of its type classes.
     */
   val autoCancelableRunLoops: Boolean = {
-    getEnv("monix.environment.autoCancelableRunLoops")
+    Option(System.getProperty("monix.environment.autoCancelableRunLoops", ""))
       .map(_.toLowerCase)
       .forall(v => v != "no" && v != "false" && v != "0")
   }
@@ -131,7 +132,7 @@ private[monix] object Platform {
     *    (`true`, `yes` or `1` for enabling)
     */
   val localContextPropagation: Boolean =
-    getEnv("monix.environment.localContextPropagation")
+    Option(System.getProperty("monix.environment.localContextPropagation", ""))
       .map(_.toLowerCase)
       .exists(v => v == "yes" || v == "true" || v == "1")
 
@@ -158,12 +159,14 @@ private[monix] object Platform {
     *        ...
     * </pre>
     */
-  val fusionMaxStackDepth =
-    getEnv("monix.environment.fusionMaxStackDepth")
+  val fusionMaxStackDepth = {
+    Option(System.getProperty("monix.environment.fusionMaxStackDepth"))
+      .filter(s => s != null && s.nonEmpty)
       .flatMap(s => Try(s.toInt).toOption)
       .filter(_ > 0)
       .map(_ - 1)
       .getOrElse(127)
+  }
 
   /** Blocks for the result of `fa`.
     *

--- a/monix-execution/shared/src/test/scala/monix/execution/TestUtils.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/TestUtils.scala
@@ -17,6 +17,7 @@
 
 package monix.execution
 
+import monix.execution.internal.Platform
 import java.io.{ByteArrayOutputStream, PrintStream}
 import scala.util.control.NonFatal
 
@@ -24,9 +25,9 @@ import scala.util.control.NonFatal
   * INTERNAL API — test utilities.
   */
 trait TestUtils {
-  lazy val isCI =
-    System.getenv("TRAVIS") == "true" ||
-    System.getenv("CI") == "true"
+  lazy val isCI = {
+    Platform.getEnv("CI").map(_.toLowerCase).contains("true")
+  }
 
   /**
     * Silences `System.err`, only printing the output in case exceptions are


### PR DESCRIPTION
Fixes flaky JS tests, changes `Platform` for JavaScript to mirror the JVM version and read config from environment (on top of Node, when available).