### PR TITLE
Updated current year in copyright header (2021)

### DIFF
--- a/benchmarks/shared/src/main/scala/monix/benchmarks/ArrayStackBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/ArrayStackBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/ChunkedEvalFilterMapSumBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/ChunkedEvalFilterMapSumBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/ChunkedMapFilterSumBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/ChunkedMapFilterSumBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalAttemptBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalAttemptBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalDeepBindBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalDeepBindBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalHandleErrorBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalHandleErrorBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalMapCallsBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalMapCallsBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalMapStreamBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalMapStreamBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalShallowBindBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/CoevalShallowBindBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/IterantMapFoldBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/IterantMapFoldBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/MapParallelObservableBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/MapParallelObservableBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/ObservableConcatMapBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/ObservableConcatMapBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/ObservableMapAccumulateBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/ObservableMapAccumulateBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/ObservableMapTaskBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/ObservableMapTaskBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/ObservableMergeBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/ObservableMergeBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/TaskAttemptBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/TaskAttemptBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/TaskDeepBindBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/TaskDeepBindBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/TaskHandleErrorBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/TaskHandleErrorBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/TaskMapCallsBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/TaskMapCallsBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/TaskMapStreamBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/TaskMapStreamBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/TaskSequenceBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/TaskSequenceBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/TaskShallowBindBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/TaskShallowBindBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/TrampolinedRunnableBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/TrampolinedRunnableBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/package.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/vnext/src/main/scala/monix/benchmarks/AsyncQueueBenchmark.scala
+++ b/benchmarks/vnext/src/main/scala/monix/benchmarks/AsyncQueueBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/vnext/src/main/scala/monix/benchmarks/ObservableIteratorBenchmark.scala
+++ b/benchmarks/vnext/src/main/scala/monix/benchmarks/ObservableIteratorBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/vnext/src/main/scala/monix/benchmarks/TaskShiftBenchmark.scala
+++ b/benchmarks/vnext/src/main/scala/monix/benchmarks/TaskShiftBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/vprev/src/main/scala/monix/benchmarks/AsyncQueueBenchmark.scala
+++ b/benchmarks/vprev/src/main/scala/monix/benchmarks/AsyncQueueBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmarks/vprev/src/main/scala/monix/benchmarks/TaskShiftBenchmark.scala
+++ b/benchmarks/vprev/src/main/scala/monix/benchmarks/TaskShiftBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/build.sbt
+++ b/build.sbt
@@ -229,7 +229,7 @@ lazy val sharedSettings = pgpSettings ++ Seq(
   licenses := Seq("APL2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")),
   homepage := Some(url("https://monix.io")),
   headerLicense := Some(HeaderLicense.Custom(
-    """|Copyright (c) 2014-2020 by The Monix Project Developers.
+    """|Copyright (c) 2014-2021 by The Monix Project Developers.
        |See the project homepage at: https://monix.io
        |
        |Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/js/src/main/scala/monix/catnap/internal/FutureLiftForPlatform.scala
+++ b/monix-catnap/js/src/main/scala/monix/catnap/internal/FutureLiftForPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/jvm/src/main/scala/monix/catnap/internal/FutureLiftForPlatform.scala
+++ b/monix-catnap/jvm/src/main/scala/monix/catnap/internal/FutureLiftForPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/jvm/src/test/scala/monix/catnap/CatsEffectIssue380Suite.scala
+++ b/monix-catnap/jvm/src/test/scala/monix/catnap/CatsEffectIssue380Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/jvm/src/test/scala/monix/catnap/ConcurrentChannelJVMSuite.scala
+++ b/monix-catnap/jvm/src/test/scala/monix/catnap/ConcurrentChannelJVMSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/jvm/src/test/scala/monix/catnap/ConcurrentQueueJVMSuite.scala
+++ b/monix-catnap/jvm/src/test/scala/monix/catnap/ConcurrentQueueJVMSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/jvm/src/test/scala/monix/catnap/FutureLiftJava8Suite.scala
+++ b/monix-catnap/jvm/src/test/scala/monix/catnap/FutureLiftJava8Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/jvm/src/test/scala/monix/catnap/MVarJVMSuite.scala
+++ b/monix-catnap/jvm/src/test/scala/monix/catnap/MVarJVMSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/jvm/src/test/scala/monix/catnap/SemaphoreJVMSuite.scala
+++ b/monix-catnap/jvm/src/test/scala/monix/catnap/SemaphoreJVMSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/main/scala/monix/catnap/CancelableF.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/CancelableF.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/main/scala/monix/catnap/ChannelF.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/ChannelF.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/main/scala/monix/catnap/CircuitBreaker.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/CircuitBreaker.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/main/scala/monix/catnap/ConcurrentChannel.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/ConcurrentChannel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/main/scala/monix/catnap/ConcurrentQueue.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/ConcurrentQueue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/main/scala/monix/catnap/ConsumerF.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/ConsumerF.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/main/scala/monix/catnap/FutureLift.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/FutureLift.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/main/scala/monix/catnap/MVar.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/MVar.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/main/scala/monix/catnap/OrElse.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/OrElse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/main/scala/monix/catnap/ProducerF.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/ProducerF.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/main/scala/monix/catnap/SchedulerEffect.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/SchedulerEffect.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/main/scala/monix/catnap/Semaphore.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/Semaphore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/main/scala/monix/catnap/cancelables/AssignableCancelableF.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/cancelables/AssignableCancelableF.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/main/scala/monix/catnap/cancelables/BooleanCancelableF.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/cancelables/BooleanCancelableF.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/main/scala/monix/catnap/cancelables/SingleAssignCancelableF.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/cancelables/SingleAssignCancelableF.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/main/scala/monix/catnap/internal/AsyncUtils.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/internal/AsyncUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/main/scala/monix/catnap/internal/ParallelApplicative.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/internal/ParallelApplicative.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/main/scala/monix/catnap/internal/QueueHelpers.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/internal/QueueHelpers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/main/scala/monix/catnap/syntax.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/syntax.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/main/scala/monix/execution/CancelableFutureCatsInstances.scala
+++ b/monix-catnap/shared/src/main/scala/monix/execution/CancelableFutureCatsInstances.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/main/scala/monix/execution/package.scala
+++ b/monix-catnap/shared/src/main/scala/monix/execution/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/test/scala/monix/catnap/CancelableFSuite.scala
+++ b/monix-catnap/shared/src/test/scala/monix/catnap/CancelableFSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/test/scala/monix/catnap/CircuitBreakerSuite.scala
+++ b/monix-catnap/shared/src/test/scala/monix/catnap/CircuitBreakerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/test/scala/monix/catnap/ConcurrentChannelSuite.scala
+++ b/monix-catnap/shared/src/test/scala/monix/catnap/ConcurrentChannelSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/test/scala/monix/catnap/ConcurrentQueueSuite.scala
+++ b/monix-catnap/shared/src/test/scala/monix/catnap/ConcurrentQueueSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/test/scala/monix/catnap/FutureLiftSuite.scala
+++ b/monix-catnap/shared/src/test/scala/monix/catnap/FutureLiftSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/test/scala/monix/catnap/MVarConcurrentSuite.scala
+++ b/monix-catnap/shared/src/test/scala/monix/catnap/MVarConcurrentSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/test/scala/monix/catnap/Overrides.scala
+++ b/monix-catnap/shared/src/test/scala/monix/catnap/Overrides.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/test/scala/monix/catnap/ReferenceSchedulerEffectSuite.scala
+++ b/monix-catnap/shared/src/test/scala/monix/catnap/ReferenceSchedulerEffectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/test/scala/monix/catnap/SemaphoreSuite.scala
+++ b/monix-catnap/shared/src/test/scala/monix/catnap/SemaphoreSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/test/scala/monix/catnap/TestSchedulerEffectSuite.scala
+++ b/monix-catnap/shared/src/test/scala/monix/catnap/TestSchedulerEffectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/test/scala/monix/catnap/cancelables/AssignableCancelableFSuite.scala
+++ b/monix-catnap/shared/src/test/scala/monix/catnap/cancelables/AssignableCancelableFSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/test/scala/monix/catnap/cancelables/BooleanCancelableFSuite.scala
+++ b/monix-catnap/shared/src/test/scala/monix/catnap/cancelables/BooleanCancelableFSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/test/scala/monix/catnap/cancelables/SingleAssignCancelableFSuite.scala
+++ b/monix-catnap/shared/src/test/scala/monix/catnap/cancelables/SingleAssignCancelableFSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/test/scala/monix/execution/CallbackInstanceSuite.scala
+++ b/monix-catnap/shared/src/test/scala/monix/execution/CallbackInstanceSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-catnap/shared/src/test/scala/monix/execution/TypeClassLawsForCancelableFutureSuite.scala
+++ b/monix-catnap/shared/src/test/scala/monix/execution/TypeClassLawsForCancelableFutureSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/js/src/main/scala/monix/eval/internal/TaskRunSyncUnsafe.scala
+++ b/monix-eval/js/src/main/scala/monix/eval/internal/TaskRunSyncUnsafe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/js/src/main/scala/monix/eval/internal/TracingPlatform.scala
+++ b/monix-eval/js/src/main/scala/monix/eval/internal/TracingPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/jvm/src/main/java/monix/eval/internal/TracingPlatform.java
+++ b/monix-eval/jvm/src/main/java/monix/eval/internal/TracingPlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/jvm/src/main/scala/monix/eval/internal/TaskRunSyncUnsafe.scala
+++ b/monix-eval/jvm/src/main/scala/monix/eval/internal/TaskRunSyncUnsafe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/jvm/src/test/scala/monix/eval/TaskAsyncAutoShiftJVMSuite.scala
+++ b/monix-eval/jvm/src/test/scala/monix/eval/TaskAsyncAutoShiftJVMSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/jvm/src/test/scala/monix/eval/TaskBlockingSuite.scala
+++ b/monix-eval/jvm/src/test/scala/monix/eval/TaskBlockingSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/jvm/src/test/scala/monix/eval/TaskCallbackSafetyJVMSuite.scala
+++ b/monix-eval/jvm/src/test/scala/monix/eval/TaskCallbackSafetyJVMSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/jvm/src/test/scala/monix/eval/TaskExecuteWithLocalContextSuite.scala
+++ b/monix-eval/jvm/src/test/scala/monix/eval/TaskExecuteWithLocalContextSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/jvm/src/test/scala/monix/eval/TaskIssue993Suite.scala
+++ b/monix-eval/jvm/src/test/scala/monix/eval/TaskIssue993Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/jvm/src/test/scala/monix/eval/TaskLikeConversionsJava8Suite.scala
+++ b/monix-eval/jvm/src/test/scala/monix/eval/TaskLikeConversionsJava8Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/jvm/src/test/scala/monix/eval/TaskLocalJVMSuite.scala
+++ b/monix-eval/jvm/src/test/scala/monix/eval/TaskLocalJVMSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/jvm/src/test/scala/monix/eval/TaskRejectedExecutionSuite.scala
+++ b/monix-eval/jvm/src/test/scala/monix/eval/TaskRejectedExecutionSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/jvm/src/test/scala/monix/eval/TypeClassLawsForTaskRunSyncUnsafeSuite.scala
+++ b/monix-eval/jvm/src/test/scala/monix/eval/TypeClassLawsForTaskRunSyncUnsafeSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/Coeval.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Coeval.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/CoevalLift.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/CoevalLift.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/CoevalLike.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/CoevalLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/Fiber.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Fiber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/TaskApp.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/TaskApp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/TaskLift.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/TaskLift.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/TaskLike.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/TaskLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/TaskLocal.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/TaskLocal.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/instances/CatsAsyncForTask.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/instances/CatsAsyncForTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/instances/CatsBaseForTask.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/instances/CatsBaseForTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/instances/CatsEffectForTask.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/instances/CatsEffectForTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/instances/CatsMonadToMonoid.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/instances/CatsMonadToMonoid.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/instances/CatsParallelForTask.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/instances/CatsParallelForTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/instances/CatsSyncForCoeval.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/instances/CatsSyncForCoeval.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/CoevalBracket.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/CoevalBracket.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/CoevalDeprecated.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/CoevalDeprecated.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/CoevalRunLoop.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/CoevalRunLoop.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/CoevalStackTracedContext.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/CoevalStackTracedContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/CoevalTracing.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/CoevalTracing.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/ForkedRegister.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/ForkedRegister.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/ForwardCancelable.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/ForwardCancelable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/FrameIndexRef.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/FrameIndexRef.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/LazyVal.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/LazyVal.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/StackFrame.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/StackFrame.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/StackTracedContext.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/StackTracedContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskBracket.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskBracket.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskCancellation.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskCancellation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskConnection.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskConnection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskConnectionComposite.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskConnectionComposite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskConnectionRef.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskConnectionRef.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskConversions.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskConversions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskCreate.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskCreate.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDeferAction.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDeferAction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDeprecated.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDeprecated.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDoOnCancel.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskDoOnCancel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskEffect.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskEffect.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskEvalAsync.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskEvalAsync.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskExecuteOn.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskExecuteOn.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskExecuteWithModel.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskExecuteWithModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskExecuteWithOptions.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskExecuteWithOptions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskFromFuture.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskFromFuture.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskMapBoth.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskMapBoth.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskMemoize.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskMemoize.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskParSequence.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskParSequence.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskParSequenceN.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskParSequenceN.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskParSequenceUnordered.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskParSequenceUnordered.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRace.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRace.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRaceList.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRaceList.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRacePair.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRacePair.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRestartCallback.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRestartCallback.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRunLoop.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRunLoop.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRunToFutureWithLocal.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskRunToFutureWithLocal.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskSequence.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskSequence.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskShift.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskShift.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskSleep.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskSleep.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskStart.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskStart.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskStartAndForget.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskStartAndForget.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskToReactivePublisher.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskToReactivePublisher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TaskTracing.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TaskTracing.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/TracedAsync.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/TracedAsync.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/UnsafeCancelUtils.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/UnsafeCancelUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/internal/package.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/internal/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/package.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/tracing/CoevalEvent.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/tracing/CoevalEvent.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/tracing/CoevalTrace.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/tracing/CoevalTrace.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/tracing/PrintingOptions.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/tracing/PrintingOptions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/tracing/TaskEvent.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/tracing/TaskEvent.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/main/scala/monix/eval/tracing/TaskTrace.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/tracing/TaskTrace.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/BaseLawsSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/BaseLawsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/BaseTestSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/BaseTestSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalBracketSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalBracketSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalCatsConversions.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalCatsConversions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalConversionsKSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalConversionsKSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalErrorSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalErrorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalEvalAlwaysSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalEvalAlwaysSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalEvalOnceSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalEvalOnceSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalFlatMapSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalFlatMapSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalGuaranteeSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalGuaranteeSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalLeftSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalLeftSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalLikeConversionsSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalLikeConversionsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalMemoizeOnSuccessSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalMemoizeOnSuccessSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalMemoizeSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalMemoizeSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalMiscSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalMiscSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalNowSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalNowSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalOptionSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalOptionSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalRightSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalRightSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalRunSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalRunSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalSequenceSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalSequenceSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalToStringSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalToStringSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/CoevalZipSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/CoevalZipSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskAppSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskAppSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskAsyncBoundarySuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskAsyncBoundarySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskAsyncSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskAsyncSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskBracketSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskBracketSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskCallbackSafetySuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskCallbackSafetySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskCancelableSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskCancelableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskCancellationSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskCancellationSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskClockTimerAndContextShiftSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskClockTimerAndContextShiftSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskCoevalDoOnFinishSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskCoevalDoOnFinishSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskCoevalForeachSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskCoevalForeachSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskConnectionCompositeSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskConnectionCompositeSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskConnectionRefSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskConnectionRefSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskConnectionSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskConnectionSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskConversionsKSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskConversionsKSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskConversionsSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskConversionsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskCreateSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskCreateSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskDeferActionSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskDeferActionSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskDelaySuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskDelaySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskDoOnCancelSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskDoOnCancelSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskEffectInstanceSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskEffectInstanceSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskErrorSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskErrorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskEvalAlwaysSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskEvalAlwaysSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskEvalAsyncSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskEvalAsyncSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskEvalOnceSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskEvalOnceSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskExecuteAsyncSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskExecuteAsyncSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskExecuteOnSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskExecuteOnSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskExecuteWithModelSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskExecuteWithModelSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskExecuteWithOptionsSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskExecuteWithOptionsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskExecutionModelSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskExecutionModelSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskFlatMapSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskFlatMapSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskFromEitherSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskFromEitherSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskFromFutureSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskFromFutureSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskGuaranteeSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskGuaranteeSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskLeftSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskLeftSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskLiftSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskLiftSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskLikeConversionsSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskLikeConversionsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskLocalSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskLocalSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskMapBothSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskMapBothSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskMemoizeOnSuccessSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskMemoizeOnSuccessSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskMemoizeSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskMemoizeSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskMiscSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskMiscSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskNowSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskNowSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskOptionSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskOptionSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskOptionsSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskOptionsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskOrCoevalTransformWithSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskOrCoevalTransformWithSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskOverloadsSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskOverloadsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskParSequenceNSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskParSequenceNSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskParSequenceSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskParSequenceSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskParSequenceUnorderedSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskParSequenceUnorderedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskParTraverseSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskParTraverseSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskParTraverseUnorderedSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskParTraverseUnorderedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskParZipSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskParZipSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskRaceSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskRaceSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskRightSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskRightSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskRunAsyncSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskRunAsyncSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskSequenceSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskSequenceSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskStartAndForgetSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskStartAndForgetSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskStartSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskStartSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskTimedSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskTimedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskToFutureSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskToFutureSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskToStringSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskToStringSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskTraverseSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskTraverseSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TypeClassLawsForCoevalSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TypeClassLawsForCoevalSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TypeClassLawsForParallelApplicativeSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TypeClassLawsForParallelApplicativeSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TypeClassLawsForTaskSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TypeClassLawsForTaskSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/TypeClassLawsForTaskWithCallbackSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TypeClassLawsForTaskWithCallbackSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-eval/shared/src/test/scala/monix/eval/tracing/StackTracedContextSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/tracing/StackTracedContextSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/Atomic.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/Atomic.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicAny.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicAny.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicBoolean.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicBoolean.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicBuilder.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicByte.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicByte.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicChar.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicChar.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicDouble.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicDouble.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicFloat.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicFloat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicInt.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicInt.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicLong.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicLong.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicNumber.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicNumber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicNumberAny.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicNumberAny.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicShort.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/AtomicShort.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/atomic/package.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/atomic/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/cancelables/ChainedCancelable.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/cancelables/ChainedCancelable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/internal/CancelableFutureForPlatform.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/internal/CancelableFutureForPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/internal/DefaultUncaughtExceptionReporter.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/internal/DefaultUncaughtExceptionReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/internal/FutureUtilsForPlatform.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/internal/FutureUtilsForPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/internal/Platform.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/internal/Platform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/internal/collection/JSArrayQueue.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/internal/collection/JSArrayQueue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/internal/collection/queues/LowLevelConcurrentQueueBuilders.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/internal/collection/queues/LowLevelConcurrentQueueBuilders.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/misc/ThreadLocal.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/misc/ThreadLocal.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/schedulers/AsyncScheduler.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/schedulers/AsyncScheduler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/schedulers/CanBlock.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/schedulers/CanBlock.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/schedulers/JSTimer.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/schedulers/JSTimer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/schedulers/SchedulerCompanionImpl.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/schedulers/SchedulerCompanionImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/schedulers/StandardContext.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/schedulers/StandardContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/org/reactivestreams/Processor.scala
+++ b/monix-execution/js/src/main/scala/org/reactivestreams/Processor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/org/reactivestreams/Publisher.scala
+++ b/monix-execution/js/src/main/scala/org/reactivestreams/Publisher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/org/reactivestreams/Subscriber.scala
+++ b/monix-execution/js/src/main/scala/org/reactivestreams/Subscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/main/scala/org/reactivestreams/Subscription.scala
+++ b/monix-execution/js/src/main/scala/org/reactivestreams/Subscription.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/test/scala/monix/execution/internal/AsyncSchedulerJSSuite.scala
+++ b/monix-execution/js/src/test/scala/monix/execution/internal/AsyncSchedulerJSSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/test/scala/monix/execution/internal/PlatformSuite.scala
+++ b/monix-execution/js/src/test/scala/monix/execution/internal/PlatformSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/js/src/test/scala/monix/execution/internal/collection/JSArrayQueueSuite.scala
+++ b/monix-execution/js/src/test/scala/monix/execution/internal/collection/JSArrayQueueSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/InternalApi.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/InternalApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/BoxPaddingStrategy.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/BoxPaddingStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Factory.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Factory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left128Java7BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left128Java7BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left128Java7BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left128Java7BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left128Java7BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left128Java7BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left128Java8BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left128Java8BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left128Java8BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left128Java8BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left128Java8BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left128Java8BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left128JavaXBoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left128JavaXBoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left128JavaXBoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left128JavaXBoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left128JavaXBoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left128JavaXBoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left64Java7BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left64Java7BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left64Java7BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left64Java7BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left64Java7BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left64Java7BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left64Java8BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left64Java8BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left64Java8BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left64Java8BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left64Java8BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left64Java8BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left64JavaXBoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left64JavaXBoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left64JavaXBoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left64JavaXBoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left64JavaXBoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Left64JavaXBoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftPadding120.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftPadding120.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftPadding56.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftPadding56.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight128Java7BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight128Java7BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight128Java7BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight128Java7BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight128Java7BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight128Java7BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight128Java8BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight128Java8BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight128Java8BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight128Java8BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight128Java8BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight128Java8BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight128JavaXBoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight128JavaXBoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight128JavaXBoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight128JavaXBoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight128JavaXBoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight128JavaXBoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight256Java7BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight256Java7BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight256Java7BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight256Java7BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight256Java7BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight256Java7BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight256Java8BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight256Java8BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight256Java8BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight256Java8BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight256Java8BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight256Java8BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight256JavaXBoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight256JavaXBoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight256JavaXBoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight256JavaXBoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight256JavaXBoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/LeftRight256JavaXBoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/NormalJava7BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/NormalJava7BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/NormalJava7BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/NormalJava7BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/NormalJava7BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/NormalJava7BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/NormalJava8BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/NormalJava8BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/NormalJava8BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/NormalJava8BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/NormalJava8BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/NormalJava8BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/NormalJavaXBoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/NormalJavaXBoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/NormalJavaXBoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/NormalJavaXBoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/NormalJavaXBoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/NormalJavaXBoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right128Java7BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right128Java7BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right128Java7BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right128Java7BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right128Java7BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right128Java7BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right128Java8BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right128Java8BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right128Java8BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right128Java8BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right128Java8BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right128Java8BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right128JavaXBoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right128JavaXBoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right128JavaXBoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right128JavaXBoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right128JavaXBoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right128JavaXBoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right64Java7BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right64Java7BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right64Java7BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right64Java7BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right64Java7BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right64Java7BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right64Java8BoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right64Java8BoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right64Java8BoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right64Java8BoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right64Java8BoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right64Java8BoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right64JavaXBoxedInt.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right64JavaXBoxedInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right64JavaXBoxedLong.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right64JavaXBoxedLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right64JavaXBoxedObject.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/Right64JavaXBoxedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/UnsafeAccess.java
+++ b/monix-execution/jvm/src/main/java/monix/execution/internal/atomic/UnsafeAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/Atomic.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/Atomic.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicAny.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicAny.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicBoolean.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicBoolean.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicBuilder.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicByte.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicByte.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicChar.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicChar.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicDouble.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicDouble.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicFloat.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicFloat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicInt.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicInt.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicLong.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicLong.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicNumber.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicNumber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicNumberAny.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicNumberAny.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicShort.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/AtomicShort.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/atomic/package.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/atomic/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/cancelables/ChainedCancelable.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/cancelables/ChainedCancelable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/CancelableFutureForPlatform.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/CancelableFutureForPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/DefaultUncaughtExceptionReporter.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/DefaultUncaughtExceptionReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/FutureUtilsForPlatform.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/FutureUtilsForPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/Platform.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/Platform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/ScheduledExecutors.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/ScheduledExecutors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/FromCircularQueue.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/FromCircularQueue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/FromJavaQueue.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/FromJavaQueue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/FromMessagePassingQueue.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/FromMessagePassingQueue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/LowLevelConcurrentQueueBuilders.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/LowLevelConcurrentQueueBuilders.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/QueueDrain.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/QueueDrain.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/forkJoin/AdaptedForkJoinPool.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/forkJoin/AdaptedForkJoinPool.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/forkJoin/AdaptedForkJoinTask.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/forkJoin/AdaptedForkJoinTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/forkJoin/DynamicWorkerThreadFactory.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/forkJoin/DynamicWorkerThreadFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/forkJoin/StandardWorkerThreadFactory.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/forkJoin/StandardWorkerThreadFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/misc/ThreadLocal.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/misc/ThreadLocal.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/AdaptedThreadPoolExecutorMixin.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/AdaptedThreadPoolExecutorMixin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/AsyncScheduler.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/AsyncScheduler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/CanBlock.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/CanBlock.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/Defaults.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/Defaults.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/ExecutorScheduler.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/ExecutorScheduler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/SchedulerCompanionImpl.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/SchedulerCompanionImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/ThreadFactoryBuilder.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/ThreadFactoryBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/test/scala/monix/execution/AckJVMSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/AckJVMSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/test/scala/monix/execution/AsyncQueueJVMSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/AsyncQueueJVMSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/test/scala/monix/execution/CallbackSafetyJVMSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/CallbackSafetyJVMSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/test/scala/monix/execution/CancelableFutureJVMSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/CancelableFutureJVMSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/test/scala/monix/execution/CompletableFutureConversionsSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/CompletableFutureConversionsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/test/scala/monix/execution/FeaturesJVMSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/FeaturesJVMSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/test/scala/monix/execution/FutureUtilsJVMSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/FutureUtilsJVMSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/test/scala/monix/execution/atomic/ConcurrentAtomicNumberSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/atomic/ConcurrentAtomicNumberSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/test/scala/monix/execution/atomic/ConcurrentAtomicSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/atomic/ConcurrentAtomicSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/test/scala/monix/execution/cancelables/ChainedCancelableJVMSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/cancelables/ChainedCancelableJVMSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/test/scala/monix/execution/internal/PlatformSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/internal/PlatformSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/test/scala/monix/execution/misc/LocalJVMSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/misc/LocalJVMSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/AsyncSchedulerJVMSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/AsyncSchedulerJVMSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/ExecutorSchedulerSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/ExecutorSchedulerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/JVMUncaughtExceptionReporterSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/JVMUncaughtExceptionReporterSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/ScheduleOnceJVMSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/ScheduleOnceJVMSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/ScheduledExecutorToSchedulerSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/ScheduledExecutorToSchedulerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TestSchedulerCompanionSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TestSchedulerCompanionSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TracingSchedulerServiceSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TracingSchedulerServiceSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TrampolineExecutionContextSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TrampolineExecutionContextSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/Ack.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/Ack.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/AsyncQueue.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/AsyncQueue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/AsyncSemaphore.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/AsyncSemaphore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/AsyncVar.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/AsyncVar.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/BufferCapacity.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/BufferCapacity.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/Callback.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/Callback.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/Cancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/Cancelable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/CancelableFuture.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/CancelableFuture.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/CancelablePromise.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/CancelablePromise.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/ChannelType.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/ChannelType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/ExecutionModel.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/ExecutionModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/Features.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/Features.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/FutureUtils.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/FutureUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/Scheduler.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/Scheduler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/UncaughtExceptionReporter.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/UncaughtExceptionReporter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/annotations/Unsafe.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/annotations/Unsafe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/atomic/PaddingStrategy.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/atomic/PaddingStrategy.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/AssignableCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/AssignableCancelable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/BooleanCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/BooleanCancelable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/CompositeCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/CompositeCancelable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/MultiAssignCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/MultiAssignCancelable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/OrderedCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/OrderedCancelable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/RefCountCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/RefCountCancelable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/SerialCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/SerialCancelable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/SingleAssignCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/SingleAssignCancelable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/StackedCancelable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/StackedCancelable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/cancelables/package.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/cancelables/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/exceptions/APIContractViolationException.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/exceptions/APIContractViolationException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/exceptions/BufferOverflowException.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/exceptions/BufferOverflowException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/exceptions/CompositeException.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/exceptions/CompositeException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/exceptions/DownstreamTimeoutException.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/exceptions/DownstreamTimeoutException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/exceptions/DummyException.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/exceptions/DummyException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/exceptions/ExecutionRejectedException.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/exceptions/ExecutionRejectedException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/exceptions/UncaughtErrorException.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/exceptions/UncaughtErrorException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/exceptions/UpstreamTimeoutException.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/exceptions/UpstreamTimeoutException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/AttemptCallback.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/AttemptCallback.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/Constants.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/Constants.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/GenericSemaphore.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/GenericSemaphore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/GenericVar.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/GenericVar.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/InterceptRunnable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/InterceptRunnable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/Newtype1.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/Newtype1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/RingBuffer.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/RingBuffer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/RunnableAction.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/RunnableAction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/Trampoline.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/Trampoline.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/collection/Buffer.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/collection/Buffer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/collection/ChunkedArrayQueue.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/collection/ChunkedArrayQueue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/collection/ChunkedArrayStack.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/collection/ChunkedArrayStack.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/collection/DropAllOnOverflowQueue.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/collection/DropAllOnOverflowQueue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/collection/DropHeadOnOverflowQueue.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/collection/DropHeadOnOverflowQueue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/collection/EvictingQueue.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/collection/EvictingQueue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/collection/LinkedMap.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/collection/LinkedMap.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/collection/LowLevelConcurrentQueue.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/collection/LowLevelConcurrentQueue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/math.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/math.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/misc/CanBindLocals.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/misc/CanBindLocals.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/misc/HygieneUtilMacros.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/misc/HygieneUtilMacros.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/misc/InlineMacros.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/misc/InlineMacros.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/misc/Local.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/misc/Local.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/misc/LocalDeprecated.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/misc/LocalDeprecated.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/misc/package.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/misc/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/misc/test/TestBox.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/misc/test/TestBox.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/misc/test/TestInlineMacros.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/misc/test/TestInlineMacros.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/rstreams/ReactivePullStrategy.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/rstreams/ReactivePullStrategy.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/rstreams/SingleAssignSubscription.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/rstreams/SingleAssignSubscription.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/rstreams/Subscription.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/rstreams/Subscription.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/rstreams/package.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/rstreams/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/BatchingScheduler.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/BatchingScheduler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/ExecuteExtensions.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/ExecuteExtensions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/ReferenceScheduler.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/ReferenceScheduler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/SchedulerService.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/SchedulerService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/ShiftedRunnable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/ShiftedRunnable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/StartAsyncBatchRunnable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/StartAsyncBatchRunnable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/TestScheduler.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/TestScheduler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/TracingRunnable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/TracingRunnable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/TracingScheduler.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/TracingScheduler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/TracingSchedulerService.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/TracingSchedulerService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/TrampolineScheduler.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/TrampolineScheduler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/TrampolinedRunnable.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/TrampolinedRunnable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala_2.13+/monix/execution/compat.scala
+++ b/monix-execution/shared/src/main/scala_2.13+/monix/execution/compat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/main/scala_2.13-/monix/execution/compat.scala
+++ b/monix-execution/shared/src/main/scala_2.13-/monix/execution/compat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/AckSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/AckSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/AsyncQueueSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/AsyncQueueSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/AsyncSemaphoreSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/AsyncSemaphoreSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/AsyncVarSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/AsyncVarSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/BaseLawsSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/BaseLawsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/CallbackSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/CallbackSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/CancelableFutureSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/CancelableFutureSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/CancelablePromiseSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/CancelablePromiseSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/CancelableSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/CancelableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/FeaturesSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/FeaturesSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/FutureUtilsSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/FutureUtilsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/TestUtils.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/TestUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/atomic/AtomicBuilderSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/atomic/AtomicBuilderSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/atomic/AtomicNumberSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/atomic/AtomicNumberSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/atomic/BoxedLong.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/atomic/BoxedLong.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/atomic/GenericAtomicSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/atomic/GenericAtomicSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/cancelables/AssignableCancelableSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/cancelables/AssignableCancelableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/cancelables/BooleanCancelableSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/cancelables/BooleanCancelableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/cancelables/ChainedCancelableSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/cancelables/ChainedCancelableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/cancelables/CompositeCancelableSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/cancelables/CompositeCancelableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/cancelables/MultiAssignCancelableSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/cancelables/MultiAssignCancelableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/cancelables/OrderedCancelableSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/cancelables/OrderedCancelableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/cancelables/RefCountCancelableSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/cancelables/RefCountCancelableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/cancelables/SerialCancelableSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/cancelables/SerialCancelableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/cancelables/SingleAssignCancelableSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/cancelables/SingleAssignCancelableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/cancelables/StackedCancelableSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/cancelables/StackedCancelableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/internal/MathSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/internal/MathSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/internal/RingBufferSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/internal/RingBufferSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/internal/collection/ChunkedArrayQueueSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/internal/collection/ChunkedArrayQueueSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/internal/collection/ChunkedArrayStackSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/internal/collection/ChunkedArrayStackSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/internal/collection/DropAllOnOverflowQueueSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/internal/collection/DropAllOnOverflowQueueSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/internal/collection/DropHeadOnOverflowQueueSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/internal/collection/DropHeadOnOverflowQueueSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/misc/CanBindLocalsSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/misc/CanBindLocalsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/misc/InlineMacrosTest.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/misc/InlineMacrosTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/misc/LocalSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/misc/LocalSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/misc/ThreadLocalSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/misc/ThreadLocalSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/rstreams/SingleAssignSubscriptionSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/rstreams/SingleAssignSubscriptionSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/rstreams/SubscriptionSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/rstreams/SubscriptionSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/schedulers/ExecutionModelSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/schedulers/ExecutionModelSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/schedulers/ReferenceSchedulerSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/schedulers/ReferenceSchedulerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/schedulers/TestSchedulerSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/schedulers/TestSchedulerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/schedulers/TracingSchedulerSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/schedulers/TracingSchedulerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/schedulers/TrampolineSchedulerSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/schedulers/TrampolineSchedulerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-execution/shared/src/test/scala/monix/execution/schedulers/UncaughtExceptionReporterSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/schedulers/UncaughtExceptionReporterSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-java/src/main/scala/monix/java8/eval/package.scala
+++ b/monix-java/src/main/scala/monix/java8/eval/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-java/src/main/scala/monix/java8/execution/package.scala
+++ b/monix-java/src/main/scala/monix/java8/execution/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/AbstractBackPressuredBufferedSubscriber.scala
+++ b/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/AbstractBackPressuredBufferedSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/BackPressuredBufferedSubscriber.scala
+++ b/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/BackPressuredBufferedSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/BatchedBufferedSubscriber.scala
+++ b/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/BatchedBufferedSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/BuildersImpl.scala
+++ b/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/BuildersImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/SyncBufferedSubscriber.scala
+++ b/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/SyncBufferedSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/main/java/monix/reactive/observers/buffers/CommonBufferMembers.java
+++ b/monix-reactive/jvm/src/main/java/monix/reactive/observers/buffers/CommonBufferMembers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/compression/CompressionException.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/compression/CompressionException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/compression/CompressionParameters.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/compression/CompressionParameters.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/compression/internal/operators/Deflate.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/compression/internal/operators/Deflate.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/compression/internal/operators/DeflateOperator.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/compression/internal/operators/DeflateOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/compression/internal/operators/GunzipOperator.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/compression/internal/operators/GunzipOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/compression/internal/operators/GzipOperator.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/compression/internal/operators/GzipOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/compression/internal/operators/InflateOperator.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/compression/internal/operators/InflateOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/compression/package.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/compression/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/AbstractBackPressuredBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/AbstractBackPressuredBufferedSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/BackPressuredBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/BackPressuredBufferedSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/BatchedBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/BatchedBufferedSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/BuildersImpl.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/BuildersImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/ConcurrentQueue.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/ConcurrentQueue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/DropNewBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/DropNewBufferedSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/EvictingBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/EvictingBufferedSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/SimpleBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/SimpleBufferedSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/BaseConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/BaseConcurrencySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/SerializableSuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/SerializableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/compression/BaseDecompressionSuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/compression/BaseDecompressionSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/compression/CompressionIntegrationSuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/compression/CompressionIntegrationSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/compression/CompressionTestData.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/compression/CompressionTestData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/compression/DeflateIntegrationSuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/compression/DeflateIntegrationSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/compression/DeflateOperatorSuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/compression/DeflateOperatorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/compression/DeflateTestUtils.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/compression/DeflateTestUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/compression/GunzipOperatorSuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/compression/GunzipOperatorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/compression/GzipIntegrationTest.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/compression/GzipIntegrationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/compression/GzipOperatorSuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/compression/GzipOperatorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/compression/GzipTestsUtils.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/compression/GzipTestsUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/compression/InflateOperatorSuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/compression/InflateOperatorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/consumers/LoadBalanceConsumerConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/consumers/LoadBalanceConsumerConcurrencySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/ConcatMapConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/ConcatMapConcurrencySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/FlatScanConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/FlatScanConcurrencySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/MapParallelOrderedConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/MapParallelOrderedConcurrencySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/MapParallelUnorderedConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/MapParallelUnorderedConcurrencySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/MapTaskConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/MapTaskConcurrencySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/ScanTaskConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/internal/operators/ScanTaskConcurrencySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/issues/Issue1167Suite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/issues/Issue1167Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/issues/Issue908Suite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/issues/Issue908Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressuredConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressuredConcurrencySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewAndSignalConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewAndSignalConcurrencySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewConcurrencySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyFailConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyFailConcurrencySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyUnboundedConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/OverflowStrategyUnboundedConcurrencySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/subjects/ReplaySubjectConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/subjects/ReplaySubjectConcurrencySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Consumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Consumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/MulticastStrategy.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/MulticastStrategy.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Notification.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Notification.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/ObservableLike.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/ObservableLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/OverflowStrategy.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/OverflowStrategy.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Pipe.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Pipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/instances/CatsProfunctorForSubject.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/instances/CatsProfunctorForSubject.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/AsyncStateActionObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/AsyncStateActionObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/BufferedIteratorAsObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/BufferedIteratorAsObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CharsReaderObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CharsReaderObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest2Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest2Observable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest3Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest3Observable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest4Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest4Observable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest5Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest5Observable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest6Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest6Observable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatestListObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatestListObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ConsObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ConsObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CreateObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CreateObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/DeferObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/DeferObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/EmptyObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/EmptyObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ErrorObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ErrorObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/EvalAlwaysObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/EvalAlwaysObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/EvalOnceObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/EvalOnceObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ExecuteAsyncObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ExecuteAsyncObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ExecuteWithModelObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ExecuteWithModelObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/FirstStartedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/FirstStartedObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/FutureAsObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/FutureAsObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/InputStreamObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/InputStreamObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Interleave2Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Interleave2Observable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/IntervalFixedDelayObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/IntervalFixedDelayObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/IntervalFixedRateObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/IntervalFixedRateObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/IterableAsObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/IterableAsObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/IteratorAsObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/IteratorAsObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/LinesReaderObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/LinesReaderObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/MergePrioritizedListObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/MergePrioritizedListObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/NeverObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/NeverObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/NowObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/NowObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/PipeThroughSelectorObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/PipeThroughSelectorObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RangeObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RangeObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ReactiveObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ReactiveObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RepeatEvalObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RepeatEvalObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RepeatObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RepeatObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RepeatOneObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RepeatOneObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RepeatedValueObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RepeatedValueObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ResourceCaseObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ResourceCaseObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RunnableObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/RunnableObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/StateActionObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/StateActionObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/TailRecMObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/TailRecMObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/TaskAsObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/TaskAsObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/UnfoldEvalObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/UnfoldEvalObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/UnfoldObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/UnfoldObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/UnsafeCreateObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/UnsafeCreateObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip2Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip2Observable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip3Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip3Observable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip4Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip4Observable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip5Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip5Observable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip6Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip6Observable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/CancelledConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/CancelledConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/CompleteConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/CompleteConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/ContraMapConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/ContraMapConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/CreateConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/CreateConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/FirstNotificationConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/FirstNotificationConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/FoldLeftConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/FoldLeftConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/FoldLeftTaskConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/FoldLeftTaskConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/ForeachAsyncConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/ForeachAsyncConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/ForeachConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/ForeachConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/FromObserverConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/FromObserverConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/HeadConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/HeadConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/HeadOptionConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/HeadOptionConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/LoadBalanceConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/LoadBalanceConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/MapConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/MapConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/MapTaskConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/MapTaskConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/RaiseErrorConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/RaiseErrorConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/TransformInputConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/TransformInputConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/deprecated/ObservableDeprecatedBuilders.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/deprecated/ObservableDeprecatedBuilders.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/deprecated/ObservableDeprecatedMethods.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/deprecated/ObservableDeprecatedMethods.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/AsyncBoundaryOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/AsyncBoundaryOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferIntrospectiveObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferIntrospectiveObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferSlidingOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferSlidingOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferTimedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferTimedObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferWhileOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferWhileOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferWithSelectorObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferWithSelectorObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/CollectOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/CollectOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/CollectWhileOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/CollectWhileOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/CompletedOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/CompletedOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ConcatMapIterableOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ConcatMapIterableOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ConcatMapObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ConcatMapObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ConcatObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ConcatObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/CountOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/CountOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DebounceObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DebounceObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DefaultIfEmptyOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DefaultIfEmptyOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayBySelectorObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayBySelectorObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayByTimespanObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayByTimespanObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayExecutionByTimespanObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayExecutionByTimespanObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayExecutionWithTriggerObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayExecutionWithTriggerObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayOnCompleteObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayOnCompleteObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DematerializeOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DematerializeOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DistinctUntilChangedByKeyOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DistinctUntilChangedByKeyOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DistinctUntilChangedOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DistinctUntilChangedOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnCompleteOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnCompleteOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnEarlyStopOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnEarlyStopOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnErrorOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnErrorOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnNextAckOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnNextAckOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnStartOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnStartOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnSubscribeObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnSubscribeObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnSubscriptionCancelObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnSubscriptionCancelObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnTerminateOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnTerminateOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DownstreamTimeoutObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DownstreamTimeoutObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropByPredicateOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropByPredicateOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropByPredicateWithIndexOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropByPredicateWithIndexOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropByTimespanObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropByTimespanObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropFirstOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropFirstOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropLastOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropLastOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropUntilObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropUntilObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DumpObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DumpObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EchoObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EchoObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EndWithErrorOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EndWithErrorOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ExecuteOnObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ExecuteOnObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FailedOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FailedOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FilterOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FilterOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FlatScanObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FlatScanObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FoldLeftObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FoldLeftObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FoldWhileLeftObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FoldWhileLeftObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/GroupByOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/GroupByOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/GuaranteeCaseObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/GuaranteeCaseObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/IntersperseObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/IntersperseObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/IsEmptyOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/IsEmptyOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/LiftByOperatorObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/LiftByOperatorObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapAccumulateObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapAccumulateObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapParallelOrderedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapParallelOrderedObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapParallelUnorderedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapParallelUnorderedObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapTaskObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapTaskObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MaterializeOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MaterializeOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MergeMapObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MergeMapObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ObserveOnObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ObserveOnObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/OnCancelTriggerErrorObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/OnCancelTriggerErrorObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/OnErrorRecoverWithObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/OnErrorRecoverWithObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/OnErrorRetryCountedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/OnErrorRetryCountedObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/OnErrorRetryIfObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/OnErrorRetryIfObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/PipeThroughObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/PipeThroughObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ReduceOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ReduceOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/RepeatSourceObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/RepeatSourceObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/RestartUntilObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/RestartUntilObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ScanObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ScanObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ScanTaskObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ScanTaskObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/SearchByOrderOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/SearchByOrderOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/SubscribeOnObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/SubscribeOnObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/SwitchIfEmptyObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/SwitchIfEmptyObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/SwitchMapObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/SwitchMapObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeByPredicateOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeByPredicateOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeEveryNthOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeEveryNthOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeLastObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeLastObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeLeftByTimespanObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeLeftByTimespanObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeLeftOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeLeftOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeUntilObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeUntilObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeWhileNotCanceledOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeWhileNotCanceledOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ThrottleFirstOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ThrottleFirstOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ThrottleLastObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ThrottleLastObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/UncancelableObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/UncancelableObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/UpstreamTimeoutObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/UpstreamTimeoutObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/WhileBusyAggregateEventsOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/WhileBusyAggregateEventsOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/WhileBusyDropEventsAndSignalOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/WhileBusyDropEventsAndSignalOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/WhileBusyDropEventsOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/WhileBusyDropEventsOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/WithLatestFromObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/WithLatestFromObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ZipWithIndexOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ZipWithIndexOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/rstreams/ReactiveSubscriberAsMonixSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/rstreams/ReactiveSubscriberAsMonixSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/rstreams/SubscriberAsReactiveSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/rstreams/SubscriberAsReactiveSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/subscribers/ForeachSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/subscribers/ForeachSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/util/Instances.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/util/Instances.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/util/PromiseCounter.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/util/PromiseCounter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observables/CachedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observables/CachedObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observables/ChainedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observables/ChainedObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observables/CombineObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observables/CombineObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observables/ConnectableObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observables/ConnectableObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observables/GroupedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observables/GroupedObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observables/RefCountObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observables/RefCountObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observers/BufferedSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observers/BufferedSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observers/CacheUntilConnectSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observers/CacheUntilConnectSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observers/ConnectableSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observers/ConnectableSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observers/SafeSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observers/SafeSubscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observers/Subscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observers/Subscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observers/buffers/package.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observers/buffers/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/subjects/AsyncSubject.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/subjects/AsyncSubject.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/subjects/BehaviorSubject.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/subjects/BehaviorSubject.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/subjects/ConcurrentSubject.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/subjects/ConcurrentSubject.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/subjects/PublishSubject.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/subjects/PublishSubject.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/subjects/PublishToOneSubject.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/subjects/PublishToOneSubject.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/subjects/ReplaySubject.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/subjects/ReplaySubject.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/subjects/Subject.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/subjects/Subject.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/main/scala/monix/reactive/subjects/Var.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/subjects/Var.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/BaseTestSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/BaseTestSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/ObservableLikeConversionsSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/ObservableLikeConversionsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/PipeSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/PipeSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/TypeClassLawsForConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/TypeClassLawsForConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/TypeClassLawsForObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/TypeClassLawsForObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/TypeClassLawsForSubjectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/TypeClassLawsForSubjectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/CancelConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/CancelConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/CompleteConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/CompleteConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/ContramapConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/ContramapConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/FirstNotificationConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/FirstNotificationConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/FoldLeftConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/FoldLeftConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/FoldLeftTaskConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/FoldLeftTaskConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/ForeachAsyncConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/ForeachAsyncConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/ForeachConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/ForeachConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/ForeachParallelAsyncConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/ForeachParallelAsyncConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/ForeachParallelConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/ForeachParallelConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/FromObserverConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/FromObserverConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/HeadConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/HeadConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/HeadOptionConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/HeadOptionConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/ListConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/ListConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/LoadBalanceConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/LoadBalanceConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/MapConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/MapConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/MapEvalConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/MapEvalConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/MapTaskConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/MapTaskConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/RaiseErrorConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/RaiseErrorConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/TransformInputConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/TransformInputConsumerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/AsyncStateActionObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/AsyncStateActionObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/BracketObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/BracketObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/BufferedIteratorAsObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/BufferedIteratorAsObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/CatsConversionsSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/CatsConversionsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/CharsReaderObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/CharsReaderObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/CreateObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/CreateObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/EmptyObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/EmptyObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/ErrorObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/ErrorObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/EvalAlwaysObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/EvalAlwaysObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/EvalObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/EvalObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/EvalOnceObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/EvalOnceObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/ExecuteAsyncObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/ExecuteAsyncObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/FirstStartedObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/FirstStartedObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/FromResourceObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/FromResourceObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/FutureAsObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/FutureAsObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/InputStreamObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/InputStreamObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/IntervalObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/IntervalObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/IterableAsObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/IterableAsObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/IteratorAsObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/IteratorAsObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/LinesReaderObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/LinesReaderObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/NeverObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/NeverObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/NowObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/NowObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/RangeObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/RangeObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/RepeatEvalFSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/RepeatEvalFSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/RepeatEvalObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/RepeatEvalObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/RepeatOneObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/RepeatOneObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/RepeatedValueObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/RepeatedValueObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/ResourceCaseObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/ResourceCaseObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/StateActionObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/StateActionObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/UnfoldEvalObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/UnfoldEvalObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/UnfoldObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/UnfoldObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/UnsafeCreateObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/UnsafeCreateObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/AsyncBoundarySuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/AsyncBoundarySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BaseOperatorSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BaseOperatorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferIntrospectiveSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferIntrospectiveSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferSlidingDropSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferSlidingDropSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferSlidingOverlapSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferSlidingOverlapSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferSlidingSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferSlidingSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferTimedOrCountedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferTimedOrCountedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferTimedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferTimedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferTumblingSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferTumblingSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferWhileInclusiveSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferWhileInclusiveSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferWhileSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferWhileSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferWithSelectorSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferWithSelectorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CacheSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CacheSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CollectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CollectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CollectWhileSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CollectWhileSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CombineLatest2Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CombineLatest2Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CombineLatest3Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CombineLatest3Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CombineLatest4Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CombineLatest4Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CombineLatest5Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CombineLatest5Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CombineLatest6Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CombineLatest6Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CombineLatestListSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CombineLatestListSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ConcatCancellationSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ConcatCancellationSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ConcatDelayErrorsSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ConcatDelayErrorsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ConcatManySuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ConcatManySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ConcatMapIterableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ConcatMapIterableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ConcatOneSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ConcatOneSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CountSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/CountSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DebounceFlattenSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DebounceFlattenSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DebounceRepeatedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DebounceRepeatedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DebounceSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DebounceSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DelayBySelectorSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DelayBySelectorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DelayByTimespanSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DelayByTimespanSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DelayExecutionSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DelayExecutionSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DelayExecutionWithSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DelayExecutionWithSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DelayOnCompleteSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DelayOnCompleteSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DematerializeSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DematerializeSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DistinctUntilChangedByKeySuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DistinctUntilChangedByKeySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DistinctUntilChangedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DistinctUntilChangedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnCompleteSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnCompleteSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnEarlyStopSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnEarlyStopSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnErrorSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnErrorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnNextAckSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnNextAckSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnNextSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnNextSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnStartSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnStartSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnSubscribeSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnSubscribeSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnSubscriptionCancelSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DoOnSubscriptionCancelSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DropByPredicateInclusiveSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DropByPredicateInclusiveSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DropByPredicateSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DropByPredicateSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DropByPredicateWithIndexSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DropByPredicateWithIndexSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DropByTimespanSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DropByTimespanSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DropFirstSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DropFirstSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DropLastSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DropLastSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DropUntilSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DropUntilSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DumpSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/DumpSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/EchoRepeatedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/EchoRepeatedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/EndWithErrorSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/EndWithErrorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ExecuteOnObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ExecuteOnObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ExecuteOnSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ExecuteOnSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/FilterNotSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/FilterNotSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/FilterSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/FilterSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/FlatScanDelayErrorSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/FlatScanDelayErrorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/FlatScanSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/FlatScanSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/FoldLeftObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/FoldLeftObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/FoldWhileObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/FoldWhileObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/GroupBySuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/GroupBySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/GuaranteeCaseSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/GuaranteeCaseSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Interleave2Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Interleave2Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/IntersperseSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/IntersperseSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapAccumulateSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapAccumulateSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapEffectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapEffectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapParallelOrderedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapParallelOrderedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapParallelUnorderedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapParallelUnorderedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapTaskSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MapTaskSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MaterializeSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MaterializeSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MaxBySuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MaxBySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MaxSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MaxSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MergeDelayErrorManySuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MergeDelayErrorManySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MergeDelayErrorOneSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MergeDelayErrorOneSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MergeManySuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MergeManySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MergeOneSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MergeOneSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MergePrioritizedListSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MergePrioritizedListSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MinBySuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MinBySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MinSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MinSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MiscCompleteSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MiscCompleteSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MiscDefaultIfEmptySuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MiscDefaultIfEmptySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MiscFailedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MiscFailedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MiscIsEmptySuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MiscIsEmptySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MiscNonEmptySuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/MiscNonEmptySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ObservableOpsReturningTaskSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ObservableOpsReturningTaskSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ObserveOnSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ObserveOnSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/OnCancelTriggerErrorSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/OnCancelTriggerErrorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/OnErrorFallbackToSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/OnErrorFallbackToSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/OnErrorRecoverWithSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/OnErrorRecoverWithSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/OnErrorRetryCountedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/OnErrorRetryCountedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/OnErrorRetryIfSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/OnErrorRetryIfSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/OnErrorRetryUnlimitedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/OnErrorRetryUnlimitedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/PipeThroughSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/PipeThroughSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/PublishSelectorSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/PublishSelectorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/RecursiveConcatSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/RecursiveConcatSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/RecursiveConsSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/RecursiveConsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ReduceSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ReduceSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/RepeatSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/RepeatSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/SampleOnceSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/SampleOnceSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/SampleRepeatedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/SampleRepeatedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ScanEffectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ScanEffectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ScanMapSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ScanMapSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ScanSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ScanSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ScanTaskSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ScanTaskSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/SumSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/SumSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/SwitchIfEmptySuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/SwitchIfEmptySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/SwitchMapSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/SwitchMapSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeByPredicateInclusiveSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeByPredicateInclusiveSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeByPredicateSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeByPredicateSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeByTimespanSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeByTimespanSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeEveryNthOperatorSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeEveryNthOperatorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeLastSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeLastSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeLeftSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeLeftSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeUntilObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeUntilObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeWhileNotCanceledSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TakeWhileNotCanceledSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ThrottleFirstSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ThrottleFirstSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ThrottleSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ThrottleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TimeoutOnSlowDownstreamSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TimeoutOnSlowDownstreamSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TimeoutOnSlowUpstreamSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TimeoutOnSlowUpstreamSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TransformerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/TransformerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/UncancelableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/UncancelableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WhileBusyAggregateEventsOperatorSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WhileBusyAggregateEventsOperatorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WhileBusyDropEventsAndSignalOverflowSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WhileBusyDropEventsAndSignalOverflowSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WhileBusyDropEventsSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WhileBusyDropEventsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WithLatestFrom2Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WithLatestFrom2Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WithLatestFrom3Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WithLatestFrom3Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WithLatestFrom4Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WithLatestFrom4Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WithLatestFrom5Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WithLatestFrom5Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WithLatestFrom6Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WithLatestFrom6Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WithLatestFromSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/WithLatestFromSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip2Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip2Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip3Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip3Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip4Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip4Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip5Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip5Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip6Suite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/Zip6Suite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ZipListSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ZipListSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ZipWithIndexSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/ZipWithIndexSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/rstreams/MonixSubscriberAsReactiveSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/rstreams/MonixSubscriberAsReactiveSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/rstreams/ObservableIsPublisherSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/rstreams/ObservableIsPublisherSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/rstreams/PublisherIsObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/rstreams/PublisherIsObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/subscribers/ObservableForeachSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/subscribers/ObservableForeachSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observables/ChainedObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observables/ChainedObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observables/ConnectableObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observables/ConnectableObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observables/RefCountObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observables/RefCountObservableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/ConnectableSubscriberSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/ConnectableSubscriberSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/ContramapObserverSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/ContramapObserverSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/ContramapSubscriberSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/ContramapSubscriberSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/DumpObserverSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/DumpObserverSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/ObserverFeedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/ObserverFeedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressureBatchedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressureBatchedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressureSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyBackPressureSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyClearBufferAndSignalSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyClearBufferAndSignalSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyClearBufferSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyClearBufferSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewAndSignalSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewAndSignalSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropNewSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropOldAndSignalSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropOldAndSignalSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropOldSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyDropOldSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyFailSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyFailSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyUnboundedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/OverflowStrategyUnboundedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/SafeSubscriberSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/SafeSubscriberSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/StoppedObserverSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/StoppedObserverSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/SubscriberFeedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/SubscriberFeedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/subjects/AsyncSubjectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/subjects/AsyncSubjectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/subjects/BaseConcurrentSubjectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/subjects/BaseConcurrentSubjectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/subjects/BaseSubjectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/subjects/BaseSubjectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/subjects/BehaviorSubjectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/subjects/BehaviorSubjectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/subjects/ConcurrentAsyncSubjectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/subjects/ConcurrentAsyncSubjectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/subjects/ConcurrentBehaviorSubjectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/subjects/ConcurrentBehaviorSubjectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/subjects/ConcurrentPublishSubjectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/subjects/ConcurrentPublishSubjectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/subjects/ConcurrentReplayLimitedSubjectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/subjects/ConcurrentReplayLimitedSubjectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/subjects/ConcurrentReplaySubjectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/subjects/ConcurrentReplaySubjectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/subjects/ProfunctorSubjectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/subjects/ProfunctorSubjectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/subjects/PublishSubjectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/subjects/PublishSubjectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/subjects/ReplaySubjectSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/subjects/ReplaySubjectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-reactive/shared/src/test/scala/monix/reactive/subjects/VarSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/subjects/VarSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/Iterant.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/IterantBuilders.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/IterantBuilders.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/batches/ArrayBatch.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/batches/ArrayBatch.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/batches/ArrayCursor.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/batches/ArrayCursor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/batches/Batch.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/batches/Batch.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/batches/BatchCursor.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/batches/BatchCursor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/batches/BooleansBatch.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/batches/BooleansBatch.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/batches/BooleansCursor.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/batches/BooleansCursor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/batches/BytesBatch.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/batches/BytesBatch.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/batches/BytesCursor.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/batches/BytesCursor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/batches/CharsBatch.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/batches/CharsBatch.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/batches/CharsCursor.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/batches/CharsCursor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/batches/DoublesBatch.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/batches/DoublesBatch.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/batches/DoublesCursor.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/batches/DoublesCursor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/batches/EmptyBatch.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/batches/EmptyBatch.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/batches/EmptyCursor.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/batches/EmptyCursor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/batches/GenericBatch.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/batches/GenericBatch.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/batches/GenericCursor.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/batches/GenericCursor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/batches/IntegersBatch.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/batches/IntegersBatch.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/batches/IntegersCursor.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/batches/IntegersCursor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/batches/IteratorCursor.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/batches/IteratorCursor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/batches/LongsBatch.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/batches/LongsBatch.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/batches/LongsCursor.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/batches/LongsCursor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/batches/SeqBatch.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/batches/SeqBatch.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/AndThen.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/AndThen.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/Constants.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/Constants.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantAttempt.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantAttempt.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantBuffer.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantBuffer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantCollect.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantCollect.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantCompleteL.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantCompleteL.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantConcat.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantConcat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantConsume.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantConsume.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantDeprecated.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantDeprecated.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantDistinctUntilChanged.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantDistinctUntilChanged.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantDrop.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantDrop.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantDropLast.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantDropLast.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantDropWhile.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantDropWhile.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantDropWhileWithIndex.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantDropWhileWithIndex.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantDump.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantDump.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFilter.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFoldLeftL.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFoldLeftL.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFoldRightL.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFoldRightL.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFoldWhileLeftL.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFoldWhileLeftL.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFromConsumer.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFromConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFromReactivePublisher.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFromReactivePublisher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantHeadOptionL.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantHeadOptionL.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantInterleave.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantInterleave.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantIntersperse.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantIntersperse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantIntervalAtFixedRate.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantIntervalAtFixedRate.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantIntervalWithFixedDelay.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantIntervalWithFixedDelay.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantLiftMap.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantLiftMap.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantMap.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantMap.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantMapBatch.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantMapBatch.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantMapEval.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantMapEval.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantOnErrorHandleWith.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantOnErrorHandleWith.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantPushToChannel.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantPushToChannel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantReduce.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantReduce.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantRepeat.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantRepeat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantRetryIfEmpty.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantRetryIfEmpty.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantScan.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantScan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantScanEval.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantScanEval.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantSwitchIfEmpty.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantSwitchIfEmpty.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantTail.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantTail.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantTake.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantTake.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantTakeEveryNth.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantTakeEveryNth.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantTakeLast.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantTakeLast.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantTakeWhile.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantTakeWhile.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantTakeWhileWithIndex.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantTakeWhileWithIndex.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantToReactivePublisher.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantToReactivePublisher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantUncons.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantUncons.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantZipMap.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantZipMap.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/IterantZipWithIndex.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/IterantZipWithIndex.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/main/scala/monix/tail/internal/package.scala
+++ b/monix-tail/shared/src/main/scala/monix/tail/internal/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/AndThenSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/AndThenSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/ArbitraryInstances.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/ArbitraryInstances.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/BaseLawsSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/BaseLawsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/BaseTestSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/BaseTestSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/BatchCursorBuildersSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/BatchCursorBuildersSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/BatchCursorEmptySuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/BatchCursorEmptySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/BatchCursorSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/BatchCursorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/BatchEmptySuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/BatchEmptySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/BatchSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/BatchSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IntervalIntervalSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IntervalIntervalSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantBasicSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantBasicSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantBufferSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantBufferSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantChannelSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantChannelSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantCollectSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantCollectSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantCompleteLSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantCompleteLSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantConcatSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantConcatSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantConsumeSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantConsumeSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantDistinctUntilChangedSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantDistinctUntilChangedSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantDropLastSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantDropLastSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantDropSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantDropSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantDropWhileIndexSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantDropWhileIndexSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantDropWhileSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantDropWhileSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantDumpSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantDumpSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantFilterSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantFilterSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantFlatMapSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantFlatMapSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantFoldLeftSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantFoldLeftSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantFoldRightSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantFoldRightSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantFoldWhileLeftSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantFoldWhileLeftSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantFromIndexedSeqSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantFromIndexedSeqSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantFromIterableSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantFromIterableSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantFromListSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantFromListSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantFromReactivePublisherSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantFromReactivePublisherSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantFromReactiveStreamAsyncSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantFromReactiveStreamAsyncSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantFromResourceSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantFromResourceSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantFromSeqSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantFromSeqSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantFromStateActionSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantFromStateActionSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantHeadOptionSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantHeadOptionSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantInterleaveSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantInterleaveSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantIntersperseSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantIntersperseSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantLastOptionSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantLastOptionSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantLiftMapSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantLiftMapSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantMapBatchSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantMapBatchSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantMapEvalSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantMapEvalSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantMapSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantMapSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantOnErrorSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantOnErrorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantRangesSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantRangesSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantReduceSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantReduceSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantRepeatSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantRepeatSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantResourceSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantResourceSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantRetryIfEmptySuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantRetryIfEmptySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantScanEvalSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantScanEvalSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantScanMapSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantScanMapSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantScanSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantScanSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantStatesSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantStatesSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantSwitchIfEmptySuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantSwitchIfEmptySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantTailSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantTailSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantTakeEveryNthSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantTakeEveryNthSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantTakeLastSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantTakeLastSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantTakeSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantTakeSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantTakeWhileSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantTakeWhileSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantTakeWhileWithIndexSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantTakeWhileWithIndexSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantToReactivePublisherSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantToReactivePublisherSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantUnconsSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantUnconsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantZipMapSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantZipMapSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/IterantZipWithIndexSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/IterantZipWithIndexSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/ThrowExceptionBatch.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/ThrowExceptionBatch.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/ThrowExceptionCursor.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/ThrowExceptionCursor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/TypeClassLawsForIterantCoevalSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/TypeClassLawsForIterantCoevalSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/TypeClassLawsForIterantIOSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/TypeClassLawsForIterantIOSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix-tail/shared/src/test/scala/monix/tail/TypeClassLawsForIterantTaskSuite.scala
+++ b/monix-tail/shared/src/test/scala/monix/tail/TypeClassLawsForIterantTaskSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/monix/shared/src/main/scala/monix/package.scala
+++ b/monix/shared/src/main/scala/monix/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2020 by The Monix Project Developers.
+# Copyright (c) 2014-2021 by The Monix Project Developers.
 # See the project homepage at: https://monix.io
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/reactiveTests/src/test/scala/monix/reactiveTests/IterantToPublisherTest.scala
+++ b/reactiveTests/src/test/scala/monix/reactiveTests/IterantToPublisherTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/reactiveTests/src/test/scala/monix/reactiveTests/ObservableToPublisherTest.scala
+++ b/reactiveTests/src/test/scala/monix/reactiveTests/ObservableToPublisherTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/reactiveTests/src/test/scala/monix/reactiveTests/SubscriberWhiteBoxAsyncTest.scala
+++ b/reactiveTests/src/test/scala/monix/reactiveTests/SubscriberWhiteBoxAsyncTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/reactiveTests/src/test/scala/monix/reactiveTests/SubscriberWhiteBoxSyncTest.scala
+++ b/reactiveTests/src/test/scala/monix/reactiveTests/SubscriberWhiteBoxSyncTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/reactiveTests/src/test/scala/monix/reactiveTests/package.scala
+++ b/reactiveTests/src/test/scala/monix/reactiveTests/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tracingTests/src/test/scala/tracing/CachedStackTracingSuite.scala
+++ b/tracingTests/src/test/scala/tracing/CachedStackTracingSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tracingTests/src/test/scala/tracing/TracingSuite.scala
+++ b/tracingTests/src/test/scala/tracing/TracingSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  * See the project homepage at: https://monix.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
2️⃣0️⃣2️⃣1️⃣ 🎆