### PR TITLE
Only include JCTools in executionShadedJCTools

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -529,7 +529,7 @@ lazy val executionShadedJCTools = project.in(file("monix-execution/shaded/jctool
   .settings(assemblyShadeSettings)
   .settings(
     description := "Monix Execution Shaded JCTools is a shaded version of JCTools library. See: https://github.com/JCTools/JCTools",
-    libraryDependencies += jcToolsLib % "optional;provided",
+    libraryDependencies := Seq(jcToolsLib % "optional;provided"),
     // https://github.com/sbt/sbt-assembly#shading
     assembly / assemblyShadeRules := Seq(
       ShadeRule.rename("org.jctools.**" -> "monix.execution.internal.jctools.@1")


### PR DESCRIPTION
Currently JCTools accidentally brings in scala-collection-compat, this change makes sure that only JCTools is included and nothing else)

Here's the content of the currently published jar

```
~/Downloads/monix-internal-jctools_2.13-3.3.0
❯ tree -L 4
.
├── META-INF
│   └── MANIFEST.MF
├── monix
│   └── execution
│       └── internal
│           └── jctools
├── scala
│   ├── collection
│   │   └── compat
│   │       ├── immutable
│   │       ├── package$.class
│   │       └── package.class
│   └── util
│       └── control
│           └── compat
└── scala-collection-compat.properties
```

All the `scala/collection/compat` stuff shouldn't probably be there and it can cause conflicts when running assembly in an app which brings in a different version of `scala-collection-compat` (e.g. `scala-collection-compat.properties` will conflict).

This bug was originally reported on the Scala Discord (see https://discordapp.com/channels/632150470000902164/635669047588945930/907577696270295070)

A similar, and maybe more general fix could be to "reset" the libraryDependencies to Nil in assemblyShadeSettings (although that's currently only used by the jctools module)