### PR TITLE
Trampoline.trampolineContext no longer ignores its parent BlockContext

### DIFF
--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
@@ -127,7 +127,7 @@ object TrampolineExecutionContext {
   private final class JVMOptimalTrampoline extends Trampoline {
     override def startLoop(runnable: Runnable, ec: ExecutionContext): Unit = {
       val parentContext = localContext.get()
-      localContext.set(trampolineContext(ec))
+      localContext.set(trampolineContext(parentContext, ec))
       try {
         super.startLoop(runnable, ec)
       } finally {
@@ -138,7 +138,7 @@ object TrampolineExecutionContext {
 
   private class JVMNormalTrampoline extends Trampoline {
     override def startLoop(runnable: Runnable, ec: ExecutionContext): Unit = {
-      BlockContext.withBlockContext(trampolineContext(ec)) {
+      BlockContext.withBlockContext(trampolineContext(BlockContext.current, ec)) {
         super.startLoop(runnable, ec)
       }
     }

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/Trampoline.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/Trampoline.scala
@@ -75,13 +75,17 @@ private[execution] class Trampoline {
     if (next ne null) immediateLoop(next, ec)
   }
 
-  protected final def trampolineContext(ec: ExecutionContext): BlockContext =
+  protected final def trampolineContext(parentContext: BlockContext, ec: ExecutionContext): BlockContext =
     new BlockContext {
       def blockOn[T](thunk: => T)(implicit permission: CanAwait): T = {
         // In case of blocking, execute all scheduled local tasks on
         // a separate thread, otherwise we could end up with a dead-lock
         forkTheRest(ec)
-        thunk
+        if (parentContext ne null) {
+          parentContext.blockOn(thunk)
+        } else {
+          thunk
+        }
       }
     }
 }


### PR DESCRIPTION
Fix for #1543 