### PR TITLE
Support for 'as' in Task and Coeval

### DIFF
--- a/monix-eval/shared/src/main/scala/monix/eval/Coeval.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Coeval.scala
@@ -924,6 +924,12 @@ sealed abstract class Coeval[+A] extends (() => A) with Serializable { self =>
       a => f(None).map(_ => a)
     )
 
+  /**
+    * Returns this coeval mapped to the supplied value.
+    */
+  final def as[B](b: B): Coeval[B] =
+    this.map(_ => b)
+
   /** Returns this coeval mapped to unit
     */
   final def void: Coeval[Unit] =

--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -2498,6 +2498,12 @@ sealed abstract class Task[+A] extends Serializable with TaskDeprecated.BinCompa
       end   <- Task.clock.monotonic(NANOSECONDS)
     } yield (FiniteDuration(end - start, NANOSECONDS), a)
 
+  /**
+    * Returns this task mapped to the supplied value.
+    */
+  final def as[B](b: B): Task[B] =
+    this.map(_ => b)
+
   /** Returns this task mapped to unit
     */
   final def void: Task[Unit] =


### PR DESCRIPTION
Addresses #1278 