### PR TITLE
More Observable Benchmarks

### DIFF
--- a/benchmarks/shared/src/main/scala/monix/benchmarks/ChunkedEvalFilterMapSumBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/ChunkedEvalFilterMapSumBenchmark.scala
@@ -84,8 +84,8 @@ class ChunkedEvalFilterMapSumBenchmark {
     chunks = (1 to chunkCount).map(i => Array.fill(chunkSize)(i))
     fs2Chunks = chunks.map(fs2.Chunk.array)
     zioChunks = chunks.map(zio.Chunk.fromArray)
-    allElements = (1 to chunkCount * chunkSize)
-    expectedSum = (1 to chunkCount * chunkSize).sum.toLong
+    allElements = 1 to chunkCount * chunkSize
+    expectedSum = (1 to chunkCount * chunkSize).map(_.toLong).sum
   }
 
   @TearDown

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/ChunkedEvalFilterMapSumBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/ChunkedEvalFilterMapSumBenchmark.scala
@@ -144,21 +144,7 @@ class ChunkedEvalFilterMapSumBenchmark {
     testResult(stream.runSyncUnsafe())
   }
 
-  @Benchmark
-  def zioStream = {
-    val stream = ZStream
-      // Note that ZIO is not iterating iterable,
-      // it is simply accessing it by index
-      .fromIterable(allElements)
-      .chunkN(chunkSize)
-      .mapChunksM(chunk => UIO(Chunk.single(sumIntScala(chunk))))
-      .filter(_ > 0)
-      .map(_.toLong)
-      .fold(0L)(_ + _)
-
-    testResult(zioUntracedRuntime.unsafeRun(stream))
-  }
-
+  // On 1.0.0, ZIO doesn't iterate iterable so we can't test sliding window
   @Benchmark
   def zioStreamPreChunked = {
     val stream = ZStream

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/ChunkedMapFilterSumBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/ChunkedMapFilterSumBenchmark.scala
@@ -144,8 +144,7 @@ class ChunkedMapFilterSumBenchmark {
 
   @Benchmark
   def akkaStream(): Long = {
-    val stream = AkkaSource
-      .fromIterator(() => allElements.iterator)
+    val stream = AkkaSource(allElements)
       .map(_ + 1)
       .filter(_ % 2 == 0)
       .toMat(AkkaSink.fold(0L)(_ + _))(Keep.right)

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/ChunkedMapFilterSumBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/ChunkedMapFilterSumBenchmark.scala
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.benchmarks
+
+import java.util.concurrent.TimeUnit
+
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.{Keep, Sink => AkkaSink, Source => AkkaSource}
+import fs2.{Stream => FS2Stream}
+import monix.benchmarks
+import monix.execution.Ack.Continue
+import monix.reactive.Observable
+import monix.reactive.observers.Subscriber
+import org.openjdk.jmh.annotations._
+import zio.stream.{Stream => ZStream}
+
+import scala.collection.immutable.IndexedSeq
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Promise}
+
+/** To do comparative benchmarks between versions:
+  *
+  *     benchmarks/run-benchmark ChunkedMapFilterSumBenchmark
+  *
+  * This will generate results in `benchmarks/results`.
+  *
+  * Or to run the benchmark from within SBT:
+  *
+  *     jmh:run -i 10 -wi 10 -f 2 -t 1 monix.benchmarks.ChunkedMapFilterSumBenchmark
+  *
+  * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread".
+  * Please note that benchmarks should be usually executed at least in
+  * 10 iterations (as a rule of thumb), but more is better.
+  */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class ChunkedMapFilterSumBenchmark {
+  @Param(Array("1000"))
+  var chunkCount: Int = _
+
+  @Param(Array("1000"))
+  var chunkSize: Int = _
+
+  // All events that need to be streamed
+  var allElements: IndexedSeq[Int] = _
+
+  var chunks: IndexedSeq[Array[Int]] = _
+  var fs2Chunks: IndexedSeq[fs2.Chunk[Int]] = _
+  var zioChunks: IndexedSeq[zio.Chunk[Int]] = _
+
+  @Setup
+  def setup(): Unit = {
+    chunks = (1 to chunkCount).map(i => Array.fill(chunkSize)(i))
+    fs2Chunks = chunks.map(fs2.Chunk.array)
+    zioChunks = chunks.map(zio.Chunk.fromArray)
+    allElements = chunks.flatten
+  }
+
+  implicit val system = ActorSystem("benchmarks", defaultExecutionContext = Some(scheduler))
+
+  @TearDown
+  def shutdown(): Unit = {
+    system.terminate()
+    ()
+  }
+
+  @Benchmark
+  def monixObservableNoChunks(): Int = {
+    val stream = Observable
+      .fromIterable(allElements)
+      .map(_ + 1)
+      .filter(_ % 2 == 0)
+
+    sum(stream)
+  }
+
+  @Benchmark
+  def fs2Stream(): Int = {
+    val stream = FS2Stream(fs2Chunks: _*)
+      .flatMap(FS2Stream.chunk)
+      .map(_ + 1)
+      .filter(_ % 2 == 0)
+      .compile
+      .fold(0)(_ + _)
+
+    stream
+  }
+
+  @Benchmark
+  def zioStream(): Int = {
+    val stream = ZStream
+      .fromChunks(zioChunks: _*)
+      .map(_ + 1)
+      .filter(_ % 2 == 0)
+      .runSum
+
+    zioUntracedRuntime.unsafeRun(stream)
+  }
+
+  @Benchmark
+  def akkaStreamNoChunks(): Long = {
+    val stream = AkkaSource
+      .fromIterator(() => allElements.iterator)
+      .map(_ + 1)
+      .filter(_ % 2 == 0)
+      .toMat(AkkaSink.fold(0L)(_ + _))(Keep.right)
+
+    Await.result(stream.run(), Duration.Inf)
+  }
+
+  def sum(stream: Observable[Int]): Int = {
+    val p = Promise[Int]()
+    stream.unsafeSubscribeFn(new Subscriber.Sync[Int] {
+      val scheduler = benchmarks.scheduler
+      private[this] var sum: Int = 0
+
+      def onError(ex: Throwable): Unit =
+        p.failure(ex)
+      def onComplete(): Unit =
+        p.success(sum)
+      def onNext(elem: Int) = {
+        sum += elem
+        Continue
+      }
+    })
+    Await.result(p.future, Duration.Inf)
+  }
+}

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/ObservableMapAccumulateBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/ObservableMapAccumulateBenchmark.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.benchmarks
+
+import java.util.concurrent.TimeUnit
+
+import fs2.{Stream => FS2Stream}
+import monix.reactive.Observable
+import org.openjdk.jmh.annotations._
+import zio.stream.{Stream => ZStream}
+
+/** To do comparative benchmarks between versions:
+  *
+  *     benchmarks/run-benchmark ObservableMapAccumulateBenchmark
+  *
+  * This will generate results in `benchmarks/results`.
+  *
+  * Or to run the benchmark from within SBT:
+  *
+  *     jmh:run -i 10 -wi 10 -f 2 -t 1 monix.benchmarks.ObservableMapAccumulateBenchmark
+  *
+  * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread".
+  * Please note that benchmarks should be usually executed at least in
+  * 10 iterations (as a rule of thumb), but more is better.
+  */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class ObservableMapAccumulateBenchmark {
+  @Param(Array("1000", "10000"))
+  var n: Int = _
+
+  @Benchmark
+  def monixMapAccumulate() = {
+    Observable
+      .fromIterable(0 until n)
+      .mapAccumulate(0) { case (acc, i) =>
+        val added = acc + i
+        (added, added)
+      }
+      .completedL
+      .runSyncUnsafe()
+  }
+
+  @Benchmark
+  def fs2MapAccumulate() = {
+    FS2Stream
+      .emits(0 until n)
+      .mapAccumulate(0) { case (acc, i) =>
+        val added = acc + i
+        (added, added)
+      }
+      .compile
+      .drain
+  }
+
+  @Benchmark
+  def zioMapAccumulate() = {
+    val stream = ZStream
+      .fromIterable(0 until n)
+      .mapAccum(0) { case (acc, i) =>
+        val added = acc + i
+        (added, added)
+      }
+      .runDrain
+
+    zioUntracedRuntime.unsafeRun(stream)
+  }
+}

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/ObservableMergeBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/ObservableMergeBenchmark.scala
@@ -94,7 +94,7 @@ class ObservableMergeBenchmark {
 
   @Benchmark
   def akkaStream(): Long = {
-    val stream = AkkaSource.fromIterator(() => (0 until streams).iterator)
+    val stream = AkkaSource(0 until streams)
       .flatMapMerge(Int.MaxValue, i => AkkaSource.lazyFuture(() => Future.fromTry(Try(i))))
       .toMat(AkkaSink.fold(0L)(_ + _))(Keep.right)
 

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ addCommandAlias("ci-release",  ";+publishSigned ;sonatypeBundleRelease")
 
 val cats_Version = "2.1.1"
 val catsEffect_Version = "2.1.4"
-val fs2_Version = "2.4.0"
+val fs2_Version = "2.4.4"
 val jcTools_Version = "3.0.1"
 val reactiveStreams_Version = "1.0.3"
 val minitest_Version = "2.8.2"
@@ -677,8 +677,9 @@ lazy val benchmarksPrev = project.in(file("benchmarks/vprev"))
   .settings(
     libraryDependencies ++= Seq(
       "io.monix" %% "monix" % "3.2.2",
-      "dev.zio" %% "zio-streams" % "1.0.0-RC21-2",
-      "co.fs2" %% "fs2-core" % fs2_CrossVersion.value
+      "dev.zio" %% "zio-streams" % "1.0.0",
+      "co.fs2" %% "fs2-core" % fs2_CrossVersion.value,
+      "com.typesafe.akka" %% "akka-stream" % "2.6.9"
   ))
 
 lazy val benchmarksNext = project.in(file("benchmarks/vnext"))
@@ -690,6 +691,7 @@ lazy val benchmarksNext = project.in(file("benchmarks/vnext"))
   .dependsOn(reactiveJVM, tailJVM)
   .settings(
     libraryDependencies ++= Seq(
-      "dev.zio" %% "zio-streams" % "1.0.0-RC21-2",
-      "co.fs2" %% "fs2-core" % fs2_CrossVersion.value
+      "dev.zio" %% "zio-streams" % "1.0.0",
+      "co.fs2" %% "fs2-core" % fs2_CrossVersion.value,
+      "com.typesafe.akka" %% "akka-stream" % "2.6.9"
     ))


### PR DESCRIPTION
I was benchmarking a little bit for a talk and I would like to keep some in the repo,

Sample results for Monix 3.3.0, fs2 2.4.4, Akka Streams 2.6.9 and ZIO 1.0.0 on Scala 2.13:

```
ChunkedMapFilterSum

[info] Benchmark  (chunkCount)  (chunkSize)   Mode  Cnt   Score   Error  Units
[info] akka               1000         1000  thrpt   20  10.749 ± 0.082  ops/s
[info] fs2                1000         1000  thrpt   20  55.939 ± 0.497  ops/s
[info] iterator           1000         1000  thrpt   20  76.830 ± 1.182  ops/s
[info] monix              1000         1000  thrpt   20  97.942 ± 2.479  ops/s
[info] vector             1000         1000  thrpt   20  61.514 ± 0.213  ops/s
[info] whileLoop          1000         1000  thrpt   20  355.31 ± 2.803  ops/s
[info] zio                1000         1000  thrpt   20  31.971 ± 0.197  ops/s
```

```
MapAccumulate

[info] Benchmark  (n)   Mode  Cnt      Score     Error  Units
[info] fs2       1000  thrpt   20  66490.570 ± 211.840  ops/s
[info] fs2      10000  thrpt   20   8241.498 ±  52.588  ops/s
[info] monix     1000  thrpt   20  99300.153 ± 619.293  ops/s
[info] monix    10000  thrpt   20  10539.976 ± 203.321  ops/s
[info] zio       1000  thrpt   20   1819.379 ±  16.974  ops/s
[info] zio      10000  thrpt   20    201.752 ±   2.983  ops/s
```

```
ChunkedEvalFilterMapSum

[info] Benchmark (chunkCount)  (chunkSize)   Mode  Cnt    Score   Error  Units
[info] akka              1000         1000  thrpt   20   12.620 ± 0.418  ops/s
[info] akkaPreChunked    1000         1000  thrpt   20  193.842 ± 1.147  ops/s
[info] fs2               1000         1000  thrpt   20   61.285 ± 1.243  ops/s
[info] fs2PreChunked     1000         1000  thrpt   20  150.544 ± 1.089  ops/s
[info] monix             1000         1000  thrpt   20   80.448 ± 1.510  ops/s
[info] monixPreChunked   1000         1000  thrpt   20  280.467 ± 4.769  ops/s
[info] zioPreChunked     1000         1000  thrpt   20  121.028 ± 0.861  ops/s
```

```
Merge

[info] Benchmark  (streams)   Mode  Cnt      Score     Error  Units
[info] akka             100  thrpt   20   1048.289 ±   4.834  ops/s
[info] akka            1000  thrpt   20    118.239 ±   1.396  ops/s
[info] fs2              100  thrpt   20    347.603 ±   8.651  ops/s
[info] fs2             1000  thrpt   20      8.636 ±   0.128  ops/s
[info] monix            100  thrpt   20  15860.931 ± 122.029  ops/s
[info] monix           1000  thrpt   20   2563.933 ±  53.844  ops/s
[info] zio              100  thrpt   20    116.100 ±   0.973  ops/s
[info] zio             1000  thrpt   20     12.260 ±   0.315  ops/s
```