### PR TITLE
Handle ContextSwitch in TaskRunSyncUnsafe properly

### DIFF
--- a/monix-eval/jvm/src/main/scala/monix/eval/internal/TaskRunSyncUnsafe.scala
+++ b/monix-eval/jvm/src/main/scala/monix/eval/internal/TaskRunSyncUnsafe.scala
@@ -134,12 +134,11 @@ private[eval] object TaskRunSyncUnsafe {
     val context = Context(scheduler, opts)
 
     // Starting actual execution
-    val rcb = TaskRestartCallback(context, cb)
     source match {
       case async: Async[Any] @unchecked =>
-        executeAsyncTask(async, context, cb, rcb, bFirst, bRest, 1)
+        executeAsyncTask(async, context, cb, null, bFirst, bRest, 1)
       case _ =>
-        startFull(source, context, cb, rcb, bFirst, bRest, 1)
+        startFull(source, context, cb, null, bFirst, bRest, 1)
     }
 
     val isFinished = limit match {


### PR DESCRIPTION
`RestartCallback` was created before the option was updated