### PR TITLE
Implement Asynchronous Stack Traces for Task

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ val jvmTests = List(
 
 addCommandAlias("ci-all",      ";ci-jvm ;ci-js ;ci-meta")
 addCommandAlias("ci-js",       ";clean ;coreJS/test:compile ;coreJS/test ;coreJS/package")
-addCommandAlias("ci-jvm",      s";clean ;coreJVM/test:compile ;coreJVM/test ;$benchmarkProjects ;$jvmTests ;coreJVM/package")
+addCommandAlias("ci-jvm",      s";clean ;coreJVM/test:compile ;coreJVM/test ;coreJVM/package ;tracingTests/test")
 addCommandAlias("ci-meta",     ";mimaReportBinaryIssues ;unidoc")
 addCommandAlias("ci-release",  ";+publishSigned ;sonatypeBundleRelease")
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,12 +7,17 @@ import MonixBuildUtils._
 val benchmarkProjects = List(
   "benchmarksPrev",
   "benchmarksNext"
-).map(_ + "/compile")
+).map(_ + "/compile").mkString(" ;")
+
+val jvmTests = List(
+  "reactiveTests",
+  "tracingTests"
+).map(x => s"$x/test:compile; $x/test").mkString(" ;")
 
 addCommandAlias("ci",          ";ci-jvm ;ci-js")
 addCommandAlias("ci-all",      ";ci-jvm ;ci-js ;ci-meta")
 addCommandAlias("ci-js",       ";clean ;coreJS/test:compile ;coreJS/test ;coreJS/package")
-addCommandAlias("ci-jvm",      ";clean ;coreJVM/test:compile ;coreJVM/test ;coreJVM/package")
+addCommandAlias("ci-jvm",      s";clean ;coreJVM/test:compile ;coreJVM/test; $benchmarkProjects; $jvmTests; coreJVM/package")
 addCommandAlias("ci-meta",     ";mimaReportBinaryIssues ;unidoc")
 addCommandAlias("ci-release",  ";+publishSigned ;sonatypeBundleRelease")
 
@@ -664,6 +669,37 @@ lazy val reactiveTests = project.in(file("reactiveTests"))
       reactiveStreamsTCKLib % Test,
       scalaTestLib.value % Test,
     ))
+
+// --------------------------------------------
+// monix-tracing-tests (not published)
+
+lazy val FullTracingTest = config("fulltracing").extend(Test)
+
+lazy val tracingTests = project.in(file("tracingTests"))
+  .configure(monixSubModule(
+    "monix-tracing-tests",
+    publishArtifacts = false
+  ))
+  .dependsOn(evalJVM % "compile->compile; test->test")
+  .configs(FullTracingTest)
+  .settings(testFrameworks := Seq(new TestFramework("minitest.runner.Framework")))
+  .settings(inConfig(FullTracingTest)(Defaults.testSettings): _*)
+  .settings(
+    unmanagedSourceDirectories in FullTracingTest += {
+      baseDirectory.value.getParentFile / "src" / "fulltracing" / "scala"
+    },
+    test in Test := (test in Test).dependsOn(test in FullTracingTest).value,
+    fork in Test := true,
+    fork in FullTracingTest := true,
+    javaOptions in Test ++= Seq(
+      "-Dmonix.eval.tracing=true",
+      "-Dmonix.eval.stackTracingMode=cached"
+    ),
+    javaOptions in FullTracingTest ++= Seq(
+      "-Dmonix.eval.tracing=true",
+      "-Dmonix.eval.stackTracingMode=full"
+    )
+  )
 
 // --------------------------------------------
 // monix-benchmarks-{prev,next} (not published)

--- a/build.sbt
+++ b/build.sbt
@@ -12,12 +12,11 @@ val benchmarkProjects = List(
 val jvmTests = List(
   "reactiveTests",
   "tracingTests"
-).map(x => s"$x/test:compile; $x/test").mkString(" ;")
+).map(_ + "/test").mkString(" ;")
 
-addCommandAlias("ci",          ";ci-jvm ;ci-js")
 addCommandAlias("ci-all",      ";ci-jvm ;ci-js ;ci-meta")
 addCommandAlias("ci-js",       ";clean ;coreJS/test:compile ;coreJS/test ;coreJS/package")
-addCommandAlias("ci-jvm",      s";clean ;coreJVM/test:compile ;coreJVM/test; $benchmarkProjects; $jvmTests; coreJVM/package")
+addCommandAlias("ci-jvm",      s";clean ;coreJVM/test:compile ;coreJVM/test ;$benchmarkProjects ;$jvmTests ;coreJVM/package")
 addCommandAlias("ci-meta",     ";mimaReportBinaryIssues ;unidoc")
 addCommandAlias("ci-release",  ";+publishSigned ;sonatypeBundleRelease")
 

--- a/monix-eval/js/src/main/scala/monix/eval/internal/TracingPlatform.scala
+++ b/monix-eval/js/src/main/scala/monix/eval/internal/TracingPlatform.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval.internal
+
+private[monix] object TracingPlatform {
+  final val isCachedStackTracing: Boolean = false
+
+  final val isFullStackTracing: Boolean = false
+
+  final val isStackTracing: Boolean = isFullStackTracing || isCachedStackTracing
+
+  final val traceBufferLogSize: Int = 4
+
+  final val enhancedExceptions: Boolean = false
+}

--- a/monix-eval/jvm/src/main/java/monix/eval/internal/TracingPlatform.java
+++ b/monix-eval/jvm/src/main/java/monix/eval/internal/TracingPlatform.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval.internal;
+
+import java.util.Optional;
+
+/**
+  * All Credits to https://github.com/typelevel/cats-effect and https://github.com/RaasAhsan
+  *
+  * Holds platform-specific flags that control tracing behavior.
+  *
+  * The Scala compiler inserts a volatile bitmap access for module field accesses.
+  * Because the `tracingMode` flag is read in various Task combinators, we are opting
+  * to define it in a Java source file to avoid the volatile access.
+  *
+  * INTERNAL API.
+  */
+public final class TracingPlatform {
+
+  /**
+    * Sets stack tracing mode for a JVM process, which controls
+    * how much stack trace information is captured.
+    * Acceptable values are: NONE, CACHED, FULL.
+    */
+  private static final String stackTracingMode = Optional.ofNullable(System.getProperty("monix.eval.stackTracingMode"))
+    .filter(x -> !x.isEmpty())
+    .orElse("cached");
+
+  public static final boolean isCachedStackTracing = stackTracingMode.equalsIgnoreCase("cached");
+
+  public static final boolean isFullStackTracing = stackTracingMode.equalsIgnoreCase("full");
+
+  public static final boolean isStackTracing = isFullStackTracing || isCachedStackTracing;
+
+  /**
+    * The number of trace lines to retain during tracing. If more trace
+    * lines are produced, then the oldest trace lines will be discarded.
+    * Automatically rounded up to the nearest power of 2.
+    */
+  public static final int traceBufferLogSize = Optional.ofNullable(System.getProperty("monix.eval.traceBufferLogSize"))
+    .filter(x -> !x.isEmpty())
+    .flatMap(x -> {
+      try {
+        return Optional.of(Integer.valueOf(x));
+      } catch (Exception e) {
+        return Optional.empty();
+      }
+    })
+    .orElse(4);
+
+  /**
+    * Sets the enhanced exceptions flag, which controls whether or not the
+    * stack traces of IO exceptions are augmented to include async stack trace information.
+    * Stack tracing must be enabled in order to use this feature.
+    * This flag is enabled by default.
+    */
+  public static final boolean enhancedExceptions = Optional.ofNullable(System.getProperty("monix.eval.enhancedExceptions"))
+    .map(Boolean::valueOf)
+    .orElse(true);
+
+}

--- a/monix-eval/jvm/src/main/scala/monix/eval/internal/TaskRunSyncUnsafe.scala
+++ b/monix-eval/jvm/src/main/scala/monix/eval/internal/TaskRunSyncUnsafe.scala
@@ -20,9 +20,11 @@ package monix.eval.internal
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.locks.AbstractQueuedSynchronizer
 
-import monix.eval.Task.{Async, Context, Error, Eval, FlatMap, Map, Now, Suspend}
+import monix.eval.Task.{Async, Context, Error, Eval, FlatMap, Map, Now, Suspend, Trace}
 import monix.eval.internal.TaskRunLoop._
 import monix.eval.Task
+import monix.eval.internal.TracingPlatform.{enhancedExceptions, isStackTracing}
+import monix.eval.tracing.TaskEvent
 import monix.execution.{Callback, Scheduler}
 import monix.execution.internal.collection.ChunkedArrayStack
 
@@ -44,9 +46,17 @@ private[eval] object TaskRunSyncUnsafe {
     var hasUnboxed: Boolean = false
     var unboxed: AnyRef = null
 
+    // we might not need to initialize full Task.Context
+    var tracingCtx: StackTracedContext = null
+
     do {
       current match {
-        case FlatMap(fa, bindNext) =>
+        case bind @ FlatMap(fa, bindNext, _) =>
+          if (isStackTracing) {
+            val trace = bind.trace
+            if (tracingCtx eq null) tracingCtx = new StackTracedContext
+            if (trace ne null) tracingCtx.pushEvent(trace.asInstanceOf[TaskEvent])
+          }
           if (bFirst ne null) {
             if (bRest eq null) bRest = ChunkedArrayStack()
             bRest.push(bFirst)
@@ -69,6 +79,11 @@ private[eval] object TaskRunSyncUnsafe {
           }
 
         case bindNext @ Map(fa, _, _) =>
+          if (isStackTracing) {
+            val trace = bindNext.trace
+            if (tracingCtx eq null) tracingCtx = new StackTracedContext
+            if (trace ne null) tracingCtx.pushEvent(trace.asInstanceOf[TaskEvent])
+          }
           if (bFirst ne null) {
             if (bRest eq null) bRest = ChunkedArrayStack()
             bRest.push(bFirst)
@@ -85,6 +100,10 @@ private[eval] object TaskRunSyncUnsafe {
           }
 
         case Error(error) =>
+          if (isStackTracing && enhancedExceptions) {
+            if (tracingCtx eq null) tracingCtx = new StackTracedContext
+            augmentException(error, tracingCtx)
+          }
           findErrorHandler(bFirst, bRest) match {
             case null => throw error
             case bind =>
@@ -95,8 +114,13 @@ private[eval] object TaskRunSyncUnsafe {
               bFirst = null
           }
 
+        case Trace(sourceTask, frame) =>
+          if (tracingCtx eq null) tracingCtx = new StackTracedContext
+          tracingCtx.pushEvent(frame)
+          current = sourceTask
+
         case async =>
-          return blockForResult(async, timeout, scheduler, opts, bFirst, bRest)
+          return blockForResult(async, timeout, scheduler, opts, bFirst, bRest, tracingCtx)
       }
 
       if (hasUnboxed) {
@@ -127,11 +151,12 @@ private[eval] object TaskRunSyncUnsafe {
     scheduler: Scheduler,
     opts: Task.Options,
     bFirst: Bind,
-    bRest: CallStack): A = {
+    bRest: CallStack,
+    tracingCtx: StackTracedContext): A = {
 
     val latch = new OneShotLatch
     val cb = new BlockingCallback[Any](latch)
-    val context = Context(scheduler, opts)
+    val context = Context(scheduler, opts, TaskConnection(), tracingCtx)
 
     // Starting actual execution
     source match {

--- a/monix-eval/jvm/src/main/scala/monix/eval/internal/TaskRunSyncUnsafe.scala
+++ b/monix-eval/jvm/src/main/scala/monix/eval/internal/TaskRunSyncUnsafe.scala
@@ -120,6 +120,7 @@ private[eval] object TaskRunSyncUnsafe {
           current = sourceTask
 
         case async =>
+          if (tracingCtx eq null) tracingCtx = new StackTracedContext
           return blockForResult(async, timeout, scheduler, opts, bFirst, bRest, tracingCtx)
       }
 

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/ForkedRegister.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/ForkedRegister.scala
@@ -44,8 +44,8 @@ private[eval] object ForkedRegister {
     */
   @tailrec def detect(task: Task[_], limit: Int = 8): Boolean = {
     if (limit > 0) task match {
-      case Async(_: ForkedRegister[_], _, _, _) => true
-      case FlatMap(other, _) => detect(other, limit - 1)
+      case Async(_: ForkedRegister[_], _, _, _, _) => true
+      case FlatMap(other, _, _) => detect(other, limit - 1)
       case Map(other, _, _) => detect(other, limit - 1)
       case ContextSwitch(other, _, _) => detect(other, limit - 1)
       case _ => false

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/StackTracedContext.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/StackTracedContext.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval.internal
+
+import monix.eval.tracing.{TaskEvent, TaskTrace}
+import monix.eval.internal.TracingPlatform.traceBufferLogSize
+import monix.execution.internal.RingBuffer
+
+/**
+  * All Credits to https://github.com/typelevel/cats-effect and https://github.com/RaasAhsan
+  */
+private[eval] final class StackTracedContext {
+  private[this] val events: RingBuffer[TaskEvent] = new RingBuffer(traceBufferLogSize)
+  private[this] var captured: Int = 0
+  private[this] var omitted: Int = 0
+
+  def pushEvent(fr: TaskEvent): Unit = {
+    captured += 1
+    if (events.push(fr) != null) omitted += 1
+  }
+
+  def trace(): TaskTrace =
+    TaskTrace(events.toList, captured, omitted)
+
+  def getStackTraces(): List[TaskEvent.StackTrace] =
+    events.toList.collect { case ev: TaskEvent.StackTrace => ev }
+}

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskBracket.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskBracket.scala
@@ -34,11 +34,12 @@ private[monix] object TaskBracket {
   // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 
   def guaranteeCase[A](task: Task[A], finalizer: ExitCase[Throwable] => Task[Unit]): Task[A] =
-    Task.Async(
+    TracedAsync(
       new ReleaseStart(task, finalizer),
       trampolineBefore = true,
       trampolineAfter = true,
-      restoreLocals = true
+      restoreLocals = true,
+      traceKey = task
     )
 
   private final class ReleaseStart[A](source: Task[A], release: ExitCase[Throwable] => Task[Unit])
@@ -89,11 +90,12 @@ private[monix] object TaskBracket {
     use: A => Task[B],
     release: (A, Either[Option[Throwable], B]) => Task[Unit]): Task[B] = {
 
-    Task.Async(
+    TracedAsync(
       new StartE(acquire, use, release),
       trampolineBefore = true,
       trampolineAfter = true,
-      restoreLocals = true
+      restoreLocals = true,
+      traceKey = use
     )
   }
 
@@ -128,11 +130,12 @@ private[monix] object TaskBracket {
     * [[monix.eval.Task.bracketE]]
     */
   def exitCase[A, B](acquire: Task[A], use: A => Task[B], release: (A, ExitCase[Throwable]) => Task[Unit]): Task[B] =
-    Task.Async(
+    TracedAsync(
       new StartCase(acquire, use, release),
       trampolineBefore = true,
       trampolineAfter = true,
-      restoreLocals = true
+      restoreLocals = true,
+      traceKey = use
     )
 
   private final class StartCase[A, B](

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskCreate.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskCreate.scala
@@ -20,7 +20,7 @@ package monix.eval.internal
 import java.util.concurrent.RejectedExecutionException
 
 import cats.effect.{CancelToken, IO}
-import monix.eval.Task.{Async, Context}
+import monix.eval.Task.Context
 import monix.eval.{Coeval, Task}
 import monix.execution.atomic.AtomicInt
 import monix.execution.exceptions.CallbackCalledMultipleTimesException
@@ -45,11 +45,7 @@ private[eval] object TaskCreate {
       def setConnection(ref: TaskConnectionRef, token: CancelToken[Task])(implicit s: Scheduler): Unit =
         ref := token
     }
-    Async(
-      start,
-      trampolineBefore = false,
-      trampolineAfter = false
-    )
+    TracedAsync[A](start, trampolineBefore = false, trampolineAfter = false, traceKey = fn)
   }
 
   /**
@@ -66,7 +62,7 @@ private[eval] object TaskCreate {
       def setConnection(ref: TaskConnectionRef, token: Cancelable)(implicit s: Scheduler): Unit =
         ref := token
     }
-    Async(start, trampolineBefore = false, trampolineAfter = false)
+    TracedAsync[A](start, trampolineBefore = false, trampolineAfter = false, traceKey = fn)
   }
 
   /**
@@ -92,7 +88,7 @@ private[eval] object TaskCreate {
           }
       }
     }
-    Async(start, trampolineBefore = false, trampolineAfter = false)
+    TracedAsync[A](start, trampolineBefore = false, trampolineAfter = false, traceKey = fn)
   }
 
   /**
@@ -114,7 +110,7 @@ private[eval] object TaskCreate {
           }
       }
     }
-    Async(start, trampolineBefore = false, trampolineAfter = false)
+    TracedAsync[A](start, trampolineBefore = false, trampolineAfter = false, traceKey = k)
   }
 
   /**
@@ -141,7 +137,7 @@ private[eval] object TaskCreate {
           }
       }
     }
-    Async(start, trampolineBefore = false, trampolineAfter = false)
+    TracedAsync[A](start, trampolineBefore = false, trampolineAfter = false, traceKey = k)
   }
 
   private abstract class Cancelable0Start[A, Token](fn: (Scheduler, Callback[Throwable, A]) => Token)

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskMapBoth.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskMapBoth.scala
@@ -17,7 +17,7 @@
 
 package monix.eval.internal
 
-import monix.eval.Task.{Async, Context}
+import monix.eval.Task.Context
 import monix.execution.Callback
 import monix.eval.Task
 import monix.execution.Ack.Stop
@@ -32,7 +32,7 @@ private[eval] object TaskMapBoth {
     * Implementation for `Task.mapBoth`.
     */
   def apply[A1, A2, R](fa1: Task[A1], fa2: Task[A2])(f: (A1, A2) => R): Task[R] = {
-    Async(new Register(fa1, fa2, f), trampolineBefore = true, trampolineAfter = true, restoreLocals = true)
+    TracedAsync(new Register(fa1, fa2, f), trampolineBefore = true, trampolineAfter = true, restoreLocals = true, traceKey = f)
   }
 
   // Implementing Async's "start" via `ForkedStart` in order to signal

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskMemoize.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskMemoize.scala
@@ -37,7 +37,7 @@ private[eval] object TaskMemoize {
         source
       case Task.Eval(Coeval.Suspend(f: LazyVal[A @unchecked])) if !cacheErrors || f.cacheErrors =>
         source
-      case Task.Async(r: Register[A] @unchecked, _, _, _) if !cacheErrors || r.cacheErrors =>
+      case Task.Async(r: Register[A] @unchecked, _, _, _, _) if !cacheErrors || r.cacheErrors =>
         source
       case _ =>
         Task.Async(

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRunLoop.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRunLoop.scala
@@ -30,6 +30,8 @@ import scala.util.control.NonFatal
 import monix.eval.internal.TracingPlatform.{enhancedExceptions, isStackTracing}
 import monix.eval.tracing.{TaskEvent, TaskTrace}
 
+import scala.reflect.NameTransformer
+
 private[eval] object TaskRunLoop {
   type Current = Task[Any]
   type Bind = Any => Task[Any]
@@ -859,7 +861,9 @@ private[eval] object TaskRunLoop {
           .flatMap(t => TaskTrace.getOpAndCallSite(t.stackTrace))
           .map {
             case (methodSite, callSite) =>
-              new StackTraceElement(methodSite.getMethodName + " @ " + callSite.getClassName,
+              val op = NameTransformer.decode(methodSite.getMethodName)
+
+              new StackTraceElement(op + " @ " + callSite.getClassName,
                 callSite.getMethodName,
                 callSite.getFileName,
                 callSite.getLineNumber)

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskToReactivePublisher.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskToReactivePublisher.scala
@@ -33,7 +33,7 @@ private[eval] object TaskToReactivePublisher {
           private[this] var isActive = true
           private[this] val conn = TaskConnection()
           private[this] val context =
-            Task.Context(s, Task.defaultOptions.withSchedulerFeatures, conn)
+            Task.Context(s, Task.defaultOptions.withSchedulerFeatures, conn, new StackTracedContext)
 
           def request(n: Long): Unit = {
             require(n > 0, "n must be strictly positive, according to the Reactive Streams contract, rule 3.9")

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskTracing.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskTracing.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval.internal
+
+import java.util.concurrent.ConcurrentHashMap
+
+import monix.eval.Task
+import monix.eval.Task.Trace
+import monix.eval.tracing.TaskEvent
+
+/**
+  * All Credits to https://github.com/typelevel/cats-effect and https://github.com/RaasAhsan
+  */
+private[eval] object TaskTracing {
+
+  def decorated[A](source: Task[A]): Task[A] =
+    Trace(source, buildFrame())
+
+  def uncached(): TaskEvent =
+    buildFrame()
+
+  def cached(clazz: Class[_]): TaskEvent =
+    buildCachedFrame(clazz)
+
+  private def buildCachedFrame(clazz: Class[_]): TaskEvent = {
+    val currentFrame = frameCache.get(clazz)
+    if (currentFrame eq null) {
+      val newFrame = buildFrame()
+      frameCache.put(clazz, newFrame)
+      newFrame
+    } else {
+      currentFrame
+    }
+  }
+
+  private def buildFrame(): TaskEvent =
+    TaskEvent.StackTrace(new Throwable().getStackTrace.toList)
+
+  /**
+    * Global cache for trace frames. Keys are references to lambda classes.
+    * Should converge to the working set of traces very quickly for hot code paths.
+    */
+  private[this] val frameCache: ConcurrentHashMap[Class[_], TaskEvent] = new ConcurrentHashMap()
+
+}

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TracedAsync.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TracedAsync.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval.internal
+
+import monix.eval.Task
+import monix.eval.internal.TracingPlatform.{isCachedStackTracing, isFullStackTracing}
+import monix.execution.Callback
+
+/**
+  * All Credits to https://github.com/typelevel/cats-effect and https://github.com/RaasAhsan
+  */
+private[eval] object TracedAsync {
+
+  // Convenience function for internal Async calls that intend
+  // to opt into tracing so the following code isn't repeated.
+  def apply[A](
+    k: (Task.Context, Callback[Throwable, A]) => Unit,
+    trampolineBefore: Boolean = false,
+    trampolineAfter: Boolean = false,
+    restoreLocals: Boolean = true,
+    traceKey: AnyRef): Task[A] = {
+
+    val trace = if (isCachedStackTracing) {
+      TaskTracing.cached(traceKey.getClass)
+    } else if (isFullStackTracing) {
+      TaskTracing.uncached()
+    } else {
+      null
+    }
+
+    Task.Async(k, trampolineBefore, trampolineAfter, restoreLocals, trace)
+  }
+
+}

--- a/monix-eval/shared/src/main/scala/monix/eval/tracing/PrintingOptions.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/tracing/PrintingOptions.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval.tracing
+
+/**
+  * @param showFullStackTraces Whether or not to show the entire stack trace
+  * @param maxStackTraceLines When `showFullStackTraces` is `true`, the maximum number of stack trace
+  *                           elements to print
+  * @param ignoreStackTraceLines When `showFullStackTraces` is `true`, the number of stack trace elements
+  *                              to ignore from the start
+  *
+  * All Credits to https://github.com/typelevel/cats-effect and https://github.com/RaasAhsan
+  */
+final case class PrintingOptions private (showFullStackTraces: Boolean,
+                                          maxStackTraceLines: Int,
+                                          ignoreStackTraceLines: Int) {
+  def withShowFullStackTraces(showFullStackTraces: Boolean): PrintingOptions =
+    copy(showFullStackTraces = showFullStackTraces)
+
+  def withMaxStackTraceLines(maxStackTraceLines: Int): PrintingOptions =
+    copy(maxStackTraceLines = maxStackTraceLines)
+
+  def withIgnoreStackTraceLines(ignoreStackTraceLines: Int): PrintingOptions =
+    copy(ignoreStackTraceLines = ignoreStackTraceLines)
+}
+
+object PrintingOptions {
+  val Default = PrintingOptions(
+    showFullStackTraces = false,
+    maxStackTraceLines = Int.MaxValue,
+    ignoreStackTraceLines = 3 // the number of frames to ignore because of TaskTracing
+  )
+
+  def apply(): PrintingOptions = Default
+}

--- a/monix-eval/shared/src/main/scala/monix/eval/tracing/TaskEvent.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/tracing/TaskEvent.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval.tracing
+
+/**
+  * All Credits to https://github.com/typelevel/cats-effect and https://github.com/RaasAhsan
+  */
+sealed abstract class TaskEvent
+
+object TaskEvent {
+
+  final case class StackTrace(stackTrace: List[StackTraceElement]) extends TaskEvent
+
+}

--- a/monix-eval/shared/src/main/scala/monix/eval/tracing/TaskTrace.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/tracing/TaskTrace.scala
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval.tracing
+
+import monix.eval.Task
+
+import scala.reflect.NameTransformer
+
+/**
+  * All Credits to https://github.com/typelevel/cats-effect and https://github.com/RaasAhsan
+  */
+final case class TaskTrace(events: List[TaskEvent], captured: Int, omitted: Int) {
+
+  import TaskTrace._
+
+  def printFiberTrace(options: PrintingOptions = PrintingOptions.Default): Task[Unit] =
+    Task(System.err.println(showFiberTrace(options)))
+
+  def showFiberTrace(options: PrintingOptions = PrintingOptions.Default): String = {
+    val TurnRight = "╰"
+    val InverseTurnRight = "╭"
+    val Junction = "├"
+    val Line = "│"
+
+    val acc0 = s"TaskTrace: $captured frames captured\n"
+    if (options.showFullStackTraces) {
+      val stackTraces = events.collect { case e: TaskEvent.StackTrace => e }
+
+      val acc1 = stackTraces.zipWithIndex
+        .map {
+          case (st, index) =>
+            val tag = getOpAndCallSite(st.stackTrace)
+              .map {
+                case (methodSite, _) =>
+                  NameTransformer.decode(methodSite.getMethodName)
+              }
+              .getOrElse("(...)")
+            val op = if (index == 0) s"$InverseTurnRight $tag\n" else s"$Junction $tag\n"
+            val relevantLines = st.stackTrace
+              .slice(options.ignoreStackTraceLines, options.ignoreStackTraceLines + options.maxStackTraceLines)
+            val lines = relevantLines.zipWithIndex
+              .map {
+                case (ste, i) =>
+                  val junc = if (i == relevantLines.length - 1) TurnRight else Junction
+                  val codeLine = renderStackTraceElement(ste)
+                  s"$Line  $junc $codeLine"
+              }
+              .mkString("", "\n", "\n")
+
+            s"$op$lines$Line"
+        }
+        .mkString("\n")
+
+      val acc2 = if (omitted > 0) {
+        "\n" + TurnRight + s" ... ($omitted frames omitted)\n"
+      } else "\n" + TurnRight + "\n"
+
+      acc0 + acc1 + acc2
+    } else {
+      val acc1 = events.zipWithIndex
+        .map {
+          case (event, index) =>
+            val junc = if (index == events.length - 1 && omitted == 0) TurnRight else Junction
+            val message = event match {
+              case ev: TaskEvent.StackTrace => {
+                getOpAndCallSite(ev.stackTrace)
+                  .map {
+                    case (methodSite, callSite) =>
+                      val loc = renderStackTraceElement(callSite)
+                      val op = NameTransformer.decode(methodSite.getMethodName)
+                      s"$op @ $loc"
+                  }
+                  .getOrElse("(...)")
+              }
+            }
+            s" $junc $message"
+        }
+        .mkString(acc0, "\n", "")
+
+      val acc2 = if (omitted > 0) {
+        acc1 + "\n " + TurnRight + s" ... ($omitted frames omitted)"
+      } else acc1
+
+      acc2 + "\n"
+    }
+  }
+}
+
+private[eval] object TaskTrace {
+
+  def getOpAndCallSite(frames: List[StackTraceElement]): Option[(StackTraceElement, StackTraceElement)] =
+    frames
+      .sliding(2)
+      .collect {
+        case a :: b :: Nil => (a, b)
+      }
+      .find {
+        case (_, callSite) =>
+          !stackTraceFilter.exists(callSite.getClassName.startsWith(_))
+      }
+
+  private def renderStackTraceElement(ste: StackTraceElement): String = {
+    val methodName = demangleMethod(ste.getMethodName)
+    s"${ste.getClassName}.$methodName (${ste.getFileName}:${ste.getLineNumber})"
+  }
+
+  private def demangleMethod(methodName: String): String =
+    anonfunRegex.findFirstMatchIn(methodName) match {
+      case Some(mat) => mat.group(1)
+      case None      => methodName
+    }
+
+  private[this] val anonfunRegex = "^\\$+anonfun\\$+(.+)\\$+\\d+$".r
+
+  private[this] val stackTraceFilter = List(
+    "monix.",
+    "cats.effect.",
+    "cats.",
+    "sbt.",
+    "java.",
+    "sun.",
+    "scala."
+  )
+}

--- a/monix-eval/shared/src/test/scala/monix/eval/tracing/StackTracedContextSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/tracing/StackTracedContextSuite.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval.tracing
+
+import monix.eval.BaseTestSuite
+import monix.eval.internal.StackTracedContext
+
+/**
+  * All Credits to https://github.com/typelevel/cats-effect and https://github.com/RaasAhsan
+  */
+object StackTracedContextSuite extends BaseTestSuite {
+  val traceBufferSize: Int = 1 << monix.eval.internal.TracingPlatform.traceBufferLogSize
+  val stackTrace = new Throwable().getStackTrace.toList
+
+  test("push traces") { _ =>
+    val ctx = new StackTracedContext()
+
+    val t1 = TaskEvent.StackTrace(stackTrace)
+    val t2 = TaskEvent.StackTrace(stackTrace)
+
+    ctx.pushEvent(t1)
+    ctx.pushEvent(t2)
+
+    val trace = ctx.trace()
+    assertEquals(trace.events, List(t1, t2))
+    assertEquals(trace.captured, 2)
+    assertEquals(trace.omitted, 0)
+  }
+
+  test("track omitted frames") { _ =>
+    val ctx = new StackTracedContext()
+
+    for (_ <- 0 until (traceBufferSize + 10)) {
+      ctx.pushEvent(TaskEvent.StackTrace(stackTrace))
+    }
+
+    val trace = ctx.trace()
+    assertEquals(trace.events.length, traceBufferSize)
+    assertEquals(trace.captured, traceBufferSize + 10)
+    assertEquals(trace.omitted, 10)
+  }
+
+}

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/RingBuffer.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/RingBuffer.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.execution.internal
+
+/**
+  * Provides a fast, mutable ring buffer.
+  *
+  * All Credits to https://github.com/typelevel/cats-effect and https://github.com/RaasAhsan
+  */
+final private[monix] class RingBuffer[A <: AnyRef](logSize: Int) {
+
+  // These two probably don't need to be allocated every single time, maybe in Java?
+  private[this] val length = 1 << logSize
+  private[this] val mask = length - 1
+
+  private[this] val array: Array[AnyRef] = new Array(length)
+  private[this] var index: Int = 0
+
+  def push(a: A): A = {
+    val wi = index & mask
+    val old = array(wi).asInstanceOf[A]
+    array(wi) = a
+    index += 1
+    old
+  }
+
+  def isEmpty: Boolean =
+    index == 0
+
+  def capacity: Int =
+    length
+
+  // returns a list in reverse order of insertion
+  def toList: List[A] = {
+    val start = index - 1
+    val end = Math.max(index - length, 0)
+    (start to end by -1).toList
+      .map(i => array(i & mask).asInstanceOf[A])
+  }
+
+}

--- a/monix-execution/shared/src/test/scala/monix/execution/internal/RingBufferSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/internal/RingBufferSuite.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.execution.internal
+
+import minitest.SimpleTestSuite
+
+/**
+  * All Credits to https://github.com/typelevel/cats-effect and https://github.com/RaasAhsan
+  */
+object RingBufferSuite extends SimpleTestSuite {
+  test("empty ring buffer") {
+    val buffer = new RingBuffer[Integer](2)
+    assertEquals(buffer.isEmpty, true)
+  }
+
+  test("non-empty ring buffer") {
+    val buffer = new RingBuffer[Integer](2)
+    buffer.push(0)
+    assertEquals(buffer.isEmpty, false)
+  }
+
+  test("writing elements") {
+    val buffer = new RingBuffer[Integer](2)
+    for (i <- 0 to 3) buffer.push(i)
+    assertEquals(buffer.toList.map(_.toInt), List(3, 2, 1, 0))
+  }
+
+  test("overwriting elements") {
+    val buffer = new RingBuffer[Integer](2)
+    for (i <- 0 to 100) buffer.push(i)
+    assertEquals(buffer.toList.map(_.toInt), List(100, 99, 98, 97))
+  }
+}

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapParallelOrderedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapParallelOrderedSuite.scala
@@ -462,10 +462,9 @@ object MapParallelOrderedSuite extends BaseOperatorSuite {
   }
 
   test("should cancel the whole stream when if one fails") { implicit s =>
-    val wasThrown: Throwable = null
     var received = 0
 
-    val failedTask = Task.raiseError(wasThrown).delayExecution(1.second)
+    val failedTask = Task.raiseError(DummyException("dummy")).delayExecution(1.second)
     val otherTask = Task.sleep(2.second).doOnCancel(Task { received += 1 })
 
     Observable(0, 1, 2, 3, 4, 5,

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapParallelUnorderedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapParallelUnorderedSuite.scala
@@ -415,10 +415,9 @@ object MapParallelUnorderedSuite extends BaseOperatorSuite {
   }
 
   test("should cancel the whole stream when if one fails") { implicit s =>
-    val wasThrown: Throwable = null
     var received = 0
 
-    val failedTask = Task.raiseError(wasThrown).delayExecution(1.second)
+    val failedTask = Task.raiseError(DummyException("boom")).delayExecution(1.second)
     val otherTask = Task.sleep(2.second).doOnCancel(Task(received += 1))
 
     Observable(0, 1, 2, 3, 4, 5,

--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -44,6 +44,22 @@ object MimaFilters {
     exclude[MissingClassProblem]("monix.eval.internal.CoevalDeprecated"),
     exclude[MissingClassProblem]("monix.eval.internal.CoevalDeprecated$"),
     // Fixed observable.takeLast, replaced with TakeLastObservable
-    exclude[MissingClassProblem]("monix.reactive.internal.operators.TakeLastOperator")
+    exclude[MissingClassProblem]("monix.reactive.internal.operators.TakeLastOperator"),
+    // Changes in Task model due to Asynchronous Stack Traces
+    exclude[DirectMissingMethodProblem]("monix.eval.Task#Context.copy"),
+    exclude[DirectMissingMethodProblem]("monix.eval.Task#Context.this"),
+    exclude[IncompatibleMethTypeProblem]("monix.eval.Task#Context.apply"),
+    exclude[DirectMissingMethodProblem]("monix.eval.Task#Context.apply"),
+    exclude[IncompatibleMethTypeProblem]("monix.eval.Task#Map.apply"),
+    exclude[IncompatibleMethTypeProblem]("monix.eval.Task#Map.this"),
+    exclude[IncompatibleResultTypeProblem]("monix.eval.Task#Map.copy$default$3"),
+    exclude[DirectMissingMethodProblem]("monix.eval.Task#Map.index"),
+    exclude[IncompatibleMethTypeProblem]("monix.eval.Task#Map.copy"),
+    exclude[DirectMissingMethodProblem]("monix.eval.Task#FlatMap.apply"),
+    exclude[DirectMissingMethodProblem]("monix.eval.Task#FlatMap.this"),
+    exclude[DirectMissingMethodProblem]("monix.eval.Task#FlatMap.copy"),
+    exclude[DirectMissingMethodProblem]("monix.eval.Task#Async.apply"),
+    exclude[DirectMissingMethodProblem]("monix.eval.Task#Async.copy"),
+    exclude[DirectMissingMethodProblem]("monix.eval.Task#Async.this")
   )
 }

--- a/tracingTests/src/fulltracing/scala/tracing/FullStackTracingSuite.scala
+++ b/tracingTests/src/fulltracing/scala/tracing/FullStackTracingSuite.scala
@@ -1,0 +1,146 @@
+package tracing
+
+import monix.eval.tracing.{TaskEvent, TaskTrace}
+import monix.eval.{BaseTestSuite, Task}
+
+/**
+  * All Credits to https://github.com/typelevel/cats-effect and https://github.com/RaasAhsan
+  */
+object FullStackTracingSuite extends BaseTestSuite {
+
+  def traced[A](io: Task[A]): Task[TaskTrace] =
+    io.flatMap(_ => Task.trace)
+
+  testAsync("captures map frames") { implicit s =>
+    val task = Task.pure(0).map(_ + 1).map(_ + 1)
+
+    val test =
+      for (r <- traced(task)) yield {
+        assertEquals(r.captured, 5)
+        assertEquals(
+          r.events.collect { case e: TaskEvent.StackTrace => e }.count(_.stackTrace.exists(_.getMethodName == "map")),
+          3)
+      }
+
+    test.runToFuture
+  }
+
+  testAsync("captures bind frames") { implicit s =>
+    val task = Task.pure(0).flatMap(a => Task(a + 1)).flatMap(a => Task(a + 1))
+
+    val test =
+      for (r <- traced(task)) yield {
+        assertEquals(r.captured, 7)
+        assertEquals(
+          r.events.collect { case e: TaskEvent.StackTrace => e }
+            .count(_.stackTrace.exists(_.getMethodName == "flatMap")),
+          3
+        ) // the extra one is used to capture the trace
+      }
+
+    test.runToFuture
+  }
+
+  testAsync("captures async frames") { implicit s =>
+    val task = Task.async[Int](_(Right(0))).flatMap(a => Task(a + 1)).flatMap(a => Task(a + 1))
+
+    val test =
+      for (r <- traced(task)) yield {
+        assertEquals(r.captured, 7)
+        assertEquals(
+          r.events.collect { case e: TaskEvent.StackTrace => e }.count(_.stackTrace.exists(_.getMethodName == "async")),
+          1)
+      }
+
+    test.runToFuture
+  }
+
+  testAsync("captures pure frames") { implicit s =>
+    val task = Task.pure(0).flatMap(a => Task.pure(a + 1))
+
+    val test =
+      for (r <- traced(task)) yield {
+        assertEquals(r.captured, 5)
+        assertEquals(
+          r.events.collect { case e: TaskEvent.StackTrace => e }.count(_.stackTrace.exists(_.getMethodName == "pure")),
+          2)
+      }
+
+    test.runToFuture
+  }
+
+  testAsync("full stack tracing captures eval frames") { implicit s =>
+    val task = Task(0).flatMap(a => Task(a + 1))
+
+    val test =
+      for (r <- traced(task)) yield {
+        assertEquals(r.captured, 5)
+        assertEquals(
+          r.events.collect { case e: TaskEvent.StackTrace => e }.count(_.stackTrace.exists(_.getMethodName == "eval")),
+          2)
+      }
+
+    test.runToFuture
+  }
+
+  testAsync("full stack tracing captures suspend frames") { implicit s =>
+    val task = Task.suspend(Task(1)).flatMap(a => Task.suspend(Task(a + 1)))
+
+    val test =
+      for (r <- traced(task)) yield {
+        assertEquals(r.captured, 7)
+        assertEquals(
+          r.events.collect { case e: TaskEvent.StackTrace => e }
+            .count(_.stackTrace.exists(_.getMethodName == "suspend")),
+          2)
+      }
+
+    test.runToFuture
+  }
+
+  testAsync("captures raiseError frames") { implicit s =>
+    val task = Task(0).flatMap(_ => Task.raiseError(new Throwable())).onErrorHandleWith(_ => Task.unit)
+
+    val test =
+      for (r <- traced(task)) yield {
+        assertEquals(r.captured, 6)
+        assertEquals(
+          r.events.collect { case e: TaskEvent.StackTrace => e }
+            .count(_.stackTrace.exists(_.getMethodName == "raiseError")),
+          1)
+      }
+
+    test.runToFuture
+  }
+
+  testAsync("captures bracket frames") { implicit s =>
+    val task = Task.unit.bracket(_ => Task.pure(10))(_ => Task.unit).flatMap(a => Task(a + 1)).flatMap(a => Task(a + 1))
+
+    val test =
+      for (r <- traced(task)) yield {
+        assertEquals(r.captured, 13)
+        assertEquals(
+          r.events.collect { case e: TaskEvent.StackTrace => e }
+            .count(_.stackTrace.exists(_.getMethodName == "bracket")),
+          1)
+      }
+
+    test.runToFuture
+  }
+
+  testAsync("captures bracketCase frames") { implicit s =>
+    val task =
+      Task.unit.bracketCase(_ => Task.pure(10))((_, _) => Task.unit).flatMap(a => Task(a + 1)).flatMap(a => Task(a + 1))
+
+    val test =
+      for (r <- traced(task)) yield {
+        assertEquals(r.captured, 13)
+        assertEquals(
+          r.events.collect { case e: TaskEvent.StackTrace => e }
+            .count(_.stackTrace.exists(_.getMethodName == "bracketCase")),
+          1)
+      }
+
+    test.runToFuture
+  }
+}

--- a/tracingTests/src/test/scala/tracing/CachedStackTracingSuite.scala
+++ b/tracingTests/src/test/scala/tracing/CachedStackTracingSuite.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tracing
+
+import monix.eval.tracing.{TaskEvent, TaskTrace}
+import monix.eval.{BaseTestSuite, Task}
+
+/**
+  * All Credits to https://github.com/typelevel/cats-effect and https://github.com/RaasAhsan
+  */
+object CachedStackTracingSuite extends BaseTestSuite {
+
+  def traced[A](io: Task[A]): Task[TaskTrace] =
+    io.flatMap(_ => Task.trace)
+
+  testAsync("captures map frames") { implicit s =>
+    val task = Task.pure(0).map(_ + 1).map(_ + 1)
+
+    val test =
+      for (r <- traced(task)) yield {
+        assertEquals(r.captured, 4)
+        assertEquals(
+          r.events.collect { case e: TaskEvent.StackTrace => e }.count(_.stackTrace.exists(_.getMethodName == "map")),
+          3)
+      }
+
+    test.runToFuture
+  }
+
+  testAsync("captures bind frames") { implicit s =>
+    val task = Task.pure(0).flatMap(a => Task(a + 1)).flatMap(a => Task(a + 1))
+
+    val test =
+      for (r <- traced(task)) yield {
+        assertEquals(r.captured, 4)
+        assertEquals(
+          r.events.collect { case e: TaskEvent.StackTrace => e }
+            .count(_.stackTrace.exists(_.getMethodName == "flatMap")),
+          3
+        ) // the extra one is used to capture the trace
+      }
+
+    test.runToFuture
+  }
+
+  testAsync("captures async frames") { implicit s =>
+    val task = Task.async[Int](_(Right(0))).flatMap(a => Task(a + 1)).flatMap(a => Task(a + 1))
+
+    val test =
+      for (r <- traced(task)) yield {
+        assertEquals(r.captured, 5)
+        assertEquals(
+          r.events.collect { case e: TaskEvent.StackTrace => e }.count(_.stackTrace.exists(_.getMethodName == "async")),
+          1)
+      }
+
+    test.runToFuture
+  }
+
+  testAsync("captures bracket frames") { implicit s =>
+    val task = Task.unit.bracket(_ => Task.pure(10))(_ => Task.unit).flatMap(a => Task(a + 1)).flatMap(a => Task(a + 1))
+
+    val test =
+      for (r <- traced(task)) yield {
+        assertEquals(r.captured, 6)
+        assertEquals(
+          r.events.collect { case e: TaskEvent.StackTrace => e }
+            .count(_.stackTrace.exists(_.getMethodName == "bracket")),
+          1)
+      }
+
+    test.runToFuture
+  }
+
+  testAsync("captures bracketCase frames") { implicit s =>
+    val task =
+      Task.unit.bracketCase(_ => Task.pure(10))((_, _) => Task.unit).flatMap(a => Task(a + 1)).flatMap(a => Task(a + 1))
+
+    val test =
+      for (r <- traced(task)) yield {
+        assertEquals(r.captured, 6)
+        assertEquals(
+          r.events.collect { case e: TaskEvent.StackTrace => e }
+            .count(_.stackTrace.exists(_.getMethodName == "bracketCase")),
+          1)
+      }
+
+    test.runToFuture
+  }
+}

--- a/tracingTests/src/test/scala/tracing/TracingSuite.scala
+++ b/tracingTests/src/test/scala/tracing/TracingSuite.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tracing
+
+import monix.eval.tracing.TaskTrace
+import monix.eval.{BaseTestSuite, Task}
+
+import scala.util.control.NoStackTrace
+import cats.syntax.all._
+import monix.execution.Scheduler
+
+/**
+  * All Credits to https://github.com/typelevel/cats-effect and https://github.com/RaasAhsan
+  */
+object TracingSuite extends BaseTestSuite {
+
+  implicit val s: Scheduler = Scheduler.global
+
+  def traced[A](io: Task[A]): Task[TaskTrace] =
+    io.flatMap(_ => Task.trace)
+
+  testAsync("traces are preserved across asynchronous boundaries") { _ =>
+    val task = for {
+      a <- Task.pure(1)
+      _ <- Task.shift
+      b <- Task.pure(1)
+    } yield a + b
+
+    val test =
+      for (r <- traced(task).runToFuture) yield {
+        assertEquals(r.captured, 4)
+      }
+
+    test
+  }
+
+  testAsync("enhanced exceptions are not augmented more than once") { _ =>
+    val task = for {
+      _ <- Task.pure(1)
+      _ <- Task.pure(2)
+      _ <- Task.pure(3)
+      _ <- Task.shift
+      _ <- Task.pure(1)
+      _ <- Task.pure(2)
+      _ <- Task.pure(3)
+      e1 <- Task.raiseError(new Throwable("Encountered an error")).attempt
+      e2 <- Task.pure(e1).rethrow.attempt
+    } yield (e1, e2)
+
+    for (r <- task.runToFuture) yield {
+      val (e1, e2) = r
+      assertEquals(e1.swap.toOption.get.getStackTrace.length, e2.swap.toOption.get.getStackTrace.length)
+    }
+  }
+
+  testAsync("enhanced exceptions is not applied when stack trace is empty") { _ =>
+    val task = for {
+      e1 <- Task.raiseError(new EmptyException).attempt
+    } yield e1
+
+    for (r <- task.runToFuture) yield {
+      assertEquals(r.swap.toOption.get.getStackTrace.length, 0)
+    }
+
+  }
+
+  class EmptyException extends NoStackTrace
+}


### PR DESCRIPTION
Fixes #1015

Latest snapshot version: `3.2.2+55-9adf112c-SNAPSHOT`

This is a direct port of `cats.effect.IO` solution, [released in 2.2.0](https://github.com/typelevel/cats-effect/releases/tag/v2.2.0).
[Tracing docs](https://typelevel.org/cats-effect/tracing/)

See the following PR's for more context:
- https://github.com/typelevel/cats-effect/pull/854
- https://github.com/typelevel/cats-effect/pull/981
- https://github.com/typelevel/cats-effect/pull/1077

So pretty much all credit goes to @RaasAhsan and @djspiewak 👏 

TODO:
- [x] Proper attributions
- [x] Documentation, created issue #1300
- [x] Double check if all internals are private
- [x] Consider reusing classes with Cats-Effect after upgrade to 2.2.0
- [x] Benchmarks
- [x] Consider tracing more operators (e.g. race, parTraverse) created issue #1288

The feature works exactly the same as in Cats-Effect and is enabled by default. 
It can be configured the same way as Cats version, which is [documented here](https://typelevel.org/cats-effect/tracing/)

The prefix is `monix.eval` instead of `cats.effect` e.g.:

`-Dmonix.eval.stackTracingMode=full -Dmonix.eval.traceBufferLogSize=5`

Example of the current state:

```scala
package test.app

import monix.eval.Task
import monix.execution.Scheduler
import cats.implicits._
import scala.concurrent.duration._

object TestTracingApp extends App {
  implicit val s = Scheduler.global

  def customMethod: Task[Unit] =
    Task.now(()).guarantee(Task.sleep(10.millis))

  val tracingTestApp: Task[Unit] = for {
    _ <- Task.shift
    _ <- Task.unit.attempt
    _ <- (Task(println("Started the program")), Task.unit).parTupled
    _ <- customMethod
    _ <- if (true) Task.raiseError(new Exception("boom")) else Task.unit
  } yield ()

  tracingTestApp.onErrorHandleWith(ex => Task(ex.printStackTrace())).runSyncUnsafe
}
```

Old stack trace:

```
java.lang.Exception: boom
        at test.app.TestTracingApp$.$anonfun$tracingTestApp$5(TestTracingApp.scala:36)
        at monix.eval.internal.TaskRunLoop$.startFull(TaskRunLoop.scala:188)
        at monix.eval.internal.TaskRestartCallback.syncOnSuccess(TaskRestartCallback.scala:101)
        at monix.eval.internal.TaskRestartCallback$$anon$1.run(TaskRestartCallback.scala:118)
        at monix.execution.internal.Trampoline.monix$execution$internal$Trampoline$$immediateLoop(Trampoline.scala:66)
        at monix.execution.internal.Trampoline.startLoop(Trampoline.scala:32)
        at monix.execution.schedulers.TrampolineExecutionContext$JVMNormalTrampoline.super$startLoop(TrampolineExecutionContext.scala:142)
        at monix.execution.schedulers.TrampolineExecutionContext$JVMNormalTrampoline.$anonfun$startLoop$1(TrampolineExecutionContext.scala:142)
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
        at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:94)
        at monix.execution.schedulers.TrampolineExecutionContext$JVMNormalTrampoline.startLoop(TrampolineExecutionContext.scala:142)
        at monix.execution.internal.Trampoline.execute(Trampoline.scala:40)
        at monix.execution.schedulers.TrampolineExecutionContext.execute(TrampolineExecutionContext.scala:57)
        at monix.execution.schedulers.BatchingScheduler.execute(BatchingScheduler.scala:50)
        at monix.execution.schedulers.BatchingScheduler.execute$(BatchingScheduler.scala:47)
        at monix.execution.schedulers.AsyncScheduler.execute(AsyncScheduler.scala:31)
        at monix.eval.internal.TaskRestartCallback.onSuccess(TaskRestartCallback.scala:72)
        at monix.eval.internal.TaskRunLoop$.startFull(TaskRunLoop.scala:183)
        at monix.eval.internal.TaskRestartCallback.syncOnSuccess(TaskRestartCallback.scala:101)
        at monix.eval.internal.TaskRestartCallback.onSuccess(TaskRestartCallback.scala:74)
        at monix.eval.internal.TaskSleep$SleepRunnable.run(TaskSleep.scala:71)
        at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1402)
        at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
        at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
        at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
        at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
```

Cached Mode:

```
java.lang.Exception: boom
        at test.app.TestTracingApp$.$anonfun$tracingTestApp$5(TestTracingApp.scala:36)
        at guarantee @ test.app.TestTracingApp$.customMethod(TestTracingApp.scala:29)
        at flatMap @ test.app.TestTracingApp$.$anonfun$tracingTestApp$4(TestTracingApp.scala:35)
        at parTupled @ test.app.TestTracingApp$.$anonfun$tracingTestApp$2(TestTracingApp.scala:34)
        at parTupled @ test.app.TestTracingApp$.$anonfun$tracingTestApp$2(TestTracingApp.scala:34)
        at flatMap @ test.app.TestTracingApp$.$anonfun$tracingTestApp$2(TestTracingApp.scala:34)
        at flatMap @ test.app.TestTracingApp$.$anonfun$tracingTestApp$1(TestTracingApp.scala:33)
        at flatMap @ test.app.TestTracingApp$.delayedEndpoint$test$app$TestTracingApp$1(TestTracingApp.scala:32)
```

Full Tracing Mode:

```
java.lang.Exception: boom
        at test.app.TestTracingApp$.$anonfun$tracingTestApp$5(TestTracingApp.scala:36)
        at raiseError @ test.app.TestTracingApp$.$anonfun$tracingTestApp$5(TestTracingApp.scala:36)
        at now @ test.app.TestTracingApp$.customMethod(TestTracingApp.scala:29)
        at guarantee @ test.app.TestTracingApp$.customMethod(TestTracingApp.scala:29)
        at flatMap @ test.app.TestTracingApp$.$anonfun$tracingTestApp$4(TestTracingApp.scala:35)
        at <clinit> @ test.app.TestTracingApp$.delayedEndpoint$test$app$TestTracingApp$1(TestTracingApp.scala:32)
        at apply @ test.app.TestTracingApp$.$anonfun$tracingTestApp$2(TestTracingApp.scala:34)
        at parTupled @ test.app.TestTracingApp$.$anonfun$tracingTestApp$2(TestTracingApp.scala:34)
        at parTupled @ test.app.TestTracingApp$.$anonfun$tracingTestApp$2(TestTracingApp.scala:34)
        at flatMap @ test.app.TestTracingApp$.$anonfun$tracingTestApp$2(TestTracingApp.scala:34)
        at <clinit> @ test.app.TestTracingApp$.delayedEndpoint$test$app$TestTracingApp$1(TestTracingApp.scala:32)
        at flatMap @ test.app.TestTracingApp$.$anonfun$tracingTestApp$1(TestTracingApp.scala:33)
        at flatMap @ test.app.TestTracingApp$.delayedEndpoint$test$app$TestTracingApp$1(TestTracingApp.scala:32)
```
