### PR TITLE
Fix publishing of shaded JCTools

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,16 @@
+name: Backport
+on:
+  pull_request:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    runs-on: ubuntu-18.04
+    name: Backport
+    steps:
+      - name: Backport
+        uses: tibdex/backport@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/build.sbt
+++ b/build.sbt
@@ -347,10 +347,6 @@ lazy val assemblyShadeSettings = Seq(
   makePomConfiguration := makePomConfiguration.value.withConfigurations(Vector.empty),
   // package by running assembly
   packageBin in Compile := ReproducibleBuildsPlugin.postProcessJar((assembly in Compile).value),
-  // disable publishing the main API jar
-  Compile / packageDoc / publishArtifact := false,
-  // disable publishing the main sources jar
-  Compile / packageSrc / publishArtifact := false
 )
 
 lazy val unidocSettings = Seq(


### PR DESCRIPTION
Publishing [currently fails](https://github.com/monix/monix/runs/979550593?check_suite_focus=true) with:

```
2020-08-13 08:41:13.921Z error [SonatypeClient] [close] Failed  - (SonatypeClient.scala:184)
2020-08-13 08:41:13.921Z error [SonatypeClient] Activity name:close, started:2020-08-13T08:40:44.348Z  - (SonatypeClient.scala:462)
2020-08-13 08:41:13.923Z error [SonatypeClient]     Failed: sources-staging, failureMessage:Missing: no sources jar found in folder '/io/monix/monix-internal-jctools_2.13/3.2.2+40-67cbea18'  - (SonatypeClient.scala:380)
2020-08-13 08:41:13.924Z error [Sonatype] [STAGE_FAILURE] Failed to close the repository.  - (Sonatype.scala:406)
##[error]Process completed with exit code 1.
```

As part of this PR I'm also trying to activate automatic backporting. Let's see how this goes.