### PR TITLE
Publish selector subscription issue (#1292)

### DIFF
--- a/monix-reactive/shared/src/main/scala/monix/reactive/observables/ChainedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observables/ChainedObservable.scala
@@ -66,14 +66,14 @@ object ChainedObservable {
     // Subscription can be synchronous, which can trigger really
     // weird ordering issues, therefore we need a light async boundary
     // to delay it and force ordering; plus it protects from stack overflows
-    out.scheduler.executeTrampolined { () =>
       source match {
         case _: ChainedObservable[_] =>
-          source.asInstanceOf[ChainedObservable[A]].unsafeSubscribeFn(conn, out)
+          out.scheduler.executeTrampolined { () =>
+            source.asInstanceOf[ChainedObservable[A]].unsafeSubscribeFn(conn, out)
+          }
         case _ =>
           conn := source.unsafeSubscribeFn(out)
           ()
-      }
     }
   }
 }

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/PublishSelectorSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/PublishSelectorSuite.scala
@@ -22,6 +22,7 @@ import monix.execution.atomic.Atomic
 import monix.reactive.{BaseTestSuite, Observable}
 
 import scala.util.Success
+import scala.concurrent.duration._
 
 object PublishSelectorSuite extends BaseTestSuite {
   test("publishSelector sanity test") { implicit s =>
@@ -59,5 +60,15 @@ object PublishSelectorSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(2000)))
     assertEquals(isStarted.get(), 1)
     assert(isCanceled.get(), "isCanceled")
+  }
+
+  test("publish selector respects subscription when used with chained operators") { implicit s =>
+    val ob = Observable.now(1)
+      .publishSelector(_.takeLast(1))
+      .takeLast(1)
+
+    s.tick(1.second)
+    val f = ob.headL.runToFuture
+    assertEquals(f.value, Some(Success(1)))
   }
 }


### PR DESCRIPTION
This is an attempt to show/help to further investigate the issue with publish selector raised on the ticket #1292.

As @alexandru mentioned, this is a timing on subscription, which only happens when a publish selector along with two `ChainedObservable` operators, one that applies to the hot one (within the brackets) and used after.

As you can appreciate in the ticket the issue was reported with `++` but for simplicity, I have added a test that uses `takeLast`, which is also a chained one.

The issue can be fixed by avoiding the trampolined execution on the subscription of the `ChainedObservable`, thus being representing a synchronous subscription flow. Probably there are important reasons why done in that way, so I am unsure if that change would impact negatively on other functionalities. So would be good if someone know of a better alternative to solve it :)