### PR TITLE
deprecate `Scheduler` extension methods, move them to `Scheduler`

### DIFF
--- a/monix-eval/jvm/src/test/scala/monix/eval/TaskAsyncAutoShiftJVMSuite.scala
+++ b/monix-eval/jvm/src/test/scala/monix/eval/TaskAsyncAutoShiftJVMSuite.scala
@@ -504,7 +504,7 @@ object TaskAsyncAutoShiftJVMSuite extends TestSuite[SchedulerService] {
     repeatTest(1000) {
       val r = Task
         .async[Unit] { cb =>
-          s2.executeAsync(() => cb.onSuccess(()))
+          s2.execute(() => cb.onSuccess(()))
         }
         .flatMap(_ => Task(Thread.currentThread().getName))
         .executeAsync
@@ -538,7 +538,7 @@ object TaskAsyncAutoShiftJVMSuite extends TestSuite[SchedulerService] {
       val dummy = DummyException("dummy")
       val r = Task
         .async[Unit] { cb =>
-          s2.executeAsync(() => cb.onError(dummy))
+          s2.execute(() => cb.onError(dummy))
         }
         .onErrorHandle(e => assertEquals(e, dummy))
         .flatMap(_ => Task(Thread.currentThread().getName))
@@ -574,7 +574,7 @@ object TaskAsyncAutoShiftJVMSuite extends TestSuite[SchedulerService] {
     repeatTest(1000) {
       val r = Task
         .async0[Unit] { (_, cb) =>
-          s2.executeAsync(() => cb.onSuccess(()))
+          s2.execute(() => cb.onSuccess(()))
         }
         .flatMap(_ => Task(Thread.currentThread().getName))
         .executeAsync
@@ -608,7 +608,7 @@ object TaskAsyncAutoShiftJVMSuite extends TestSuite[SchedulerService] {
       val dummy = DummyException("dummy")
       val r = Task
         .async0[Unit] { (_, cb) =>
-          s2.executeAsync(() => cb.onError(dummy))
+          s2.execute(() => cb.onError(dummy))
         }
         .onErrorHandle(e => assertEquals(e, dummy))
         .flatMap(_ => Task(Thread.currentThread().getName))
@@ -644,7 +644,7 @@ object TaskAsyncAutoShiftJVMSuite extends TestSuite[SchedulerService] {
     repeatTest(1000) {
       val r = Task
         .cancelable[Unit] { cb =>
-          s2.executeAsync(() => cb.onSuccess(()))
+          s2.execute(() => cb.onSuccess(()))
           Task(())
         }
         .flatMap(_ => Task(Thread.currentThread().getName))
@@ -682,7 +682,7 @@ object TaskAsyncAutoShiftJVMSuite extends TestSuite[SchedulerService] {
       val dummy = DummyException("dummy")
       val r = Task
         .cancelable[Unit] { cb =>
-          s2.executeAsync(() => cb.onError(dummy))
+          s2.execute(() => cb.onError(dummy))
           Task(())
         }
         .onErrorHandle(e => assertEquals(e, dummy))
@@ -722,7 +722,7 @@ object TaskAsyncAutoShiftJVMSuite extends TestSuite[SchedulerService] {
     repeatTest(1000) {
       val r = Task
         .cancelable0[Unit] { (_, cb) =>
-          s2.executeAsync(() => cb.onSuccess(()))
+          s2.execute(() => cb.onSuccess(()))
           Task(())
         }
         .flatMap(_ => Task(Thread.currentThread().getName))
@@ -760,7 +760,7 @@ object TaskAsyncAutoShiftJVMSuite extends TestSuite[SchedulerService] {
       val dummy = DummyException("dummy")
       val r = Task
         .cancelable0[Unit] { (_, cb) =>
-          s2.executeAsync(() => cb.onError(dummy))
+          s2.execute(() => cb.onError(dummy))
           Task(())
         }
         .onErrorHandle(e => assertEquals(e, dummy))
@@ -800,7 +800,7 @@ object TaskAsyncAutoShiftJVMSuite extends TestSuite[SchedulerService] {
     repeatTest(1000) {
       val r = Task
         .create[Unit] { (_, cb) =>
-          s2.executeAsync(() => cb.onSuccess(()))
+          s2.execute(() => cb.onSuccess(()))
           Task(())
         }
         .flatMap(_ => Task(Thread.currentThread().getName))
@@ -838,7 +838,7 @@ object TaskAsyncAutoShiftJVMSuite extends TestSuite[SchedulerService] {
       val dummy = DummyException("dummy")
       val r = Task
         .create[Unit] { (_, cb) =>
-          s2.executeAsync(() => cb.onError(dummy))
+          s2.execute(() => cb.onError(dummy))
           Task(())
         }
         .onErrorHandle(e => assertEquals(e, dummy))
@@ -879,7 +879,7 @@ object TaskAsyncAutoShiftJVMSuite extends TestSuite[SchedulerService] {
     repeatTest(1000) {
       val r = Task
         .asyncF[Unit] { cb =>
-          Task(s2.executeAsync(() => cb.onSuccess(())))
+          Task(s2.execute(() => cb.onSuccess(())))
         }
         .flatMap(_ => Task(Thread.currentThread().getName))
         .executeAsync
@@ -913,7 +913,7 @@ object TaskAsyncAutoShiftJVMSuite extends TestSuite[SchedulerService] {
       val dummy = DummyException("dummy")
       val r = Task
         .asyncF[Unit] { cb =>
-          Task(s2.executeAsync(() => cb.onError(dummy)))
+          Task(s2.execute(() => cb.onError(dummy)))
         }
         .onErrorHandle(e => assertEquals(e, dummy))
         .flatMap(_ => Task(Thread.currentThread().getName))

--- a/monix-eval/jvm/src/test/scala/monix/eval/TaskCallbackSafetyJVMSuite.scala
+++ b/monix-eval/jvm/src/test/scala/monix/eval/TaskCallbackSafetyJVMSuite.scala
@@ -122,7 +122,7 @@ object TaskCallbackSafetyJVMSuite extends SimpleTestSuite with TestUtils {
     val latchWorkersFinished = new CountDownLatch(WORKERS)
 
     for (_ <- 0 until WORKERS) {
-      sc.executeAsync { () =>
+      sc.execute { () =>
         latchWorkersStart.countDown()
         try {
           f

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskEvalAsync.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskEvalAsync.scala
@@ -38,7 +38,7 @@ private[eval] object TaskEvalAsync {
   private final class EvalAsyncRegister[A](a: () => A) extends ForkedRegister[A] {
 
     def apply(ctx: Task.Context, cb: Callback[Throwable, A]): Unit =
-      ctx.scheduler.executeAsync(() => {
+      ctx.scheduler.execute(() => {
         ctx.frameRef.reset()
         var streamError = true
         try {

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskParSequence.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskParSequence.scala
@@ -110,7 +110,7 @@ private[eval] object TaskParSequence {
         if (tasksCount == 0) {
           // With no tasks available, we need to return an empty sequence;
           // Needs to ensure full async delivery due to implementing ForkedStart!
-          context.scheduler.executeAsync(() => finalCallback.onSuccess(makeBuilder().result()))
+          context.scheduler.execute(() => finalCallback.onSuccess(makeBuilder().result()))
         } else if (tasksCount == 1) {
           // If it's a single task, then execute it directly
           val source = tasks(0).map(r => (makeBuilder() += r).result())

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskParSequenceUnordered.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskParSequenceUnordered.scala
@@ -65,7 +65,7 @@ private[eval] object TaskParSequenceUnordered {
           else {
             // Needs to force async execution in case we had no tasks,
             // due to the contract of ForkedStart
-            s.executeAsync(() => finalCallback.onSuccess(list))
+            s.execute(() => finalCallback.onSuccess(list))
           }
         case _ =>
           () // invalid state

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRunLoop.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRunLoop.scala
@@ -219,7 +219,7 @@ private[eval] object TaskRunLoop {
       if (context.options.localContextPropagation) Local.getContext()
       else null
 
-    context.scheduler.executeAsync { () =>
+    context.scheduler.execute { () =>
       // Checking for the cancellation status after the async boundary;
       // This is consistent with the behavior on `Async` tasks, i.e. check
       // is done *after* the evaluation and *before* signaling the result
@@ -783,7 +783,7 @@ private[eval] object TaskRunLoop {
         ctx.frameRef := nextFrame
         (ctx, cb) => startFull(source, ctx, cb, null, bFirst, bRest, ctx.frameRef())
       } else { (ctx, cb) =>
-        ctx.scheduler.executeAsync(() => startFull(source, ctx, cb, null, bFirst, bRest, 1))
+        ctx.scheduler.execute(() => startFull(source, ctx, cb, null, bFirst, bRest, 1))
       }
 
     Left(

--- a/monix-eval/shared/src/test/scala/monix/eval/BaseLawsSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/BaseLawsSuite.scala
@@ -111,7 +111,7 @@ trait ArbitraryInstancesBase extends monix.execution.ArbitraryInstances {
     def genCancelable: Gen[Task[A]] =
       for (a <- getArbitrary[A]) yield Task.cancelable0[A] { (sc, cb) =>
         val isActive = Atomic(true)
-        sc.executeAsync { () =>
+        sc.execute { () =>
           if (isActive.getAndSet(false))
             cb.onSuccess(a)
         }

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskAsyncSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskAsyncSuite.scala
@@ -31,7 +31,7 @@ object TaskAsyncSuite extends BaseTestSuite {
 
   test("Task.async should execute") { implicit s =>
     val task = Task.async0[Int] { (ec, cb) =>
-      ec.executeAsync { () =>
+      ec.execute { () =>
         cb.onSuccess(1)
       }
     }
@@ -93,7 +93,7 @@ object TaskAsyncSuite extends BaseTestSuite {
 
   test("Task.async0 works for async successful value") { implicit sc =>
     val f = Task
-      .async0[Int]((s, cb) => s.executeAsync(() => cb.onSuccess(1)))
+      .async0[Int]((s, cb) => s.execute(() => cb.onSuccess(1)))
       .runToFuture
 
     sc.tick()
@@ -103,7 +103,7 @@ object TaskAsyncSuite extends BaseTestSuite {
   test("Task.async0 works for async error") { implicit sc =>
     val e = DummyException("dummy")
     val f = Task
-      .async0[Int]((s, cb) => s.executeAsync(() => cb.onError(e)))
+      .async0[Int]((s, cb) => s.execute(() => cb.onError(e)))
       .runToFuture
 
     sc.tick()
@@ -125,7 +125,7 @@ object TaskAsyncSuite extends BaseTestSuite {
 
   test("Task.async0 is memory safe in async flatMap loops") { implicit sc =>
     def signal(n: Int): Task[Int] =
-      Task.async0((s, cb) => s.executeAsync(() => cb.onSuccess(n)))
+      Task.async0((s, cb) => s.execute(() => cb.onSuccess(n)))
 
     def loop(n: Int, acc: Int): Task[Int] =
       signal(n).flatMap { n =>

--- a/monix-execution/js/src/test/scala/monix/execution/internal/AsyncSchedulerJSSuite.scala
+++ b/monix-execution/js/src/test/scala/monix/execution/internal/AsyncSchedulerJSSuite.scala
@@ -45,11 +45,11 @@ object AsyncSchedulerJSSuite extends TestSuite[Scheduler] with TestUtils {
     var effect = 0
     val p = Promise[Int]()
 
-    s.executeAsync { () =>
+    s.execute { () =>
       effect += 1
-      s.executeAsync { () =>
+      s.execute { () =>
         effect += 2
-        s.executeAsync { () =>
+        s.execute { () =>
           effect += 3
           p.success(effect)
           ()

--- a/monix-execution/jvm/src/test/scala/monix/execution/CallbackSafetyJVMSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/CallbackSafetyJVMSuite.scala
@@ -311,7 +311,7 @@ object CallbackSafetyJVMSuite extends TestSuite[SchedulerService] with TestUtils
     val latchWorkersFinished = new CountDownLatch(WORKERS)
 
     for (_ <- 0 until WORKERS) {
-      sc.executeAsync { () =>
+      sc.execute { () =>
         latchWorkersStart.countDown()
         try { f; () }
         finally latchWorkersFinished.countDown()

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/ExecutorSchedulerSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/ExecutorSchedulerSuite.scala
@@ -224,7 +224,7 @@ object ForkJoinSchedulerSuite extends ExecutorSchedulerSuite {
     val finish = new CountDownLatch(1)
 
     for (_ <- 0 until threadsCount)
-      scheduler.executeAsync { () =>
+      scheduler.execute { () =>
         blocking {
           latch.countDown()
           finish.await(15, TimeUnit.MINUTES)

--- a/monix-execution/shared/src/main/scala/monix/execution/AsyncQueue.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/AsyncQueue.scala
@@ -388,7 +388,7 @@ final class AsyncQueue[A] private[monix] (
 
     // Async boundary, for fairness reasons; also creates a full
     // memory barrier between the promise registration and what follows
-    scheduler.executeAsync { () =>
+    scheduler.execute { () =>
       // Trying to read one more time
       val value = f()
       if (filter(value)) {

--- a/monix-execution/shared/src/main/scala/monix/execution/Scheduler.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/Scheduler.scala
@@ -263,6 +263,112 @@ trait Scheduler extends ExecutionContext with UncaughtExceptionReporter with Exe
     Features.empty
     // $COVERAGE-ON$
   }
+
+  /** Schedules a task to run in the future, after `initialDelay`.
+    *
+    * For example the following schedules a message to be printed to
+    * standard output after 5 minutes:
+    * {{{
+    *   val task = scheduler.scheduleOnce(5.minutes) {
+    *     print("Hello, world!")
+    *   }
+    *
+    *   // later, if you change your mind ...
+    *   task.cancel()
+    * }}}
+    *
+    * @param initialDelay is the time to wait until the execution happens
+    * @param action is the callback to be executed
+    * @return a `Cancelable` that can be used to cancel the created task
+    *         before execution.
+    */
+  final def scheduleOnce(initialDelay: FiniteDuration)(action: => Unit): Cancelable =
+    scheduleOnce(initialDelay.length, initialDelay.unit, RunnableAction(action))
+
+  /** Schedules for execution a periodic task that is first executed
+    * after the given initial delay and subsequently with the given
+    * delay between the termination of one execution and the
+    * commencement of the next.
+    *
+    * For example the following schedules a message to be printed to
+    * standard output every 10 seconds with an initial delay of 5
+    * seconds:
+    * {{{
+    *   val task = s.scheduleWithFixedDelay(5.seconds, 10.seconds) {
+    *     print("Repeated message")
+    *   }
+    *
+    *   // later if you change your mind ...
+    *   task.cancel()
+    * }}}
+    *
+    * @param initialDelay is the time to wait until the first execution happens
+    * @param delay is the time to wait between 2 successive executions of the task
+    * @param action is the callback to be executed
+    * @return a cancelable that can be used to cancel the execution of
+    *         this repeated task at any time.
+    */
+  final def scheduleWithFixedDelay(initialDelay: FiniteDuration, delay: FiniteDuration)(action: => Unit): Cancelable =
+    scheduleWithFixedDelay(initialDelay.toMillis, delay.toMillis, MILLISECONDS, RunnableAction(action))
+
+  /** Schedules a periodic task that becomes enabled first after the given
+    * initial delay, and subsequently with the given period. Executions will
+    * commence after `initialDelay` then `initialDelay + period`, then
+    * `initialDelay + 2 * period` and so on.
+    *
+    * If any execution of the task encounters an exception, subsequent executions
+    * are suppressed. Otherwise, the task will only terminate via cancellation or
+    * termination of the scheduler. If any execution of this task takes longer
+    * than its period, then subsequent executions may start late, but will not
+    * concurrently execute.
+    *
+    * For example the following schedules a message to be printed to standard
+    * output approximately every 10 seconds with an initial delay of 5 seconds:
+    * {{{
+    *   val task = scheduler.scheduleAtFixedRate(5.seconds, 10.seconds) {
+    *     print("Repeated message")
+    *   }
+    *
+    *   // later if you change your mind ...
+    *   task.cancel()
+    * }}}
+    *
+    * @param initialDelay is the time to wait until the first execution happens
+    * @param period is the time to wait between 2 successive executions of the task
+    * @param action is the callback to be executed
+    * @return a cancelable that can be used to cancel the execution of
+    *         this repeated task at any time.
+    */
+  final def scheduleAtFixedRate(initialDelay: FiniteDuration, period: FiniteDuration)(action: => Unit): Cancelable =
+    scheduleAtFixedRate(initialDelay.toMillis, period.toMillis, MILLISECONDS, RunnableAction(action))
+
+  /** Schedules the given callback for asynchronous
+    * execution in the thread-pool, but also indicates the
+    * start of a
+    * [[monix.execution.schedulers.TrampolinedRunnable thread-local trampoline]]
+    * in case the scheduler is a
+    * [[monix.execution.schedulers.BatchingScheduler BatchingScheduler]].
+    *
+    * This utility is provided as an optimization. If you don't understand
+    * what this does, then don't worry about it.
+    *
+    * @param cb the callback to execute asynchronously
+    */
+  final def executeAsyncBatch(cb: schedulers.TrampolinedRunnable): Unit = {
+    val r = schedulers.StartAsyncBatchRunnable(cb, this)
+    execute(r)
+  }
+
+  /** Schedules the given callback for immediate execution as a
+    * [[monix.execution.schedulers.TrampolinedRunnable TrampolinedRunnable]].
+    * Depending on the execution context, it might
+    * get executed on the current thread by using an internal
+    * trampoline, so it is still safe from stack-overflow exceptions.
+    *
+    * @param cb the callback to execute asynchronously
+    */
+  final def executeTrampolined(cb: schedulers.TrampolinedRunnable): Unit =
+    execute(cb)
 }
 
 private[monix] trait SchedulerCompanion {
@@ -304,84 +410,19 @@ object Scheduler extends SchedulerCompanionImpl {
   val TRACING = Features.flag(2)
 
   /** Utilities complementing the `Scheduler` interface. */
+  @deprecated("Extension methods are now implemented on `Scheduler` directly", "3.4.0")
   implicit final class Extensions(val source: Scheduler) extends AnyVal with schedulers.ExecuteExtensions {
 
-    /** Schedules a task to run in the future, after `initialDelay`.
-      *
-      * For example the following schedules a message to be printed to
-      * standard output after 5 minutes:
-      * {{{
-      *   val task = scheduler.scheduleOnce(5.minutes) {
-      *     print("Hello, world!")
-      *   }
-      *
-      *   // later, if you change your mind ...
-      *   task.cancel()
-      * }}}
-      *
-      * @param initialDelay is the time to wait until the execution happens
-      * @param action is the callback to be executed
-      * @return a `Cancelable` that can be used to cancel the created task
-      *         before execution.
-      */
+    @deprecated("Extension methods are now implemented on `Scheduler` directly", "3.4.0")
     def scheduleOnce(initialDelay: FiniteDuration)(action: => Unit): Cancelable =
       source.scheduleOnce(initialDelay.length, initialDelay.unit, RunnableAction(action))
 
-    /** Schedules for execution a periodic task that is first executed
-      * after the given initial delay and subsequently with the given
-      * delay between the termination of one execution and the
-      * commencement of the next.
-      *
-      * For example the following schedules a message to be printed to
-      * standard output every 10 seconds with an initial delay of 5
-      * seconds:
-      * {{{
-      *   val task = s.scheduleWithFixedDelay(5.seconds, 10.seconds) {
-      *     print("Repeated message")
-      *   }
-      *
-      *   // later if you change your mind ...
-      *   task.cancel()
-      * }}}
-      *
-      * @param initialDelay is the time to wait until the first execution happens
-      * @param delay is the time to wait between 2 successive executions of the task
-      * @param action is the callback to be executed
-      * @return a cancelable that can be used to cancel the execution of
-      *         this repeated task at any time.
-      */
+    @deprecated("Extension methods are now implemented on `Scheduler` directly", "3.4.0")
     def scheduleWithFixedDelay(initialDelay: FiniteDuration, delay: FiniteDuration)(action: => Unit): Cancelable = {
       source.scheduleWithFixedDelay(initialDelay.toMillis, delay.toMillis, MILLISECONDS, RunnableAction(action))
     }
 
-    /** Schedules a periodic task that becomes enabled first after the given
-      * initial delay, and subsequently with the given period. Executions will
-      * commence after `initialDelay` then `initialDelay + period`, then
-      * `initialDelay + 2 * period` and so on.
-      *
-      * If any execution of the task encounters an exception, subsequent executions
-      * are suppressed. Otherwise, the task will only terminate via cancellation or
-      * termination of the scheduler. If any execution of this task takes longer
-      * than its period, then subsequent executions may start late, but will not
-      * concurrently execute.
-      *
-      * For example the following schedules a message to be printed to standard
-      * output approximately every 10 seconds with an initial delay of 5 seconds:
-      * {{{
-      *   val task = scheduler.scheduleAtFixedRate(5.seconds, 10.seconds) {
-      *     print("Repeated message")
-      *   }
-      *
-      *   // later if you change your mind ...
-      *   task.cancel()
-      * }}}
-      *
-      * @param initialDelay is the time to wait until the first execution happens
-      * @param period is the time to wait between 2 successive executions of the task
-      * @param action is the callback to be executed
-      * @return a cancelable that can be used to cancel the execution of
-      *         this repeated task at any time.
-      */
+    @deprecated("Extension methods are now implemented on `Scheduler` directly", "3.4.0")
     def scheduleAtFixedRate(initialDelay: FiniteDuration, period: FiniteDuration)(action: => Unit): Cancelable = {
       source.scheduleAtFixedRate(initialDelay.toMillis, period.toMillis, MILLISECONDS, RunnableAction(action))
     }

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/ExecuteExtensions.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/ExecuteExtensions.scala
@@ -18,66 +18,21 @@
 package monix.execution
 package schedulers
 
-/** Defines extension methods for [[Scheduler]] meant for	
+/** Defines extension methods for [[Scheduler]] meant for
   * executing runnables.
   */
 private[execution] trait ExecuteExtensions extends Any {
   def source: Scheduler
 
-  /** Schedules the given callback for asynchronous	
-    * execution in the thread-pool.	
-    *
-    * On Scala < 2.12 it is described as a macro, so it	
-    * has zero overhead, being perfectly equivalent with	
-    * `execute(new Runnable { ... })`.	
-    *
-    * On Scala 2.12 because of the Java 8 SAM types integration,	
-    * this extension macro is replaced with a method that takes	
-    * a plain `Runnable` as parameter.	
-    *
-    * @param cb the callback to execute asynchronously	
-    */
+  @deprecated("Use `execute` directly, since Scala 2.11 support has been dropped", "3.4.0")
   def executeAsync(cb: Runnable): Unit =
     source.execute(cb)
 
-  /** Schedules the given callback for asynchronous	
-    * execution in the thread-pool, but also indicates the	
-    * start of a	
-    * [[monix.execution.schedulers.TrampolinedRunnable thread-local trampoline]]
-    * in case the scheduler is a	
-    * [[monix.execution.schedulers.BatchingScheduler BatchingScheduler]].	
-    *
-    * This utility is provided as an optimization. If you don't understand	
-    * what this does, then don't worry about it.	
-    *
-    * On Scala < 2.12 it is described as a macro, so it	
-    * has zero overhead. On Scala 2.12 because of the Java 8 SAM	
-    * types integration, this extension macro is replaced with a	
-    * method that takes a plain `TrampolinedRunnable` as parameter.	
-    *
-    * @param cb the callback to execute asynchronously	
-    */
-  def executeAsyncBatch(cb: TrampolinedRunnable): Unit = {
-    val r = StartAsyncBatchRunnable(cb, source)
-    source.execute(r)
-  }
+  @deprecated("Extension methods are now implemented on `Scheduler` directly", "3.4.0")
+  def executeAsyncBatch(cb: TrampolinedRunnable): Unit =
+    source.executeAsyncBatch(cb)
 
-  /** Schedules the given callback for immediate execution as a	
-    * [[monix.execution.schedulers.TrampolinedRunnable TrampolinedRunnable]].	
-    * Depending on the execution context, it might	
-    * get executed on the current thread by using an internal	
-    * trampoline, so it is still safe from stack-overflow exceptions.	
-    *
-    * On Scala < 2.12 it is described as a macro, so it	
-    * has zero overhead, being perfectly equivalent with	
-    * `execute(new TrampolinedRunnable { ... })`.	
-    *
-    * On Scala 2.12 because of the Java 8 SAM types integration,	
-    * this extension macro is replaced with a method that takes	
-    * a plain `TrampolinedRunnable` as parameter.	
-    *
-    * @param cb the callback to execute asynchronously	
-    */
+  @deprecated("Extension methods are now implemented on `Scheduler` directly", "3.4.0")
   def executeTrampolined(cb: TrampolinedRunnable): Unit =
-    source.execute(cb)
+    source.executeTrampolined(cb)
 }

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/ReferenceScheduler.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/ReferenceScheduler.scala
@@ -28,9 +28,9 @@ import monix.execution.{ExecutionModel => ExecModel}
 /** Helper for building a [[Scheduler]].
   *
   * You can inherit from this class and provided a correct
-  * [[Scheduler.scheduleOnce(initialDelay* scheduleOnce]]
-  * you'll get [[Scheduler.scheduleWithFixedDelay]] and
-  * [[Scheduler.scheduleAtFixedRate]] for free.
+  * [[Scheduler.scheduleOnce(initialDelay:Long* scheduleOnce]]
+  * you'll get [[Scheduler.scheduleWithFixedDelay(initialDelay:Long*]] and
+  * [[Scheduler.scheduleAtFixedRate(initialDelay:Long*]] for free.
   */
 trait ReferenceScheduler extends Scheduler {
   override def clockRealTime(unit: TimeUnit): Long =

--- a/monix-execution/shared/src/test/scala/monix/execution/CancelableFutureSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/CancelableFutureSuite.scala
@@ -91,7 +91,7 @@ object CancelableFutureSuite extends TestSuite[TestScheduler] {
     val b = BooleanCancelable()
     val fa = CancelableFuture.async[Int] { _ =>
       val ch = ChainedCancelable()
-      s.executeAsync(() => { ch := b; () })
+      s.execute(() => { ch := b; () })
       ch
     }
 
@@ -107,7 +107,7 @@ object CancelableFutureSuite extends TestSuite[TestScheduler] {
     val b = BooleanCancelable()
     val fa = CancelableFuture.async[Int] { _ =>
       val ch = ChainedCancelable()
-      s.executeAsync(() => { ch := b; () })
+      s.execute(() => { ch := b; () })
       ch
     }
 
@@ -561,7 +561,7 @@ object CancelableFutureSuite extends TestSuite[TestScheduler] {
 
   test("async works for success") { implicit s =>
     val fa = CancelableFuture.async[Int] { cb =>
-      s.executeAsync(() => cb(Success(1)))
+      s.execute(() => cb(Success(1)))
       Cancelable.empty
     }
 
@@ -572,7 +572,7 @@ object CancelableFutureSuite extends TestSuite[TestScheduler] {
   test("async works for failure") { implicit s =>
     val dummy = DummyException("dummy")
     val fa = CancelableFuture.async[Int] { cb =>
-      s.executeAsync(() => cb(Failure(dummy)))
+      s.execute(() => cb(Failure(dummy)))
       Cancelable.empty
     }
 

--- a/monix-execution/shared/src/test/scala/monix/execution/schedulers/ReferenceSchedulerSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/schedulers/ReferenceSchedulerSuite.scala
@@ -105,7 +105,7 @@ object ReferenceSchedulerSuite extends SimpleTestSuite {
     val ws = s.withExecutionModel(AlwaysAsyncExecution)
 
     var effect = 0
-    ws.executeAsync { () =>
+    ws.execute { () =>
       effect += 1
     }
 
@@ -138,7 +138,7 @@ object ReferenceSchedulerSuite extends SimpleTestSuite {
     val ws = s.withExecutionModel(AlwaysAsyncExecution)
 
     val dummy = new RuntimeException("dummy")
-    ws.executeAsync { () =>
+    ws.execute { () =>
       throw dummy
     }
 

--- a/monix-execution/shared/src/test/scala/monix/execution/schedulers/TestSchedulerSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/schedulers/TestSchedulerSuite.scala
@@ -36,7 +36,7 @@ object TestSchedulerSuite extends TestSuite[TestScheduler] {
 
   test("should execute asynchronously") { s =>
     var wasExecuted = false
-    s.executeAsync { () =>
+    s.execute { () =>
       wasExecuted = true
     }
     assert(!wasExecuted)
@@ -48,10 +48,10 @@ object TestSchedulerSuite extends TestSuite[TestScheduler] {
   test("should execute the whole stack") { s =>
     var iterations = 0
 
-    s.executeAsync { () =>
-      s.executeAsync { () =>
+    s.execute { () =>
+      s.execute { () =>
         iterations += 1
-        s.executeAsync { () =>
+        s.execute { () =>
           iterations += 1
         }
       }
@@ -59,9 +59,9 @@ object TestSchedulerSuite extends TestSuite[TestScheduler] {
       assert(iterations == 0)
       iterations += 1
 
-      s.executeAsync { () =>
+      s.execute { () =>
         iterations += 1
-        s.executeAsync { () =>
+        s.execute { () =>
           iterations += 1
         }
       }
@@ -229,7 +229,7 @@ object TestSchedulerSuite extends TestSuite[TestScheduler] {
 
   test("execute extension method") { implicit s =>
     var wasExecuted = false
-    s.executeAsync { () =>
+    s.execute { () =>
       wasExecuted = true
     }
 

--- a/monix-execution/shared/src/test/scala/monix/execution/schedulers/TrampolineSchedulerSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/schedulers/TrampolineSchedulerSuite.scala
@@ -40,11 +40,11 @@ object TrampolineSchedulerSuite extends TestSuite[(Scheduler, TestScheduler)] {
       var effect = 0
       val p = Promise[Int]()
 
-      s.executeAsync { () =>
+      s.execute { () =>
         effect += 1
-        s.executeAsync { () =>
+        s.execute { () =>
           effect += 2
-          s.executeAsync { () =>
+          s.execute { () =>
             effect += 3
             p.success(effect)
             ()
@@ -142,11 +142,11 @@ object TrampolineSchedulerSuite extends TestSuite[(Scheduler, TestScheduler)] {
       if (!Platform.isJVM) ignore("test relevant only for the JVM")
 
       var effect = 0
-      s.executeAsync { () =>
-        s.executeAsync { () =>
+      s.execute { () =>
+        s.execute { () =>
           effect += 20
         }
-        s.executeAsync { () =>
+        s.execute { () =>
           effect += 20
         }
 

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/ConcatMapConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/ConcatMapConcurrencySuite.scala
@@ -75,7 +75,7 @@ object ConcatMapConcurrencySuite extends BaseConcurrencySuite {
 
       // Creating race condition
       if (i % 2 == 0) {
-        s.executeAsync(() => c.cancel())
+        s.execute(() => c.cancel())
       } else {
         c.cancel()
       }
@@ -87,7 +87,7 @@ object ConcatMapConcurrencySuite extends BaseConcurrencySuite {
     def one(p: Promise[Unit])(x: Long): Observable[Long] =
       Observable.unsafeCreate { sub =>
         val ref = BooleanCancelable { () => p.trySuccess(()); () }
-        sub.scheduler.executeAsync { () =>
+        sub.scheduler.execute { () =>
           if (!ref.isCanceled) {
             Observable.now(x).unsafeSubscribeFn(sub)
             ()
@@ -109,7 +109,7 @@ object ConcatMapConcurrencySuite extends BaseConcurrencySuite {
         .subscribe()
 
       // Creating race condition
-      s.executeAsync(() => c.cancel())
+      s.execute(() => c.cancel())
       Await.result(p.future, cancelTimeout)
     }
   }
@@ -128,7 +128,7 @@ object ConcatMapConcurrencySuite extends BaseConcurrencySuite {
         .subscribe()
 
       // Creating race condition
-      s.executeAsync(() => c.cancel())
+      s.execute(() => c.cancel())
       Await.result(p.future, cancelTimeout)
     }
   }

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/FlatScanConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/FlatScanConcurrencySuite.scala
@@ -76,7 +76,7 @@ object FlatScanConcurrencySuite extends BaseConcurrencySuite {
 
       // Creating race condition
       if (i % 2 == 0) {
-        s.executeAsync(() => c.cancel())
+        s.execute(() => c.cancel())
       } else {
         c.cancel()
       }
@@ -88,7 +88,7 @@ object FlatScanConcurrencySuite extends BaseConcurrencySuite {
     def one(p: Promise[Unit])(acc: Long, x: Long): Observable[Long] =
       Observable.unsafeCreate { sub =>
         val ref = BooleanCancelable { () => p.trySuccess(()); () }
-        sub.scheduler.executeAsync { () =>
+        sub.scheduler.execute { () =>
           if (!ref.isCanceled) {
             Observable.now(x).unsafeSubscribeFn(sub)
             ()
@@ -110,7 +110,7 @@ object FlatScanConcurrencySuite extends BaseConcurrencySuite {
         .subscribe()
 
       // Creating race condition
-      s.executeAsync(() => c.cancel())
+      s.execute(() => c.cancel())
       Await.result(p.future, cancelTimeout)
     }
   }
@@ -129,7 +129,7 @@ object FlatScanConcurrencySuite extends BaseConcurrencySuite {
         .subscribe()
 
       // Creating race condition
-      s.executeAsync(() => c.cancel())
+      s.execute(() => c.cancel())
       Await.result(p.future, cancelTimeout)
     }
   }

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/MapTaskConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/MapTaskConcurrencySuite.scala
@@ -73,7 +73,7 @@ object MapTaskConcurrencySuite extends BaseConcurrencySuite {
 
       // Creating race condition
       if (i % 2 == 0) {
-        s.executeAsync(() => c.cancel())
+        s.execute(() => c.cancel())
       } else {
         c.cancel()
       }

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/ScanTaskConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/ScanTaskConcurrencySuite.scala
@@ -74,7 +74,7 @@ object ScanTaskConcurrencySuite extends BaseConcurrencySuite {
 
       // Creating race condition
       if (i % 2 == 0) {
-        s.executeAsync(() => c.cancel())
+        s.execute(() => c.cancel())
       } else {
         c.cancel()
       }

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/issues/Issue908Suite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/issues/Issue908Suite.scala
@@ -48,8 +48,8 @@ object Issue908Suite extends TestSuite[SchedulerService] {
   test("broken tasks test (1)") { implicit sc =>
     for (_ <- 0 until CYCLES) {
       val task = Task.async[String] { cb =>
-        sc.executeAsync(() => cb.onSuccess("1"))
-        sc.executeAsync(() => cb.onSuccess("2"))
+        sc.execute(() => cb.onSuccess("1"))
+        sc.execute(() => cb.onSuccess("2"))
       }
 
       val f = Task.race(task, task).runToFuture
@@ -65,8 +65,8 @@ object Issue908Suite extends TestSuite[SchedulerService] {
   test("broken tasks test (2)") { implicit sc =>
     for (_ <- 0 until CYCLES) {
       val task = Task.async[String] { cb =>
-        sc.executeAsync(() => cb.onSuccess("1"))
-        sc.executeAsync(() => cb.onSuccess("2"))
+        sc.execute(() => cb.onSuccess("1"))
+        sc.execute(() => cb.onSuccess("2"))
       }
 
       val f = Task.raceMany((0 until CONCURRENT_TASKS).map(_ => task)).runToFuture
@@ -79,8 +79,8 @@ object Issue908Suite extends TestSuite[SchedulerService] {
   test("broken tasks test (3)") { implicit sc =>
     for (_ <- 0 until CYCLES) {
       val task = Task.async[String] { cb =>
-        sc.executeAsync(() => cb.onSuccess("1"))
-        sc.executeAsync(() => cb.onSuccess("2"))
+        sc.execute(() => cb.onSuccess("1"))
+        sc.execute(() => cb.onSuccess("2"))
       }
 
       val f = task.timeout(1.millis).materialize.runToFuture

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/LoadBalanceConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/LoadBalanceConsumer.scala
@@ -79,7 +79,7 @@ private[reactive] final class LoadBalanceConsumer[-In, R](parallelism: Int, cons
           // Forcing an asynchronous boundary, to avoid any possible
           // initialization issues (in building subscribersQueue) or
           // stack overflows and other problems
-          def cancel(): Unit = scheduler.executeAsync { () =>
+          def cancel(): Unit = scheduler.execute { () =>
             // We are required to synchronize, because we need to
             // make sure that subscribersQueue is fully created before
             // triggering any cancellation!
@@ -214,7 +214,7 @@ private[reactive] final class LoadBalanceConsumer[-In, R](parallelism: Int, cons
       private def signalNext(out: IndexedSubscriber[In], elem: In): Unit = {
         // We are forcing an asynchronous boundary here, since we
         // don't want to block the main thread!
-        scheduler.executeAsync { () =>
+        scheduler.execute { () =>
           try out.out.onNext(elem).syncOnComplete {
             case Success(ack) =>
               ack match {

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressureBatchedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressureBatchedSuite.scala
@@ -134,7 +134,7 @@ object OverflowStrategyBackPressureBatchedSuite extends TestSuite[TestScheduler]
     val buffer = BufferedSubscriber.batched[Int](underlying, 1000, MultiProducer)
     def loop(n: Int): Unit =
       if (n > 0)
-        s.executeAsync { () =>
+        s.execute { () =>
           buffer.onNext(n); loop(n - 1)
         } else
         buffer.onComplete()
@@ -172,7 +172,7 @@ object OverflowStrategyBackPressureBatchedSuite extends TestSuite[TestScheduler]
     val buffer = BufferedSubscriber.batched[Int](underlying, 512, MultiProducer)
     def loop(n: Int): Unit =
       if (n > 0)
-        s.executeAsync { () =>
+        s.execute { () =>
           buffer.onNext(n); loop(n - 1)
         } else
         buffer.onComplete()

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressureSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressureSuite.scala
@@ -131,7 +131,7 @@ object OverflowStrategyBackPressureSuite extends TestSuite[TestScheduler] {
     val buffer = BufferedSubscriber[Int](underlying, BackPressure(1000))
     def loop(n: Int): Unit =
       if (n > 0)
-        s.executeAsync { () =>
+        s.execute { () =>
           buffer.onNext(n); loop(n - 1)
         } else
         buffer.onComplete()
@@ -169,7 +169,7 @@ object OverflowStrategyBackPressureSuite extends TestSuite[TestScheduler] {
     val buffer = BufferedSubscriber[Int](underlying, BackPressure(512))
     def loop(n: Int): Unit =
       if (n > 0)
-        s.executeAsync { () =>
+        s.execute { () =>
           buffer.onNext(n); loop(n - 1)
         } else
         buffer.onComplete()

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewAndSignalSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewAndSignalSuite.scala
@@ -98,7 +98,7 @@ object OverflowStrategyDropNewAndSignalSuite extends TestSuite[TestScheduler] {
 
     def loop(n: Int): Unit =
       if (n > 0)
-        s.executeAsync { () =>
+        s.execute { () =>
           buffer.onNext(n); loop(n - 1)
         } else
         buffer.onComplete()

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewSuite.scala
@@ -84,7 +84,7 @@ object OverflowStrategyDropNewSuite extends TestSuite[TestScheduler] {
 
     def loop(n: Int): Unit =
       if (n > 0)
-        s.executeAsync { () =>
+        s.execute { () =>
           buffer.onNext(n); loop(n - 1)
         } else
         buffer.onComplete()
@@ -146,7 +146,7 @@ object OverflowStrategyDropNewSuite extends TestSuite[TestScheduler] {
     val buffer = BufferedSubscriber[Int](Subscriber(underlying, s), DropNew(10000))
     def loop(n: Int): Unit =
       if (n > 0)
-        s.executeAsync { () =>
+        s.execute { () =>
           buffer.onNext(n); loop(n - 1)
         } else
         buffer.onComplete()

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyFailSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyFailSuite.scala
@@ -87,7 +87,7 @@ object OverflowStrategyFailSuite extends TestSuite[TestScheduler] {
 
     def loop(n: Int): Unit =
       if (n > 0)
-        s.executeAsync { () =>
+        s.execute { () =>
           buffer.onNext(n); loop(n - 1)
         } else
         buffer.onComplete()


### PR DESCRIPTION
Dotty does not trigger `implicit class`es for extension methods that overload existing methods.