### PR TITLE
fromIteratorBuffered

### DIFF
--- a/benchmarks/vnext/src/main/scala/monix/benchmarks/ObservableIteratorBenchmark.scala
+++ b/benchmarks/vnext/src/main/scala/monix/benchmarks/ObservableIteratorBenchmark.scala
@@ -63,23 +63,21 @@ class ObservableIteratorBenchmark {
     allElements = chunks.flatten
   }
 
-//  @Benchmark
-//  def monixObservable(): Int = {
-//    val stream = Observable
-//      .fromIteratorUnsafe(allElements.iterator)
-//      .bufferTumbling(chunkSize)
-//      .map(sumIntScala)
-//      .filter(_ % 2 == 0)
-//
-//    sum(stream)
-//  }
+  @Benchmark
+  def bufferTumbling(): Int = {
+    val stream = Observable
+      .fromIteratorUnsafe(allElements.iterator)
+      .bufferTumbling(chunkSize)
+      .map(sumIntScala)
+
+    sum(stream)
+  }
 
   @Benchmark
-  def monixObservableChunked(): Int = {
+  def fromIteratorBufferedUnsafe(): Int = {
     val stream = Observable
       .fromIteratorBufferedUnsafe(allElements.iterator, chunkSize)
       .map(sumIntScala)
-      .filter(_ % 2 == 0)
 
     sum(stream)
   }

--- a/benchmarks/vnext/src/main/scala/monix/benchmarks/ObservableIteratorBenchmark.scala
+++ b/benchmarks/vnext/src/main/scala/monix/benchmarks/ObservableIteratorBenchmark.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.benchmarks
+
+import java.util.concurrent.TimeUnit
+
+import monix.benchmarks
+import monix.execution.Ack.Continue
+import monix.reactive.Observable
+import monix.reactive.observers.Subscriber
+import org.openjdk.jmh.annotations._
+
+import scala.collection.immutable.IndexedSeq
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Promise}
+
+/** To do comparative benchmarks between versions:
+  *
+  *     benchmarks/run-benchmark ChunkedMapFilterSumBenchmark
+  *
+  * This will generate results in `benchmarks/results`.
+  *
+  * Or to run the benchmark from within SBT:
+  *
+  *     jmh:run -i 10 -wi 10 -f 2 -t 1 monix.benchmarks.ObservableIteratorBenchmark
+  *
+  * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread".
+  * Please note that benchmarks should be usually executed at least in
+  * 10 iterations (as a rule of thumb), but more is better.
+  */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class ObservableIteratorBenchmark {
+  @Param(Array("1000"))
+  var chunkCount: Int = _
+
+  @Param(Array("1000"))
+  var chunkSize: Int = _
+
+  // All events that need to be streamed
+  var allElements: IndexedSeq[Int] = _
+  var chunks: IndexedSeq[Array[Int]] = _
+
+  @Setup
+  def setup(): Unit = {
+    chunks = (1 to chunkCount).map(i => Array.fill(chunkSize)(i))
+    allElements = chunks.flatten
+  }
+
+//  @Benchmark
+//  def monixObservable(): Int = {
+//    val stream = Observable
+//      .fromIteratorUnsafe(allElements.iterator)
+//      .bufferTumbling(chunkSize)
+//      .map(sumIntScala)
+//      .filter(_ % 2 == 0)
+//
+//    sum(stream)
+//  }
+
+  @Benchmark
+  def monixObservableChunked(): Int = {
+    val stream = Observable
+      .fromIteratorBufferedUnsafe(allElements.iterator, chunkSize)
+      .map(sumIntScala)
+      .filter(_ % 2 == 0)
+
+    sum(stream)
+  }
+
+  def sum(stream: Observable[Int]): Int = {
+    val p = Promise[Int]()
+    stream.unsafeSubscribeFn(new Subscriber.Sync[Int] {
+      val scheduler = benchmarks.scheduler
+      private[this] var sum: Int = 0
+
+      def onError(ex: Throwable): Unit =
+        p.failure(ex)
+      def onComplete(): Unit =
+        p.success(sum)
+      def onNext(elem: Int) = {
+        sum += elem
+        Continue
+      }
+    })
+    Await.result(p.future, Duration.Inf)
+  }
+
+  def sumIntScala(seq: Iterable[Int]): Int = {
+    val cursor = seq.iterator
+    var sum = 0
+    while (cursor.hasNext) {
+      sum += cursor.next()
+    }
+    sum
+  }
+}

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -4986,7 +4986,7 @@ object Observable extends ObservableDeprecatedBuilders {
   def fromIteratorUnsafe[A](iterator: Iterator[A]): Observable[A] =
     new builders.IteratorAsObservable[A](iterator)
 
-  /** Wraps a [[scala.Iterator]] into an `Observable`.
+  /** Wraps a [[scala.Iterator]] into an `Observable` that emits events in `chunkSize` batches.
     *
     * This function uses [[monix.eval.Task Task]] in order to suspend
     * the creation of the `Iterator`, because reading from an `Iterator`
@@ -4997,19 +4997,19 @@ object Observable extends ObservableDeprecatedBuilders {
     * {{{
     *   import monix.eval.Task
     *
-    *   Observable.fromIterator(Task(Iterator.from(1)))
+    *   Observable.fromIteratorBuffered(Task(Iterator.from(1)))
     * }}}
     *
     * @see [[fromIterable]]
     *
-    * @see [[fromIterator[A](resource* fromIterator(Resource)]] for a version
+    * @see [[fromIteratorBuffered[A](resource* fromIteratorBuffered(Resource)]] for a version
     *      that uses `cats.effect.Resource`
     *
-    * @see [[fromIteratorUnsafe]] for the unsafe version that can wrap an
+    * @see [[fromIteratorBufferedUnsafe]] for the unsafe version that can wrap an
     *      iterator directly
     */
-  def fromIteratorBuffered[A](task: Task[Iterator[A]], chunkSize: Int): Observable[Seq[A]] =
-    Observable.fromTask(task.map(fromIteratorBufferedUnsafe(_, chunkSize))).flatten
+  def fromIteratorBuffered[A](task: Task[Iterator[A]], bufferSize: Int): Observable[Seq[A]] =
+    Observable.fromTask(task.map(fromIteratorBufferedUnsafe(_, bufferSize))).flatten
 
   /** Wraps a [[scala.Iterator]] into an `Observable` in the context of a
     * [[https://typelevel.org/cats-effect/datatypes/resource.html cats.effect.Resource]],
@@ -5017,16 +5017,16 @@ object Observable extends ObservableDeprecatedBuilders {
     *
     * @see [[fromIterable]]
     *
-    * @see [[fromIterator[A](task* fromIterator(task)]] for a version
+    * @see [[fromIteratorBuffered[A](task* fromIteratorBuffered(task)]] for a version
     *      that uses [[monix.eval.Task Task]] for suspending side effects
     *
-    * @see [[fromIteratorUnsafe]] for the unsafe version that can wrap an
+    * @see [[fromIteratorBufferedUnsafe]] for the unsafe version that can wrap an
     *      iterator directly
     */
-  def fromIteratorBuffered[A](resource: Resource[Task, Iterator[A]], chunkSize: Int): Observable[Seq[A]] =
-    Observable.fromResource(resource).flatMap(fromIteratorBufferedUnsafe(_, chunkSize))
+  def fromIteratorBuffered[A](resource: Resource[Task, Iterator[A]], bufferSize: Int): Observable[Seq[A]] =
+    Observable.fromResource(resource).flatMap(fromIteratorBufferedUnsafe(_, bufferSize))
 
-  /** Converts any `Iterator` into an observable.
+  /** Converts any `Iterator` into an observable that emits events in `bufferSize` batches.
     *
     * '''UNSAFE WARNING''': reading from an `Iterator` is a destructive process.
     * Therefore only a single subscriber is supported, the result being
@@ -5034,16 +5034,16 @@ object Observable extends ObservableDeprecatedBuilders {
     * all subscribers, except for the first one, will be terminated with a
     * [[monix.execution.exceptions.APIContractViolationException APIContractViolationException]].
     *
-    * @see [[fromIterator[A](task* fromIterator(task)]] or
-    *      [[fromIterator[A](resource* fromIterator(resource)]]
+    * @see [[fromIteratorBuffered[A](task* fromIteratorBuffered(task)]] or
+    *      [[fromIteratorBuffered[A](resource* fromIteratorBuffered(resource)]]
     *      for safe alternatives
     *
     * @param iterator to transform into an observable
     */
   @UnsafeProtocol
   @UnsafeBecauseImpure
-  def fromIteratorBufferedUnsafe[A](iterator: Iterator[A], chunkSize: Int): Observable[Seq[A]] =
-    new builders.BufferedIteratorAsObservable[A](iterator, chunkSize)
+  def fromIteratorBufferedUnsafe[A](iterator: Iterator[A], bufferSize: Int): Observable[Seq[A]] =
+    new builders.BufferedIteratorAsObservable[A](iterator, bufferSize)
 
   /** Transforms any `cats.effect.Resource` into an [[Observable]].
     *

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -603,7 +603,7 @@ abstract class Observable[+A] extends Serializable { self =>
     * then it also emits the given element (appended to the stream).
     */
   final def append[B >: A](elem: B): Observable[B] =
-    self appendAll Observable.now(elem)
+    self.appendAll(Observable.now(elem))
 
   /** Given the source observable and another `Observable`, emits all of
     * the items from the first of these Observables to emit an item
@@ -1261,8 +1261,7 @@ abstract class Observable[+A] extends Serializable { self =>
   final def doOnEarlyStopF[F[_]](task: F[Unit])(implicit F: TaskLike[F]): Observable[A] =
     doOnEarlyStop(F(task))
 
-  /**
-    * Executes the given callback when the connection is being cancelled,
+  /** Executes the given callback when the connection is being cancelled,
     * via the [[monix.execution.Cancelable Cancelable]] reference returned
     * on subscribing to the created observable.
     *
@@ -1725,7 +1724,7 @@ abstract class Observable[+A] extends Serializable { self =>
     * then it also emits the given elements (appended to the stream).
     */
   final def endWith[B >: A](elems: Seq[B]): Observable[B] =
-    self appendAll Observable.fromIterable(elems)
+    self.appendAll(Observable.fromIterable(elems))
 
   /** Concatenates the source with another observable.
     *
@@ -1743,13 +1742,11 @@ abstract class Observable[+A] extends Serializable { self =>
     *
     * result: a1, a2, a3, a4, b1, b2, b3, b4
     * </pre>
-    *
     */
   final def ++[B >: A](other: => Observable[B]): Observable[B] =
     appendAll(Observable.defer(other))
 
-  /**
-    * A strict variant of [[++]].
+  /** A strict variant of [[++]].
     */
   final def appendAll[B >: A](other: Observable[B]): Observable[B] =
     new ConcatObservable[B](self, other)
@@ -2944,8 +2941,7 @@ abstract class Observable[+A] extends Serializable { self =>
   final def scan[S](seed: => S)(op: (S, A) => S): Observable[S] =
     new ScanObservable[A, S](self, () => seed, op)
 
-  /**
-    * Applies a binary operator to a start value and all elements of
+  /** Applies a binary operator to a start value and all elements of
     * this Observable, going left to right and returns a new
     * Observable that emits on each step the result element of
     * the applied function.
@@ -3170,7 +3166,7 @@ abstract class Observable[+A] extends Serializable { self =>
     * it also emits the events of the source (prepend operation).
     */
   final def startWith[B >: A](elems: Seq[B]): Observable[B] =
-    Observable.fromIterable(elems) appendAll self
+    Observable.fromIterable(elems).appendAll(self)
 
   /** Returns a new Observable that uses the specified `Scheduler` for
     * initiating the subscription.
@@ -4912,8 +4908,7 @@ object Observable extends ObservableDeprecatedBuilders {
   def from[F[_], A](fa: F[A])(implicit F: ObservableLike[F]): Observable[A] =
     F.apply(fa)
 
-  /**
-    * Converts any `Iterable` into an [[Observable]].
+  /** Converts any `Iterable` into an [[Observable]].
     */
   def fromIterable[A](iterable: Iterable[A]): Observable[A] =
     new builders.IterableAsObservable[A](iterable)
@@ -4991,8 +4986,66 @@ object Observable extends ObservableDeprecatedBuilders {
   def fromIteratorUnsafe[A](iterator: Iterator[A]): Observable[A] =
     new builders.IteratorAsObservable[A](iterator)
 
-  /**
-    * Transforms any `cats.effect.Resource` into an [[Observable]].
+  /** Wraps a [[scala.Iterator]] into an `Observable`.
+    *
+    * This function uses [[monix.eval.Task Task]] in order to suspend
+    * the creation of the `Iterator`, because reading from an `Iterator`
+    * is a destructive process. The `Task` is being used as a "factory",
+    * in pace of [[scala.Iterable]].
+    *
+    * Example:
+    * {{{
+    *   import monix.eval.Task
+    *
+    *   Observable.fromIterator(Task(Iterator.from(1)))
+    * }}}
+    *
+    * @see [[fromIterable]]
+    *
+    * @see [[fromIterator[A](resource* fromIterator(Resource)]] for a version
+    *      that uses `cats.effect.Resource`
+    *
+    * @see [[fromIteratorUnsafe]] for the unsafe version that can wrap an
+    *      iterator directly
+    */
+  def fromIteratorBuffered[A](task: Task[Iterator[A]], chunkSize: Int): Observable[Seq[A]] =
+    Observable.fromTask(task.map(fromIteratorBufferedUnsafe(_, chunkSize))).flatten
+
+  /** Wraps a [[scala.Iterator]] into an `Observable` in the context of a
+    * [[https://typelevel.org/cats-effect/datatypes/resource.html cats.effect.Resource]],
+    * which allows for specifying a finalizer.
+    *
+    * @see [[fromIterable]]
+    *
+    * @see [[fromIterator[A](task* fromIterator(task)]] for a version
+    *      that uses [[monix.eval.Task Task]] for suspending side effects
+    *
+    * @see [[fromIteratorUnsafe]] for the unsafe version that can wrap an
+    *      iterator directly
+    */
+  def fromIteratorBuffered[A](resource: Resource[Task, Iterator[A]], chunkSize: Int): Observable[Seq[A]] =
+    Observable.fromResource(resource).flatMap(fromIteratorBufferedUnsafe(_, chunkSize))
+
+  /** Converts any `Iterator` into an observable.
+    *
+    * '''UNSAFE WARNING''': reading from an `Iterator` is a destructive process.
+    * Therefore only a single subscriber is supported, the result being
+    * a single-subscriber observable. If multiple subscribers are attempted,
+    * all subscribers, except for the first one, will be terminated with a
+    * [[monix.execution.exceptions.APIContractViolationException APIContractViolationException]].
+    *
+    * @see [[fromIterator[A](task* fromIterator(task)]] or
+    *      [[fromIterator[A](resource* fromIterator(resource)]]
+    *      for safe alternatives
+    *
+    * @param iterator to transform into an observable
+    */
+  @UnsafeProtocol
+  @UnsafeBecauseImpure
+  def fromIteratorBufferedUnsafe[A](iterator: Iterator[A], chunkSize: Int): Observable[Seq[A]] =
+    new builders.BufferedIteratorAsObservable[A](iterator, chunkSize)
+
+  /** Transforms any `cats.effect.Resource` into an [[Observable]].
     *
     * See the
     * [[https://typelevel.org/cats-effect/datatypes/resource.html documentation for Resource]].
@@ -5298,8 +5351,7 @@ object Observable extends ObservableDeprecatedBuilders {
       case Failure(e) => Observable.raiseError(e)
     }
 
-  /**
-    * Builds an `Observable` instance out of a Scala `Either`.
+  /** Builds an `Observable` instance out of a Scala `Either`.
     */
   def fromEither[E <: Throwable, A](a: Either[E, A]): Observable[A] =
     a match {
@@ -5307,8 +5359,7 @@ object Observable extends ObservableDeprecatedBuilders {
       case Left(ex) => Observable.raiseError(ex)
     }
 
-  /**
-    * Builds a [[Observable]] instance out of a Scala `Either`.
+  /** Builds a [[Observable]] instance out of a Scala `Either`.
     */
   def fromEither[E, A](f: E => Throwable)(a: Either[E, A]): Observable[A] =
     a match {
@@ -5369,8 +5420,7 @@ object Observable extends ObservableDeprecatedBuilders {
   def fromTask[A](task: Task[A]): Observable[A] =
     new builders.TaskAsObservable(task)
 
-  /**
-    * Returns a `F ~> Coeval` (`FunctionK`) for transforming any
+  /** Returns a `F ~> Coeval` (`FunctionK`) for transforming any
     * supported data-type into [[Observable]].
     */
   def liftFrom[F[_]](implicit F: ObservableLike[F]): F ~> Observable = F
@@ -5483,7 +5533,6 @@ object Observable extends ObservableDeprecatedBuilders {
 
   /** Repeats the evaluation of given effectful value, emitting
     * the results indefinitely.
-    *
     */
   def repeatEvalF[F[_], A](fa: F[A])(implicit F: TaskLike[F]): Observable[A] =
     repeat(()).mapEvalF(_ => fa)(F)
@@ -6154,7 +6203,7 @@ object Observable extends ObservableDeprecatedBuilders {
     override def pure[A](a: A): Observable[A] =
       Observable.now(a)
     override def combineK[A](x: Observable[A], y: Observable[A]): Observable[A] =
-      x appendAll y
+      x.appendAll(y)
     override def flatMap[A, B](fa: Observable[A])(f: (A) => Observable[B]): Observable[B] =
       fa.flatMap(f)
     override def flatten[A](ffa: Observable[Observable[A]]): Observable[A] =
@@ -6224,8 +6273,7 @@ object Observable extends ObservableDeprecatedBuilders {
       }
     }
 
-  /**
-    * Exposes extension methods for deprecated [[Observable]] methods.
+  /** Exposes extension methods for deprecated [[Observable]] methods.
     */
   implicit final class DeprecatedExtensions[+A](val self: Observable[A])
     extends AnyVal with ObservableDeprecatedMethods[A]

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -4997,7 +4997,7 @@ object Observable extends ObservableDeprecatedBuilders {
     * {{{
     *   import monix.eval.Task
     *
-    *   Observable.fromIteratorBuffered(Task(Iterator.from(1)))
+    *   Observable.fromIteratorBuffered(Task(Iterator.from(1)), 2)
     * }}}
     *
     * @see [[fromIterable]]

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/BufferedIteratorAsObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/BufferedIteratorAsObservable.scala
@@ -33,7 +33,7 @@ import scala.util.{Failure, Success}
 
 private[reactive] final class BufferedIteratorAsObservable[A](iterator: Iterator[A], bufferSize: Int)
   extends Observable[Seq[A]] {
-  require(bufferSize > 0, "chunkSize must be strictly positive")
+  require(bufferSize > 0, "bufferSize must be strictly positive")
 
   private[this] val wasSubscribed = Atomic(false)
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/BufferedIteratorAsObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/BufferedIteratorAsObservable.scala
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.reactive.internal.builders
+
+import monix.execution.Ack.{Continue, Stop}
+import monix.execution.atomic.Atomic
+import monix.execution.cancelables.BooleanCancelable
+import monix.execution.exceptions.APIContractViolationException
+import monix.execution.{Ack, Cancelable, ExecutionModel, Scheduler}
+import monix.reactive.Observable
+import monix.reactive.observers.Subscriber
+
+import scala.annotation.tailrec
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+import scala.util.{Failure, Success}
+
+private[reactive] final class BufferedIteratorAsObservable[A](iterator: Iterator[A], bufferSize: Int)
+  extends Observable[Seq[A]] {
+  require(bufferSize > 0, "chunkSize must be strictly positive")
+
+  private[this] val wasSubscribed = Atomic(false)
+
+  def unsafeSubscribeFn(out: Subscriber[Seq[A]]): Cancelable = {
+    if (wasSubscribed.getAndSet(true)) {
+      out.onError(APIContractViolationException("InputStreamObservable"))
+      Cancelable.empty
+    } else {
+      startLoop(out)
+    }
+  }
+
+  private def startLoop(subscriber: Subscriber[Seq[A]]): Cancelable = {
+    import subscriber.{scheduler => s}
+    // Protect against contract violations - we are only allowed to
+    // call onError if no other terminal event has been called.
+    var streamErrors = true
+    try {
+      val iteratorHasNext = iterator.hasNext
+      streamErrors = false
+      // Short-circuiting empty iterators, as there's no reason to
+      // start the streaming if we have no elements
+      if (!iteratorHasNext) {
+        subscriber.onComplete()
+        Cancelable.empty
+      } else {
+        // Starting the synchronous loop
+        val cancelable = BooleanCancelable()
+        fastLoop(iterator, subscriber, cancelable, s.executionModel, 0)(s)
+        cancelable
+      }
+    } catch {
+      case ex if NonFatal(ex) =>
+        // We can only stream onError events if we have a guarantee
+        // that no other final events happened, otherwise we could
+        // violate the contract.
+        if (streamErrors) {
+          subscriber.onError(ex)
+          Cancelable.empty
+        } else {
+          s.reportFailure(ex)
+          Cancelable.empty
+        }
+    }
+  }
+
+  /** In case of an asynchronous boundary, we reschedule the the
+    * run-loop on another logical thread. Usage of `onComplete` takes
+    * care of that.
+    *
+    * NOTE: the assumption of this method is that `iter` is
+    * NOT empty, so the first call is `next()` and not `hasNext()`.
+    */
+  private def reschedule(
+    ack: Future[Ack],
+    iter: Iterator[A],
+    out: Subscriber[Seq[A]],
+    c: BooleanCancelable,
+    em: ExecutionModel)(implicit s: Scheduler): Unit = {
+
+    ack.onComplete {
+      case Success(next) =>
+        if (next == Continue)
+          // If fastLoop throws, then it's a contract violation and
+          // the only thing we can do is to log it
+          try {
+            fastLoop(iter, out, c, em, 0)
+          } catch {
+            case ex if NonFatal(ex) =>
+              // Protocol violation
+              s.reportFailure(ex)
+          }
+      case Failure(ex) =>
+        out.onError(ex)
+    }
+  }
+
+  /** The `fastLoop` is a tail-recursive function that goes through the
+    * elements of our iterator, one by one, and tries to push them
+    * synchronously, for as long as the `ExecutionModel` permits.
+    *
+    * After it encounters an asynchronous boundary (i.e. an
+    * uncompleted `Future` returned by `onNext`), then we
+    * [[reschedule]] the loop on another logical thread.
+    *
+    * NOTE: the assumption of this method is that `iter` is
+    * NOT empty, so the first call is `next()` and not `hasNext()`.
+    */
+  @tailrec private def fastLoop(
+    iter: Iterator[A],
+    out: Subscriber[Seq[A]],
+    c: BooleanCancelable,
+    em: ExecutionModel,
+    syncIndex: Int)(implicit s: Scheduler): Unit = {
+    // The result of onNext calls, on which we must do back-pressure
+    var ack: Future[Ack] = Continue
+    // We do not want to catch errors from our interaction with our
+    // observer, since SafeObserver should take care of than, hence we
+    // must only catch and stream errors related to the interactions
+    // with the iterator
+    var streamErrors = true
+    // True in case our iterator is seen to be empty and we must
+    // signal onComplete
+    var iteratorHasNext = true
+    // non-null in case we caught an iterator related error and we
+    // must signal onError
+    var iteratorTriggeredError: Throwable = null
+
+    val buffer = ListBuffer.empty[A]
+    var size = 0
+
+    try {
+      while (iteratorHasNext && size < bufferSize) {
+        val next = iter.next()
+        buffer.append(next)
+        size += 1
+        iteratorHasNext = iter.hasNext
+      }
+
+      ack = out.onNext(buffer.toList)
+    } catch {
+      case NonFatal(ex) if streamErrors =>
+        iteratorTriggeredError = ex
+    }
+
+    // Signaling onComplete
+    if (iteratorTriggeredError != null) {
+      // Signaling error only if the subscription isn't canceled
+      if (!c.isCanceled) out.onError(iteratorTriggeredError)
+      else s.reportFailure(iteratorTriggeredError)
+    } else if (!iteratorHasNext) {
+      streamErrors = true
+      // Iterator has finished
+      out.onComplete()
+    } else {
+      // Logic for collapsing execution loops
+      val nextIndex =
+        if (ack == Continue) em.nextFrameIndex(syncIndex) // TODO check if its fine to add batch size
+        else if (ack == Stop) -1
+        else 0
+
+      if (nextIndex > 0)
+        fastLoop(iter, out, c, em, nextIndex)
+      else if (nextIndex == 0 && !c.isCanceled)
+        reschedule(ack, iter, out, c, em)
+    }
+  }
+}

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/BufferedIteratorAsObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/BufferedIteratorAsObservableSuite.scala
@@ -1,0 +1,353 @@
+/*
+ * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.reactive.internal.builders
+
+import cats.effect.Resource
+import minitest.TestSuite
+import monix.eval.Task
+import monix.execution.Ack.Continue
+import monix.execution.exceptions.APIContractViolationException
+import monix.execution.{Ack, Scheduler}
+import monix.execution.schedulers.TestScheduler
+import monix.reactive.Observable
+import monix.execution.exceptions.DummyException
+import monix.reactive.observers.Subscriber
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+object BufferedIteratorAsObservableSuite extends TestSuite[TestScheduler] {
+  def setup() = TestScheduler()
+  def tearDown(s: TestScheduler) = {
+    assert(s.state.tasks.isEmpty, "TestScheduler should be left with no pending tasks")
+  }
+
+  test("yields a single subscriber observable") { implicit s =>
+    var errorThrown: Throwable = null
+    val obs = Observable.fromIteratorBufferedUnsafe(Seq(1, 2, 3).iterator, 1)
+    obs.unsafeSubscribeFn(Subscriber.empty(s))
+
+    obs.unsafeSubscribeFn(new Subscriber[Seq[Int]] {
+      implicit val scheduler = s
+
+      def onNext(elem: Seq[Int]): Ack =
+        throw new IllegalStateException("onNext")
+      def onComplete(): Unit =
+        throw new IllegalStateException("onComplete")
+      def onError(ex: Throwable): Unit =
+        errorThrown = ex
+    })
+
+    assert(errorThrown.isInstanceOf[APIContractViolationException])
+  }
+
+  test("fromIterator(resource) should call finalizer") { implicit s =>
+    var onFinishCalled = 0
+    var onCompleteCalled = 0
+    var sum = 0
+
+    val n = s.executionModel.recommendedBatchSize * 4
+    val seq = 0 until n
+    val obs = Observable
+      .fromIteratorBuffered(Resource.make(Task(seq.iterator))(_ => Task { onFinishCalled += 1 }), 1)
+      .map { x =>
+        assertEquals(onFinishCalled, 0); x
+      }
+
+    obs.unsafeSubscribeFn(new Subscriber[Seq[Int]] {
+      implicit val scheduler: Scheduler = s
+
+      def onNext(elem: Seq[Int]): Ack = { sum += elem.sum; Continue }
+      def onComplete(): Unit =
+        onCompleteCalled += 1
+      def onError(ex: Throwable): Unit =
+        throw new IllegalStateException("onError")
+    })
+
+    s.tick()
+    assertEquals(s.state.lastReportedError, null)
+    assertEquals(onCompleteCalled, 1)
+    assertEquals(onFinishCalled, 1)
+    assertEquals(sum, n * (n - 1) / 2)
+  }
+
+  test("fromIterator(resource) should back-pressure onNext before calling finalizer") { implicit s =>
+    var onFinishCalled = 0
+    var onCompleteCalled = 0
+    var sum = 0
+
+    val n = s.executionModel.recommendedBatchSize * 4
+    val seq = 0 until n
+    val obs = Observable
+      .fromIteratorBuffered(Resource.make(Task(seq.iterator))(_ => Task { onFinishCalled += 1 }), 1)
+      .mapEval(x => Task(assertEquals(onFinishCalled, 0)).map(_ => x).delayExecution(1.millis))
+
+    obs.unsafeSubscribeFn(new Subscriber[Seq[Int]] {
+      implicit val scheduler: Scheduler = s
+
+      def onNext(elem: Seq[Int]): Ack = { sum += elem.sum; Continue }
+      def onComplete(): Unit = onCompleteCalled += 1
+      def onError(ex: Throwable): Unit =
+        throw new IllegalStateException("onError")
+    })
+
+    s.tick(1.millis * n.toLong)
+    assertEquals(sum, n * (n - 1) / 2)
+    assertEquals(onCompleteCalled, 1)
+    assertEquals(onFinishCalled, 1)
+  }
+
+  test("onFinish should be called upon onError") { implicit s =>
+    val ex = DummyException("dummy")
+    var onFinishCalled = 0
+    var onErrorCalled: Throwable = null
+    var sum = 0
+
+    val n = s.executionModel.recommendedBatchSize * 4
+    val seq = 0 until n
+    val obs = Observable
+      .fromIteratorBuffered(Resource.make(Task(seq.iterator))(_ => Task { onFinishCalled += 1 }), 1)
+      .endWithError(ex)
+
+    obs.unsafeSubscribeFn(new Subscriber[Seq[Int]] {
+      implicit val scheduler: Scheduler = s
+
+      def onNext(elem: Seq[Int]): Ack = { sum += elem.sum; Continue }
+      def onComplete(): Unit =
+        throw new IllegalStateException("onComplete")
+      def onError(ex: Throwable): Unit =
+        onErrorCalled = ex
+    })
+
+    s.tick()
+    assertEquals(sum, n * (n - 1) / 2)
+    assertEquals(onErrorCalled, ex)
+    assertEquals(onFinishCalled, 1)
+  }
+
+  test("onFinish should be called upon Stop") { implicit s =>
+    var onFinishCalled = 0
+    var onCompleteCalled = 0
+    var sum = 0
+
+    val n = s.executionModel.recommendedBatchSize * 4
+    val seq = 0 until (n * 2)
+    val obs = Observable
+      .fromIteratorBuffered(Resource.make(Task(seq.iterator))(_ => Task { onFinishCalled += 1 }), 1)
+      .take(n.toLong) // Will trigger Stop
+
+    obs.unsafeSubscribeFn(new Subscriber[Seq[Int]] {
+      implicit val scheduler: Scheduler = s
+
+      def onNext(elem: Seq[Int]): Ack = { sum += elem.sum; Continue }
+      def onComplete(): Unit = onCompleteCalled += 1
+      def onError(ex: Throwable): Unit =
+        throw new IllegalStateException("onError")
+    })
+
+    s.tick()
+    assertEquals(sum, n * (n - 1) / 2)
+    assertEquals(onCompleteCalled, 1)
+    assertEquals(onFinishCalled, 1)
+  }
+
+  test("onFinish should be called upon subscription cancel") { implicit s =>
+    var onFinishCalled = 0
+    var onCompleteCalled = 0
+    var received = 0
+
+    val n = s.executionModel.recommendedBatchSize
+    val seq = 0 until (n * 4)
+    val obs = Observable.fromIteratorBuffered(Resource.make(Task(seq.iterator))(_ => Task { onFinishCalled += 1 }), 1)
+
+    val c = obs.unsafeSubscribeFn(new Subscriber[Seq[Int]] {
+      implicit val scheduler: Scheduler = s
+
+      def onNext(elem: Seq[Int]): Ack = { received += elem.size; Continue }
+      def onComplete(): Unit = onCompleteCalled += 1
+      def onError(ex: Throwable): Unit =
+        throw new IllegalStateException("onError")
+    })
+
+    c.cancel()
+    s.tick()
+
+    assertEquals(received, n * 2)
+    assertEquals(onCompleteCalled, 0)
+    assertEquals(onFinishCalled, 1)
+  }
+
+  test("onFinish should be called if onNext triggers error before boundary") { implicit s =>
+    val ex = DummyException("dummy")
+    var onFinishCalled = 0
+    var received = 0
+    var wasThrown: Throwable = null
+
+    val n = s.executionModel.recommendedBatchSize
+    val seq = 0 until (n * 4)
+    val obs = Observable.fromIteratorBuffered(Resource.make(Task(seq.iterator))(_ => Task { onFinishCalled += 1 }), 1)
+
+    obs.unsafeSubscribeFn(new Subscriber[Seq[Int]] {
+      implicit val scheduler: Scheduler = s
+
+      def onNext(elem: Seq[Int]): Ack = {
+        received += elem.size
+        if (received == n) throw ex
+        Continue
+      }
+
+      def onComplete(): Unit =
+        throw new IllegalStateException("onComplete")
+      def onError(ex: Throwable): Unit =
+        wasThrown = ex
+    })
+
+    s.tick()
+    assertEquals(received, n)
+    assertEquals(onFinishCalled, 1)
+    assertEquals(wasThrown, ex)
+  }
+
+  test("onFinish should be called if onNext triggers error after boundary") { implicit s =>
+    val ex = DummyException("dummy")
+    var onFinishCalled = 0
+    var received = 0
+    var wasThrown: Throwable = null
+
+    val n = s.executionModel.recommendedBatchSize
+    val seq = 0 until (n * 4)
+    val obs = Observable.fromIteratorBuffered(Resource.make(Task(seq.iterator))(_ => Task { onFinishCalled += 1 }), 1)
+
+    obs.unsafeSubscribeFn(new Subscriber[Seq[Int]] {
+      implicit val scheduler: Scheduler = s
+
+      def onNext(elem: Seq[Int]): Ack = {
+        received += elem.size
+        if (received == n * 2) throw ex
+        Continue
+      }
+
+      def onComplete(): Unit =
+        throw new IllegalStateException("onComplete")
+      def onError(ex: Throwable): Unit =
+        wasThrown = ex
+    })
+
+    s.tick()
+    assertEquals(received, n * 2)
+    assertEquals(onFinishCalled, 1)
+    assertEquals(wasThrown, ex)
+  }
+
+  test("onFinish should be called if onNext triggers error asynchronously") { implicit s =>
+    val ex = DummyException("dummy")
+    var onFinishCalled = 0
+    var received = 0
+    var wasThrown: Throwable = null
+
+    val n = s.executionModel.recommendedBatchSize
+    val seq = 0 until (n * 4)
+    val obs = Observable.fromIteratorBuffered(Resource.make(Task(seq.iterator))(_ => Task { onFinishCalled += 1 }), 1)
+
+    obs.unsafeSubscribeFn(new Subscriber[Seq[Int]] {
+      implicit val scheduler: Scheduler = s
+
+      def onNext(elem: Seq[Int]): Future[Ack] = {
+        received += 1
+        if (received == n * 2)
+          Future.failed(ex)
+        else
+          Continue
+      }
+
+      def onComplete(): Unit =
+        throw new IllegalStateException("onComplete")
+      def onError(ex: Throwable): Unit =
+        wasThrown = ex
+    })
+
+    s.tick()
+    assertEquals(received, n * 2)
+    assertEquals(onFinishCalled, 1)
+    assertEquals(wasThrown, ex)
+  }
+
+  test("onFinish throwing just before onComplete") { implicit s =>
+    val ex = DummyException("ex")
+    var wasThrown: Throwable = null
+    var sum = 0
+
+    val n = s.executionModel.recommendedBatchSize * 4
+    val seq = 0 until n
+    val obs = Observable
+      .fromIteratorBuffered(Resource.make(Task(seq.iterator))(_ => Task.raiseError(ex)), 1)
+      .map { x =>
+        assertEquals(wasThrown, null); x
+      }
+
+    obs.unsafeSubscribeFn(new Subscriber[Seq[Int]] {
+      implicit val scheduler: Scheduler = s
+
+      def onNext(elem: Seq[Int]): Ack = {
+        sum += elem.sum
+        Continue
+      }
+
+      def onComplete(): Unit =
+        throw new IllegalStateException("onComplete")
+      def onError(ex: Throwable): Unit =
+        wasThrown = ex
+    })
+
+    s.tick()
+    assertEquals(wasThrown, ex)
+    assertEquals(sum, n * (n - 1) / 2)
+  }
+
+  test("onFinish throwing after Stop") { implicit s =>
+    val ex = DummyException("ex")
+    var onCompleteCalled = 0
+    var received = 0
+
+    val n = s.executionModel.recommendedBatchSize
+    val seq = 0 until (n * 4)
+    val obs = Observable
+      .fromIteratorBuffered(Resource.make(Task(seq.iterator))(_ => Task.raiseError(ex)), 1)
+      .take(n.toLong)
+
+    obs.unsafeSubscribeFn(new Subscriber[Seq[Int]] {
+      implicit val scheduler: Scheduler = s
+
+      def onNext(elem: Seq[Int]): Ack = {
+        received += elem.size
+        Continue
+      }
+
+      def onComplete(): Unit =
+        onCompleteCalled += 1
+      def onError(ex: Throwable): Unit =
+        throw new IllegalStateException("onError")
+    })
+
+    s.tick()
+    assertEquals(received, n)
+    // onComplete gets called via `take`, which sends `Stop` upstream and
+    // sends onComplete downstream and there isn't much we can do here
+    assertEquals(onCompleteCalled, 1)
+    assertEquals(s.state.lastReportedError, ex)
+  }
+}

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/BufferedIteratorAsObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/BufferedIteratorAsObservableSuite.scala
@@ -27,7 +27,6 @@ import monix.execution.{Ack, ExecutionModel, Scheduler}
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 
-import scala.collection.immutable.ArraySeq
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Success
@@ -390,14 +389,18 @@ object BufferedIteratorAsObservableSuite extends TestSuite[TestScheduler] {
   }
 
   test("emits buffers") { implicit s =>
+    import monix.execution.compat.internal.toSeq
+
     val seq = 0 to 10
     val f = Observable
       .fromIteratorBufferedUnsafe(seq.iterator, 4)
         .toListL
         .runToFuture
 
+    val expected = List(Seq(0, 1, 2, 3), Seq(4, 5, 6, 7), Seq(8, 9, 10)).map(seq => toSeq(seq.map(_.asInstanceOf[AnyRef]).toArray[AnyRef]))
+
     s.tick()
 
-    assertEquals(f.value, Some(Success(List(ArraySeq(0, 1, 2, 3), ArraySeq(4, 5, 6, 7), ArraySeq(8, 9, 10)))))
+    assertEquals(f.value, Some(Success(expected)))
   }
 }


### PR DESCRIPTION
Fixes #1275 

I've run a simple benchmark against `fromIterator` + `bufferSliding` and there seems to be a decent gain (around 35%, perhaps more than 3.2.2 because we fixed perf regression on Scala 2.13) but I'm not sure if it is enough to make a difference for your use case @deusaquilus

If it's not, I'm happy to try and help to solve the issue

```
[info] Benchmark                                               (chunkCount)  (chunkSize)   Mode  Cnt    Score   Error  Units
[info] ObservableIteratorBenchmark.bufferTumbling                      1000         1000  thrpt   40   95.434 ± 0.998  ops/s
[info] ObservableIteratorBenchmark.fromIteratorBufferedUnsafe          1000         1000  thrpt   40  130.350 ± 2.840  ops/s
```