### PR TITLE
Update FUNDING

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,6 @@
 # https://docs.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository
 
 patreon: alexelcu
-github: [alexandru, avasil]
+
+# We need to apply here: https://github.com/sponsors
+# github: [alexandru, avasil]


### PR DESCRIPTION
For the GitHub funding to work, we need to apply here first: https://github.com/sponsors

Until then Patreon links work fine.