### PR TITLE
Add Observable.whileBusyAggregateEvents

### DIFF
--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/WhileBusyAggregateEventsOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/WhileBusyAggregateEventsOperator.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.reactive.internal.operators
+
+import monix.execution.Ack
+import monix.execution.Ack.{Continue, Stop}
+import monix.reactive.Observable.Operator
+import monix.reactive.observers.Subscriber
+
+import scala.concurrent.Future
+
+private[reactive] final class WhileBusyAggregateEventsOperator[A, S](seed: A => S, aggregate: (S, A) => S) extends Operator[A, S] {
+
+  def apply(downstream: Subscriber[S]): Subscriber.Sync[A] = {
+    new Subscriber.Sync[A] {
+      upstreamSubscriber =>
+      implicit val scheduler = downstream.scheduler
+
+      private[this] var aggregated: Option[S] = None
+      private[this] var lastAck: Future[Ack] = Continue
+      private[this] var pendingAck: Boolean = false
+      private[this] var downstreamIsDone = false
+
+      def onNext(elem: A): Ack = {
+        upstreamSubscriber.synchronized {
+          if (downstreamIsDone) Stop
+          else {
+            if (!pendingAck) {
+              val downstreamAck = downstream.onNext(seed(elem))
+              lastAck = downstreamAck
+
+              if (downstreamAck == Continue) Continue
+              else if (downstreamAck == Stop) {
+                downstreamIsDone = true
+                Stop
+              }
+              else {
+                pendingAck = true
+                downstreamAck.map { ack =>
+                  if (ack == Stop) {
+                    downstreamIsDone = true
+                  } else if (ack == Continue) {
+                    emitAggregated()
+                  }
+                }
+
+                Continue
+              }
+            } else {
+              aggregated = Some(aggregated match {
+                case Some(agg) => aggregate(agg, elem)
+                case None => seed(elem)
+              })
+              Continue
+            }
+          }
+        }
+      }
+
+      private def emitAggregated(): Unit = {
+        upstreamSubscriber.synchronized {
+          aggregated match {
+            case Some(agg) =>
+              aggregated = None
+              if (!downstreamIsDone) {
+                lastAck = downstream.onNext(agg)
+
+                lastAck.map { _ =>
+                  upstreamSubscriber.synchronized {
+                    if (aggregated.isDefined) emitAggregated()
+                    else pendingAck = false
+                  }
+                }
+              }
+              ()
+            case None =>
+              pendingAck = false
+          }
+        }
+      }
+
+      def onError(ex: Throwable): Unit =
+        upstreamSubscriber.synchronized {
+          if (!downstreamIsDone) {
+            downstreamIsDone = true
+            downstream.onError(ex)
+          }
+        }
+
+      def onComplete(): Unit =
+        // Can't emit the aggregated element immediately as the previous `onNext` may not yet have been acked.
+        upstreamSubscriber.synchronized {
+          lastAck.map {
+            case Continue =>
+              upstreamSubscriber.synchronized {
+                emitAggregated()
+                downstream.onComplete()
+              }
+            case _ =>
+          }
+          ()
+        }
+
+    }
+  }
+}

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BaseOperatorSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BaseOperatorSuite.scala
@@ -148,7 +148,7 @@ abstract class BaseOperatorSuite extends BaseTestSuite {
           private[this] var ack: Future[Ack] = Continue
 
           def onNext(elem: Long): Future[Ack] = {
-            assert(ack.isCompleted, "Contact breach, last ack is not completed")
+            assert(ack.isCompleted, s"Contact breach at elem $elem of $sourceCount, last ack is not completed")
 
             ack = Future.delayedResult(100.millis) {
               received += 1

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WhileBusyAggregateEventsOperatorSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WhileBusyAggregateEventsOperatorSuite.scala
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.reactive.internal.operators
+
+import cats.data.Chain
+import monix.reactive.Observable
+
+import scala.concurrent.duration._
+import scala.util.Success
+
+object WhileBusyAggregateEventsOperatorSuite extends BaseOperatorSuite {
+  private val waitNext = 1.second
+
+  private def sum(sourceCount: Int) = {
+    (0 until sourceCount).sum
+  }
+
+  override def createObservable(sourceCount: Int) = Some {
+    require(sourceCount > 0, "sourceCount must be strictly positive")
+    val o = Observable
+      .range(0L, sourceCount.toLong)
+      .throttle(waitNext, 1)
+      .whileBusyAggregateEvents(identity)(_ + _)
+
+    Sample(o, sourceCount, sum(sourceCount), waitNext, waitNext)
+  }
+
+  override def observableInError(sourceCount: Int, ex: Throwable) = Some {
+    require(sourceCount > 0, "sourceCount must be strictly positive")
+
+    val o = Observable
+      .range(0, sourceCount.toLong)
+      .throttle(waitNext, 1)
+      .endWithError(ex)
+      .whileBusyAggregateEvents(identity)(_ + _)
+
+    Sample(o, sourceCount, sum(sourceCount), waitNext, waitNext)
+  }
+
+  override def cancelableObservables() = {
+    val o = Observable
+      .range(0, 1000)
+      .throttle(waitNext, 1)
+      .whileBusyAggregateEvents(identity)(_ + _)
+
+    Seq(
+      Sample(o, 0, 0, 0.seconds, 0.seconds),
+      Sample(o, 4, 1 + 2 + 3 + 4, waitNext * 4, 0.seconds)
+    )
+  }
+
+  override def brokenUserCodeObservable(sourceCount: Int, ex: Throwable) = None
+
+  test("performs no conflation when upstream is slow than downstream") { implicit s =>
+    val result = Observable.range(0, 10)
+      .throttle(100.milliseconds, 1)
+      .whileBusyAggregateEvents[Chain[Long]](Chain.apply(_)) { case (list, ele) => list.append(ele) }
+      .throttle(10.milliseconds, 1)
+      .toListL
+      .runToFuture
+
+    s.tick(10.seconds)
+
+    assertEquals(result.value, Some(Success((0 until 10).toList.map(Chain.apply(_)))))
+  }
+
+  test("performs conflation when upstream is faster than downstream") { implicit s =>
+    val result = Observable.range(0, 5)
+      .throttle(10.milliseconds, 1)
+      .whileBusyAggregateEvents[Chain[Long]](Chain.apply(_)) { case (list, ele) => list.append(ele) }
+      .throttle(100.milliseconds, 1)
+      .toListL
+      .runToFuture
+
+    s.tick(10.seconds)
+
+    assertEquals(result.value, Some(Success(List(Chain(0), Chain(1, 2, 3, 4)))))
+  }
+
+  test("emits groups of conflated elements each time backpressuring stops") { implicit s =>
+    val result = Observable.range(0, 9)
+      .throttle(3.seconds, 1)
+      .whileBusyAggregateEvents[Chain[Long]](Chain.apply(_)) { case (list, ele) => list.append(ele) }
+      .throttle(10.seconds, 1)
+      .toListL
+      .runToFuture
+
+    s.tick(10.seconds) // 3,6,9 seconds - elements 0,1,2
+    s.tick(10.seconds) // 12,15,18 seconds - elements 3,4,5
+    s.tick(10.seconds) // 21,24,27 seconds - elements 6,7,8
+    s.tick(10.seconds)
+
+    assertEquals(result.value, Some(Success(List(Chain(0), Chain(1, 2), Chain(3, 4 , 5), Chain(6, 7, 8)))))
+  }
+
+  test("performs conflation when upstream is unbounded and downstream is slow") { implicit s =>
+    val result = Observable.range(0, 10)
+      .whileBusyAggregateEvents[Chain[Long]](Chain.apply(_)) { case (list, ele) => list.append(ele) }
+      .throttle(100.milliseconds, 1)
+      .toListL
+      .runToFuture
+
+    s.tick(10.seconds)
+
+    assertEquals(result.value, Some(Success(List(Chain(0), Chain(1, 2, 3, 4, 5, 6, 7, 8, 9)))))
+  }
+
+  test("performs no conflation when downstream is unbounded") { implicit s =>
+    val result = Observable.range(0, 10)
+      .throttle(10.milliseconds, 1)
+      .whileBusyAggregateEvents[Chain[Long]](Chain.apply(_)) { case (list, ele) => list.append(ele) }
+      .toListL
+      .runToFuture
+
+    s.tick(10.seconds)
+
+    assertEquals(result.value, Some(Success((0 until 10).toList.map(Chain.apply(_)))))
+  }
+}


### PR DESCRIPTION
This is useful for when a downstream consumer of events is slower than the upstream consumer
and events can be aggregated.

Note the implementation of the operator is largely based on https://github.com/monix/monix/blob/5c24f19ea805d5223c9e38961703aa955d691fdd/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferWithSelectorObservable.scala

Related issue: #1319

I'd appreciate any feedback!