### PR TITLE
Adds discord badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 Asynchronous, Reactive Programming for Scala and [Scala.js](http://www.scala-js.org/).
 
 [![Build](https://github.com/monix/monix/workflows/build/badge.svg?branch=series/4.x)](https://github.com/monix/monix/actions?query=branch%3Aseries%2F4.x+workflow%3Abuild) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/monix/monix)
+[![Discord](https://img.shields.io/discord/632277896739946517.svg?label=&logo=discord&logoColor=ffffff&color=404244&labelColor=6A7EC2)](https://discord.gg/vpEv3HJ)
 
 - [Overview](#overview)
 - [Usage](#usage)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Asynchronous, Reactive Programming for Scala and [Scala.js](http://www.scala-js.org/).
 
 [![Build](https://github.com/monix/monix/workflows/build/badge.svg?branch=series/4.x)](https://github.com/monix/monix/actions?query=branch%3Aseries%2F4.x+workflow%3Abuild) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/monix/monix)
-[![Discord](https://img.shields.io/discord/632277896739946517.svg?label=&logo=discord&logoColor=ffffff&color=404244&labelColor=6A7EC2)](https://discord.gg/vpEv3HJ)
+[![Discord](https://img.shields.io/discord/632277896739946517.svg?label=&logo=discord&logoColor=ffffff&color=404244&labelColor=6A7EC2)](https://discord.gg/wsVZSEx4Nw)
 
 - [Overview](#overview)
 - [Usage](#usage)


### PR DESCRIPTION
It might be a good idea to link people to Discord now that Typelevel has its own server, the way the badge is created is by the server id `632277896739946517` and the invite does not expire. 
![Screen Shot 2021-05-09 at 17 48 26](https://user-images.githubusercontent.com/33580722/117578513-04416900-b0ef-11eb-990e-5b3ea0beb326.png)
