### PR TITLE
Scala 2/3 compatiblity

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -178,20 +178,17 @@ lazy val sharedSettings = pgpSettings ++ Seq(
   */
 
   // Disabled from the sbt-tpolecat set
-  scalacOptions in Compile ~= { options: Seq[String] =>
-    options.filterNot(
-      Set(
-        "-Wunused:privates",
-        "-Ywarn-unused:privates",
-        "-Ywarn-unused:implicits",
-        "-Wunused:implicits",
-        "-Ywarn-unused:imports",
-        "-Wunused:explicits",
-        "-Ywarn-unused:params",
-        "-Wunused:params",
-      )
-    )
-  },
+  scalacOptions in Compile --= Seq(
+    "-Wunused:privates",
+    "-Ywarn-unused:privates",
+    "-Wunused:implicits",
+    "-Ywarn-unused:implicits",
+    "-Wunused:imports",
+    "-Ywarn-unused:imports",
+    "-Wunused:explicits",
+    "-Ywarn-unused:params",
+    "-Wunused:params",
+  ),
 
   // Turning off fatal warnings for doc generation
   scalacOptions.in(Compile, doc) ~= filterConsoleScalacOptions,

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicBuilder.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicBuilder.scala
@@ -24,7 +24,7 @@ package monix.execution.atomic
   * driven by implicits.
   */
 trait AtomicBuilder[A, R <: Atomic[A]] extends Serializable {
-  def buildInstance(initialValue: A, strategy: PaddingStrategy, allowPlatformIntrinsics: Boolean): R
+  def buildInstance(initialValue: A, padding: PaddingStrategy, allowPlatformIntrinsics: Boolean): R
 
   def buildSafeInstance(initialValue: A, padding: PaddingStrategy): R
 }
@@ -34,9 +34,10 @@ private[atomic] object Implicits {
     /** Provides an [[AtomicBuilder]] instance for [[AtomicAny]]. */
     implicit def AtomicRefBuilder[A <: AnyRef]: AtomicBuilder[A, AtomicAny[A]] =
       new AtomicBuilder[A, AtomicAny[A]] {
-        def buildInstance(initialValue: A, strategy: PaddingStrategy, allowPlatformIntrinsics: Boolean) =
+        def buildInstance(initialValue: A, padding: PaddingStrategy, allowPlatformIntrinsics: Boolean) =
           AtomicAny(initialValue)
-        def buildSafeInstance(initialValue: A, strategy: PaddingStrategy) =
+
+        def buildSafeInstance(initialValue: A, padding: PaddingStrategy) =
           AtomicAny(initialValue)
       }
   }
@@ -45,9 +46,10 @@ private[atomic] object Implicits {
     /** Provides an [[AtomicBuilder]] instance for [[AtomicNumberAny]]. */
     implicit def AtomicNumberBuilder[A <: AnyRef: Numeric]: AtomicBuilder[A, AtomicNumberAny[A]] =
       new AtomicBuilder[A, AtomicNumberAny[A]] {
-        def buildInstance(initialValue: A, strategy: PaddingStrategy, allowPlatformIntrinsics: Boolean) =
+        def buildInstance(initialValue: A, padding: PaddingStrategy, allowPlatformIntrinsics: Boolean) =
           AtomicNumberAny(initialValue)
-        def buildSafeInstance(initialValue: A, strategy: PaddingStrategy) =
+
+        def buildSafeInstance(initialValue: A, padding: PaddingStrategy) =
           AtomicNumberAny(initialValue)
       }
   }

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicBuilder.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicBuilder.scala
@@ -32,18 +32,19 @@ trait AtomicBuilder[A, R <: Atomic[A]] extends Serializable {
 private[atomic] object Implicits {
   abstract class Level1 {
     /** Provides an [[AtomicBuilder]] instance for [[AtomicAny]]. */
-    implicit def AtomicRefBuilder[A <: AnyRef] = new AtomicBuilder[A, AtomicAny[A]] {
-      def buildInstance(initialValue: A, padding: PaddingStrategy, allowPlatformIntrinsics: Boolean) =
-        AtomicAny.create(initialValue, padding, allowPlatformIntrinsics)
+    implicit def AtomicRefBuilder[A <: AnyRef]: AtomicBuilder[A, AtomicAny[A]] =
+      new AtomicBuilder[A, AtomicAny[A]] {
+        def buildInstance(initialValue: A, padding: PaddingStrategy, allowPlatformIntrinsics: Boolean) =
+          AtomicAny.create(initialValue, padding, allowPlatformIntrinsics)
 
-      def buildSafeInstance(initialValue: A, padding: PaddingStrategy) =
-        AtomicAny.safe(initialValue, padding)
-    }
+        def buildSafeInstance(initialValue: A, padding: PaddingStrategy) =
+          AtomicAny.safe(initialValue, padding)
+      }
   }
 
   abstract class Level2 extends Level1 {
     /** Provides an [[AtomicBuilder]] instance for [[AtomicNumberAny]]. */
-    implicit def AtomicNumberBuilder[A <: AnyRef: Numeric] =
+    implicit def AtomicNumberBuilder[A <: AnyRef: Numeric]: AtomicBuilder[A, AtomicNumberAny[A]] =
       new AtomicBuilder[A, AtomicNumberAny[A]] {
         def buildInstance(initialValue: A, padding: PaddingStrategy, allowPlatformIntrinsics: Boolean) =
           AtomicNumberAny.create(initialValue, padding, allowPlatformIntrinsics)(implicitly[Numeric[A]])

--- a/monix-execution/shared/src/main/scala/monix/execution/CancelableFuture.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/CancelableFuture.scala
@@ -155,7 +155,7 @@ sealed abstract class CancelableFuture[+A] extends Future[A] with Cancelable { s
     // FutureUtils will use a polyfill for Scala 2.11 and will
     // use the real `transformWith` on Scala 2.12
     val f2 = FutureUtils.transformWith(
-      underlying, { result: Try[A] =>
+      underlying, { (result: Try[A]) =>
         if (isolatedCtx ne null) Local.setContext(isolatedCtx)
         val nextRef: Future[S] =
           try f(result)

--- a/monix-execution/shared/src/main/scala/monix/execution/Scheduler.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/Scheduler.scala
@@ -277,7 +277,6 @@ private[monix] trait SchedulerCompanion {
 }
 
 object Scheduler extends SchedulerCompanionImpl {
-  self: SchedulerCompanion =>
 
   /** The [[Scheduler]] supports processing in batches via an internal
     * trampoline.

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/GenericVar.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/GenericVar.scala
@@ -231,8 +231,8 @@ private[monix] abstract class GenericVar[A, CancelToken] protected (initial: Opt
         true
     }
 
-  @tailrec
   private val readCancel: (Id => Unit) = {
+    @tailrec
     def loop(id: Id): Unit =
       stateRef.get() match {
         case current @ WaitForPut(reads, takes) =>

--- a/monix-execution/shared/src/main/scala/monix/execution/rstreams/SingleAssignSubscription.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/rstreams/SingleAssignSubscription.scala
@@ -67,49 +67,55 @@ final class SingleAssignSubscription private () extends Subscription {
     }
   }
 
-  @tailrec
   def cancel(): Unit = {
-    val current = state.get()
+    @tailrec
+    def loop(): Unit = {
+      val current = state.get()
 
-    current match {
-      case Empty =>
-        if (!state.compareAndSet(current, EmptyCanceled))
-          cancel() // retry
+      current match {
+        case Empty =>
+          if (!state.compareAndSet(current, EmptyCanceled))
+            loop() // retry
 
-      case EmptyRequest(_) =>
-        if (!state.compareAndSet(current, EmptyCanceled))
-          cancel() // retry
+        case EmptyRequest(_) =>
+          if (!state.compareAndSet(current, EmptyCanceled))
+            loop() // retry
 
-      case WithSubscription(s) =>
-        if (!state.compareAndSet(current, Canceled))
-          cancel() // retry
-        else
-          s.cancel()
+        case WithSubscription(s) =>
+          if (!state.compareAndSet(current, Canceled))
+            loop() // retry
+          else
+            s.cancel()
 
-      case EmptyCanceled | Canceled =>
-        () // do nothing
+        case EmptyCanceled | Canceled =>
+          () // do nothing
+      }
     }
+    loop()
   }
 
-  @tailrec
   def request(n: Long): Unit = {
-    val current = state.get()
+    @tailrec
+    def loop(): Unit = {
+      val current = state.get()
 
-    current match {
-      case Empty =>
-        if (!state.compareAndSet(current, EmptyRequest(n)))
-          request(n) // retry
+      current match {
+        case Empty =>
+          if (!state.compareAndSet(current, EmptyRequest(n)))
+            loop() // retry
 
-      case EmptyRequest(previous) =>
-        if (!state.compareAndSet(current, EmptyRequest(previous + n)))
-          request(n) // retry
+        case EmptyRequest(previous) =>
+          if (!state.compareAndSet(current, EmptyRequest(previous + n)))
+            loop() // retry
 
-      case WithSubscription(s) =>
-        s.request(n)
+        case WithSubscription(s) =>
+          s.request(n)
 
-      case EmptyCanceled | Canceled =>
-        ()
+        case EmptyCanceled | Canceled =>
+          ()
+      }
     }
+    loop()
   }
 }
 

--- a/monix-execution/shared/src/test/scala/monix/execution/AckSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/AckSuite.scala
@@ -335,7 +335,7 @@ object AckSuite extends TestSuite[TestScheduler] {
     val source: Future[Ack] = Continue
     val fn: Ack => Ack = {
       val value = true
-      ack: Ack =>
+      (ack: Ack) =>
         ack match {
           case Stop => Stop
           case Continue =>
@@ -354,7 +354,7 @@ object AckSuite extends TestSuite[TestScheduler] {
     val source: Future[Ack] = Future(Continue)
     val fn: Ack => Ack = {
       val value = true
-      ack: Ack =>
+      (ack: Ack) =>
         ack match {
           case Stop => Stop
           case Continue =>
@@ -457,7 +457,7 @@ object AckSuite extends TestSuite[TestScheduler] {
     val source: Future[Ack] = Continue
     val fn: Ack => Ack = {
       val value = true
-      ack: Ack =>
+      (ack: Ack) =>
         ack match {
           case Stop => Stop
           case Continue =>
@@ -476,7 +476,7 @@ object AckSuite extends TestSuite[TestScheduler] {
     val source: Future[Ack] = Future(Continue)
     val fn: Ack => Ack = {
       val value = true
-      ack: Ack =>
+      (ack: Ack) =>
         ack match {
           case Stop => Stop
           case Continue =>

--- a/monix-execution/shared/src/test/scala/monix/execution/BaseLawsSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/BaseLawsSuite.scala
@@ -34,6 +34,8 @@ import scala.concurrent.duration._
 import scala.concurrent.{ExecutionException, Future}
 import scala.util.{Failure, Success, Try}
 
+import scala.language.implicitConversions
+
 trait BaseLawsSuite extends SimpleTestSuite with Checkers with ArbitraryInstances {
   override lazy val checkConfig: Parameters =
     Parameters.default
@@ -134,7 +136,7 @@ trait ArbitraryInstancesBase extends cats.instances.AllInstances with TestUtils 
       }
     }
 
-  implicit lazy val equalityThrowable = new Eq[Throwable] {
+  implicit lazy val equalityThrowable: Eq[Throwable] = new Eq[Throwable] {
     override def eqv(x: Throwable, y: Throwable): Boolean = {
       val ex1 = extractEx(x)
       val ex2 = extractEx(y)

--- a/monix-execution/shared/src/test/scala/monix/execution/FeaturesSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/FeaturesSuite.scala
@@ -24,7 +24,7 @@ import monix.execution.Features.{Flag, Flags}
 import org.scalacheck.Arbitrary
 
 object FeaturesSuite extends SimpleTestSuite with Checkers {
-  implicit val arbFeatures =
+  implicit val arbFeatures: Arbitrary[Features] =
     Arbitrary(implicitly[Arbitrary[Long]].arbitrary.map(l => new Features(l.asInstanceOf[Flags])))
   val allFlags =
     (0 until 64).map(i => (1L << i).asInstanceOf[Flag])

--- a/monix-execution/shared/src/test/scala/monix/execution/atomic/BoxedLong.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/atomic/BoxedLong.scala
@@ -23,7 +23,7 @@ object BoxedLong {
   val MinValue = BoxedLong(Long.MinValue)
   val MaxValue = BoxedLong(Long.MaxValue)
 
-  implicit val numeric = new Numeric[BoxedLong] {
+  implicit val numeric: Numeric[BoxedLong] = new Numeric[BoxedLong] {
     def plus(x: BoxedLong, y: BoxedLong): BoxedLong =
       BoxedLong(x.value + y.value)
     def toDouble(x: BoxedLong): Double =

--- a/monix-execution/shared/src/test/scala/monix/execution/atomic/GenericAtomicSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/atomic/GenericAtomicSuite.scala
@@ -83,7 +83,7 @@ abstract class GenericAtomicSuite[A, R <: Atomic[A]](
     val r = Atomic(zero)
     r.transform {
       def increment(y: A): A = valueFromInt(valueToInt(y) + 1)
-      x: A => increment(x)
+      (x: A) => increment(x)
     }
     assert(r.get() == one)
   }
@@ -132,7 +132,7 @@ abstract class GenericAtomicSuite[A, R <: Atomic[A]](
     val r = Atomic(zero)
     val result = r.transformAndGet {
       def increment(y: A): A = valueFromInt(valueToInt(y) + 1)
-      x: A => increment(x)
+      (x: A) => increment(x)
     }
     assertEquals(result, one)
   }
@@ -180,7 +180,7 @@ abstract class GenericAtomicSuite[A, R <: Atomic[A]](
     val r = Atomic(zero)
     val result = r.getAndTransform {
       def increment(y: A): A = valueFromInt(valueToInt(y) + 1)
-      x: A => increment(x)
+      (x: A) => increment(x)
     }
     assertEquals(result, zero)
     assertEquals(r.get(), one)
@@ -233,7 +233,7 @@ abstract class GenericAtomicSuite[A, R <: Atomic[A]](
     val r = Atomic(zero)
     val result = r.transformAndExtract {
       def increment(y: A): A = valueFromInt(valueToInt(y) + 1)
-      x: A => (x, increment(x))
+      (x: A) => (x, increment(x))
     }
 
     assertEquals(result, zero)


### PR DESCRIPTION
This PR contains syntactic changes in the `monix-execution` module that could be adopted regardless of Dotty.