### PR TITLE
add missing method implementation to `JSArrayQueue`

### DIFF
--- a/monix-execution/js/src/main/scala/monix/execution/internal/collection/JSArrayQueue.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/internal/collection/JSArrayQueue.scala
@@ -39,6 +39,8 @@ private[monix] final class JSArrayQueue[A] private (_size: Int, triggerEx: Int =
     queue.length - offset >= capacity
   override def length: Int =
     queue.length - offset
+  override def size: Int =
+    length
   override def isEmpty: Boolean =
     queue.length - offset == 0
 


### PR DESCRIPTION
This implementation was missing in `JSArrayQueue`. Inexplicably, Dotty complained, whereas Scala 2 didn't see a problem:

```
[error] -- Error: /home/lars/proj/monix/monix/monix-execution/js/src/main/scala/monix/execution/internal/collection/JSArrayQueue.scala:28:27 
[error] 28 |private[monix] final class JSArrayQueue[A] private (_size: Int, triggerEx: Int => Throwable = null)
[error]    |                           ^
[error]    |class JSArrayQueue needs to be abstract, since def size: => Int is not defined 
```