### PR TITLE
add explicit type for implicits

### DIFF
--- a/monix-eval/shared/src/test/scala/monix/eval/TypeClassLawsForTaskWithCallbackSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TypeClassLawsForTaskWithCallbackSuite.scala
@@ -52,7 +52,7 @@ class BaseTypeClassLawsForTaskWithCallbackSuite(implicit opts: Task.Options) ext
     A: Eq[A],
     ec: TestScheduler,
     opts: Options
-  ) = {
+  ): Eq[Task[A]] = {
 
     Eq.by { task =>
       val p = Promise[A]()

--- a/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/AbstractBackPressuredBufferedSubscriber.scala
+++ b/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/AbstractBackPressuredBufferedSubscriber.scala
@@ -19,6 +19,7 @@ package monix.reactive.observers.buffers
 
 import monix.execution.Ack
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.execution.internal.collection.JSArrayQueue
 import monix.execution.internal.math.nextPowerOf2
 import scala.util.control.NonFatal
@@ -37,7 +38,7 @@ private[observers] abstract class AbstractBackPressuredBufferedSubscriber[A, R](
   private[this] val bufferSize = nextPowerOf2(_size)
 
   private[this] val em = out.scheduler.executionModel
-  implicit final val scheduler = out.scheduler
+  implicit final val scheduler: Scheduler = out.scheduler
 
   private[this] var upstreamIsComplete = false
   private[this] var downstreamIsComplete = false

--- a/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/SyncBufferedSubscriber.scala
+++ b/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/SyncBufferedSubscriber.scala
@@ -20,6 +20,7 @@ package monix.reactive.observers.buffers
 import monix.eval.Coeval
 import monix.execution.Ack
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.execution.internal.collection.{ JSArrayQueue, _ }
 
 import scala.util.control.NonFatal
@@ -38,7 +39,7 @@ private[observers] final class SyncBufferedSubscriber[-A] private (
   onOverflow: Long => Coeval[Option[A]] /*| Null*/,
 ) extends BufferedSubscriber[A] with Subscriber.Sync[A] {
 
-  implicit val scheduler = out.scheduler
+  implicit val scheduler: Scheduler = out.scheduler
   // to be modified only in onError, before upstreamIsComplete
   private[this] var errorThrown: Throwable = _
   // to be modified only in onError / onComplete

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/compression/internal/operators/DeflateOperator.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/compression/internal/operators/DeflateOperator.scala
@@ -21,6 +21,7 @@ import java.util.zip.Deflater
 
 import monix.execution.Ack
 import monix.execution.Ack.Continue
+import monix.execution.Scheduler
 import monix.reactive.Observable.Operator
 import monix.reactive.compression.{ CompressionLevel, CompressionParameters, CompressionStrategy, FlushMode }
 import monix.reactive.observers.Subscriber
@@ -36,7 +37,7 @@ private[compression] final class DeflateOperator(
 ) extends Operator[Array[Byte], Array[Byte]] {
   override def apply(out: Subscriber[Array[Byte]]): Subscriber[Array[Byte]] = {
     new Subscriber[Array[Byte]] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       private[this] var ack: Future[Ack] = Continue
       private[this] val deflate =

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/compression/internal/operators/GunzipOperator.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/compression/internal/operators/GunzipOperator.scala
@@ -22,6 +22,7 @@ import java.{ util => ju }
 
 import monix.execution.Ack
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.reactive.Observable.Operator
 import monix.reactive.compression.internal.operators.Gunzipper._
 import monix.reactive.compression.{
@@ -42,7 +43,7 @@ private[compression] final class GunzipOperator(bufferSize: Int) extends Operato
 
   def apply(out: Subscriber[Array[Byte]]): Subscriber[Array[Byte]] =
     new Subscriber[Array[Byte]] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       private[this] var isDone = false
       private[this] var ack: Future[Ack] = _

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/compression/internal/operators/GzipOperator.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/compression/internal/operators/GzipOperator.scala
@@ -23,6 +23,7 @@ import java.util.zip.{ CRC32, Deflater }
 
 import monix.execution.Ack
 import monix.execution.Ack.Continue
+import monix.execution.Scheduler
 import monix.reactive.Observable.Operator
 import monix.reactive.compression.internal.operators.Gzipper.gzipOperatingSystem
 import monix.reactive.compression.{
@@ -52,7 +53,7 @@ private[compression] final class GzipOperator(
 ) extends Operator[Array[Byte], Array[Byte]] {
   override def apply(out: Subscriber[Array[Byte]]): Subscriber[Array[Byte]] = {
     new Subscriber[Array[Byte]] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       private[this] var ack: Future[Ack] = _
       private[this] val gzipper =

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/compression/internal/operators/InflateOperator.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/compression/internal/operators/InflateOperator.scala
@@ -22,6 +22,7 @@ import java.{ util => ju }
 
 import monix.execution.Ack
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.reactive.Observable.Operator
 import monix.reactive.compression.CompressionException
 import monix.reactive.observers.Subscriber
@@ -36,7 +37,7 @@ private[compression] final class InflateOperator(bufferSize: Int, noWrap: Boolea
 
   def apply(out: Subscriber[Array[Byte]]): Subscriber[Array[Byte]] =
     new Subscriber[Array[Byte]] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       private[this] var isDone = false
       private[this] var ack: Future[Ack] = _

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/AbstractBackPressuredBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/AbstractBackPressuredBufferedSubscriber.scala
@@ -21,6 +21,7 @@ import monix.execution.{ Ack, ChannelType }
 import monix.execution.Ack.{ Continue, Stop }
 import monix.execution.BufferCapacity.Unbounded
 import monix.execution.ChannelType._
+import monix.execution.Scheduler
 import monix.execution.atomic.Atomic
 import monix.execution.atomic.PaddingStrategy.LeftRight256
 import monix.execution.internal.collection.LowLevelConcurrentQueue
@@ -46,7 +47,7 @@ private[observers] abstract class AbstractBackPressuredBufferedSubscriber[A, R](
 
   private[this] val bufferSize = math.nextPowerOf2(_bufferSize)
   private[this] val em = out.scheduler.executionModel
-  implicit final val scheduler = out.scheduler
+  implicit final val scheduler: Scheduler = out.scheduler
 
   protected final val queue: LowLevelConcurrentQueue[A] =
     LowLevelConcurrentQueue(

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/DropNewBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/DropNewBufferedSubscriber.scala
@@ -20,6 +20,7 @@ package monix.reactive.observers.buffers
 import monix.eval.Coeval
 import monix.execution.Ack
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.execution.atomic.PaddingStrategy.{ LeftRight128, LeftRight256 }
 import monix.execution.atomic.{ Atomic, AtomicInt }
 
@@ -43,7 +44,7 @@ private[observers] final class DropNewBufferedSubscriber[A] private (
 
   require(bufferSize > 0, "bufferSize must be a strictly positive number")
 
-  implicit val scheduler = out.scheduler
+  implicit val scheduler: Scheduler = out.scheduler
   private[this] val em = out.scheduler.executionModel
 
   private[this] val itemsToPush =

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/EvictingBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/EvictingBufferedSubscriber.scala
@@ -20,6 +20,7 @@ package monix.reactive.observers.buffers
 import monix.eval.Coeval
 import monix.execution.Ack
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.execution.atomic.PaddingStrategy.{ LeftRight128, LeftRight256 }
 import monix.execution.atomic.{ Atomic, AtomicAny, AtomicInt }
 import monix.execution.internal.math
@@ -114,7 +115,7 @@ private[observers] abstract class AbstractEvictingBufferedSubscriber[-A](
 
   require(strategy.bufferSize > 0, "bufferSize must be a strictly positive number")
 
-  implicit val scheduler = out.scheduler
+  implicit val scheduler: Scheduler = out.scheduler
   private[this] val em = out.scheduler.executionModel
 
   private[this] val droppedCount: AtomicInt =

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/SimpleBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/SimpleBufferedSubscriber.scala
@@ -21,6 +21,7 @@ import monix.execution.{ Ack, ChannelType }
 import monix.execution.Ack.{ Continue, Stop }
 import monix.execution.BufferCapacity.{ Bounded, Unbounded }
 import monix.execution.ChannelType.SingleConsumer
+import monix.execution.Scheduler
 import monix.execution.atomic.Atomic
 import monix.execution.atomic.PaddingStrategy.LeftRight256
 import monix.execution.exceptions.BufferOverflowException
@@ -62,7 +63,7 @@ private[observers] abstract class AbstractSimpleBufferedSubscriber[A] protected 
 
   private[this] val queue = _qRef
   private[this] val em = out.scheduler.executionModel
-  implicit val scheduler = out.scheduler
+  implicit val scheduler: Scheduler = out.scheduler
   private[this] val itemsToPush =
     Atomic.withPadding(0, LeftRight256)
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -379,7 +379,7 @@ abstract class Observable[+A] extends Serializable { self =>
   ): Cancelable = {
 
     subscribe(new Subscriber[A] {
-      implicit val scheduler = s
+      implicit val scheduler: Scheduler = s
 
       def onNext(elem: A) = nextFn(elem)
       def onComplete() = completedFn()

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest2Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest2Observable.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.builders
 
 import monix.execution.{ Ack, Cancelable }
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.execution.cancelables.CompositeCancelable
 import scala.util.control.NonFatal
 import monix.reactive.Observable
@@ -121,7 +122,7 @@ private[reactive] final class CombineLatest2Observable[A1, A2, +R](obsA1: Observ
     val composite = CompositeCancelable()
 
     composite += obsA1.unsafeSubscribeFn(new Subscriber[A1] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A1): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -143,7 +144,7 @@ private[reactive] final class CombineLatest2Observable[A1, A2, +R](obsA1: Observ
     })
 
     composite += obsA2.unsafeSubscribeFn(new Subscriber[A2] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A2): Future[Ack] = lock.synchronized {
         if (isDone) Stop

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest3Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest3Observable.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.builders
 
 import monix.execution.{ Ack, Cancelable }
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.execution.cancelables.CompositeCancelable
 import scala.util.control.NonFatal
 import monix.reactive.Observable
@@ -128,7 +129,7 @@ private[reactive] final class CombineLatest3Observable[A1, A2, A3, +R](
     val composite = CompositeCancelable()
 
     composite += obsA1.unsafeSubscribeFn(new Subscriber[A1] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A1): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -150,7 +151,7 @@ private[reactive] final class CombineLatest3Observable[A1, A2, A3, +R](
     })
 
     composite += obsA2.unsafeSubscribeFn(new Subscriber[A2] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A2): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -172,7 +173,7 @@ private[reactive] final class CombineLatest3Observable[A1, A2, A3, +R](
     })
 
     composite += obsA3.unsafeSubscribeFn(new Subscriber[A3] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A3): Future[Ack] = lock.synchronized {
         if (isDone) Stop

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest4Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest4Observable.scala
@@ -20,6 +20,7 @@ package monix.reactive.internal.builders
 import monix.execution.cancelables.CompositeCancelable
 import monix.execution.{ Ack, Cancelable }
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import scala.util.control.NonFatal
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
@@ -133,7 +134,7 @@ private[reactive] final class CombineLatest4Observable[A1, A2, A3, A4, +R](
     val composite = CompositeCancelable()
 
     composite += obsA1.unsafeSubscribeFn(new Subscriber[A1] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A1): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -155,7 +156,7 @@ private[reactive] final class CombineLatest4Observable[A1, A2, A3, A4, +R](
     })
 
     composite += obsA2.unsafeSubscribeFn(new Subscriber[A2] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A2): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -177,7 +178,7 @@ private[reactive] final class CombineLatest4Observable[A1, A2, A3, A4, +R](
     })
 
     composite += obsA3.unsafeSubscribeFn(new Subscriber[A3] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A3): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -199,7 +200,7 @@ private[reactive] final class CombineLatest4Observable[A1, A2, A3, A4, +R](
     })
 
     composite += obsA4.unsafeSubscribeFn(new Subscriber[A4] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A4): Future[Ack] = lock.synchronized {
         if (isDone) Stop

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest5Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest5Observable.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.builders
 
 import monix.execution.{ Ack, Cancelable }
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.execution.cancelables.CompositeCancelable
 import scala.util.control.NonFatal
 import monix.reactive.Observable
@@ -138,7 +139,7 @@ private[reactive] final class CombineLatest5Observable[A1, A2, A3, A4, A5, +R](
     val composite = CompositeCancelable()
 
     composite += obsA1.unsafeSubscribeFn(new Subscriber[A1] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A1): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -160,7 +161,7 @@ private[reactive] final class CombineLatest5Observable[A1, A2, A3, A4, A5, +R](
     })
 
     composite += obsA2.unsafeSubscribeFn(new Subscriber[A2] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A2): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -182,7 +183,7 @@ private[reactive] final class CombineLatest5Observable[A1, A2, A3, A4, A5, +R](
     })
 
     composite += obsA3.unsafeSubscribeFn(new Subscriber[A3] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A3): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -204,7 +205,7 @@ private[reactive] final class CombineLatest5Observable[A1, A2, A3, A4, A5, +R](
     })
 
     composite += obsA4.unsafeSubscribeFn(new Subscriber[A4] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A4): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -226,7 +227,7 @@ private[reactive] final class CombineLatest5Observable[A1, A2, A3, A4, A5, +R](
     })
 
     composite += obsA5.unsafeSubscribeFn(new Subscriber[A5] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A5): Future[Ack] = lock.synchronized {
         if (isDone) Stop

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest6Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/CombineLatest6Observable.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.builders
 
 import monix.execution.{ Ack, Cancelable }
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.execution.cancelables.CompositeCancelable
 import scala.util.control.NonFatal
 import monix.reactive.Observable
@@ -143,7 +144,7 @@ private[reactive] final class CombineLatest6Observable[A1, A2, A3, A4, A5, A6, +
     val composite = CompositeCancelable()
 
     composite += obsA1.unsafeSubscribeFn(new Subscriber[A1] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A1): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -165,7 +166,7 @@ private[reactive] final class CombineLatest6Observable[A1, A2, A3, A4, A5, A6, +
     })
 
     composite += obsA2.unsafeSubscribeFn(new Subscriber[A2] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A2): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -187,7 +188,7 @@ private[reactive] final class CombineLatest6Observable[A1, A2, A3, A4, A5, A6, +
     })
 
     composite += obsA3.unsafeSubscribeFn(new Subscriber[A3] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A3): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -209,7 +210,7 @@ private[reactive] final class CombineLatest6Observable[A1, A2, A3, A4, A5, A6, +
     })
 
     composite += obsA4.unsafeSubscribeFn(new Subscriber[A4] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A4): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -231,7 +232,7 @@ private[reactive] final class CombineLatest6Observable[A1, A2, A3, A4, A5, A6, +
     })
 
     composite += obsA5.unsafeSubscribeFn(new Subscriber[A5] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A5): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -253,7 +254,7 @@ private[reactive] final class CombineLatest6Observable[A1, A2, A3, A4, A5, A6, +
     })
 
     composite += obsA6.unsafeSubscribeFn(new Subscriber[A6] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A6): Future[Ack] = lock.synchronized {
         if (isDone) Stop

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ExecuteWithModelObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/ExecuteWithModelObservable.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.builders
 
 import scala.util.control.NonFatal
 import monix.execution.{ Ack, Cancelable, ExecutionModel }
+import monix.execution.Scheduler
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 
@@ -34,7 +35,7 @@ private[reactive] final class ExecuteWithModelObservable[A](source: Observable[A
       streamErrors = false
 
       source.unsafeSubscribeFn(new Subscriber[A] {
-        implicit val scheduler = newS
+        implicit val scheduler: Scheduler = newS
         def onError(ex: Throwable): Unit = out.onError(ex)
         def onComplete(): Unit = out.onComplete()
         def onNext(elem: A): Future[Ack] = out.onNext(elem)

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Interleave2Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Interleave2Observable.scala
@@ -20,6 +20,7 @@ package monix.reactive.internal.builders
 import monix.execution.Ack.{ Continue, Stop }
 import monix.execution.cancelables.CompositeCancelable
 import monix.execution.{ Ack, Cancelable }
+import monix.execution.Scheduler
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 import scala.concurrent.{ Future, Promise }
@@ -78,7 +79,7 @@ private[reactive] final class Interleave2Observable[+A](obsA1: Observable[A], ob
     val composite = CompositeCancelable()
 
     composite += obsA1.unsafeSubscribeFn(new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A): Future[Ack] = lock.synchronized {
         def sendSignal(elem: A): Future[Ack] = lock.synchronized {
@@ -112,7 +113,7 @@ private[reactive] final class Interleave2Observable[+A](obsA1: Observable[A], ob
     })
 
     composite += obsA2.unsafeSubscribeFn(new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A): Future[Ack] = lock.synchronized {
         def sendSignal(elem: A): Future[Ack] = lock.synchronized {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/PipeThroughSelectorObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/PipeThroughSelectorObservable.scala
@@ -18,6 +18,7 @@
 package monix.reactive.internal.builders
 
 import monix.execution.{ Ack, Cancelable }
+import monix.execution.Scheduler
 import monix.execution.cancelables.SingleAssignCancelable
 import scala.util.control.NonFatal
 import monix.reactive.observers.Subscriber
@@ -42,7 +43,7 @@ private[reactive] final class PipeThroughSelectorObservable[A, B, C](
       streamErrors = false
 
       val downstream = observable.unsafeSubscribeFn(new Subscriber[C] {
-        implicit val scheduler = out.scheduler
+        implicit val scheduler: Scheduler = out.scheduler
         def onError(ex: Throwable) = out.onError(ex)
         def onComplete() = out.onComplete()
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip2Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip2Observable.scala
@@ -18,7 +18,7 @@
 package monix.reactive.internal.builders
 
 import monix.execution.cancelables.CompositeCancelable
-import monix.execution.{ Ack, Cancelable }
+import monix.execution.{ Ack, Cancelable, Scheduler }
 import monix.execution.Ack.{ Continue, Stop }
 import scala.util.control.NonFatal
 import monix.reactive.Observable
@@ -136,7 +136,7 @@ private[reactive] final class Zip2Observable[A1, A2, +R](obsA1: Observable[A1], 
     val composite = CompositeCancelable()
 
     composite += obsA1.unsafeSubscribeFn(new Subscriber[A1] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A1): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -158,7 +158,7 @@ private[reactive] final class Zip2Observable[A1, A2, +R](obsA1: Observable[A1], 
     })
 
     composite += obsA2.unsafeSubscribeFn(new Subscriber[A2] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A2): Future[Ack] = lock.synchronized {
         if (isDone) Stop

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip3Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip3Observable.scala
@@ -17,7 +17,7 @@
 
 package monix.reactive.internal.builders
 
-import monix.execution.{ Ack, Cancelable }
+import monix.execution.{ Ack, Cancelable, Scheduler }
 import monix.execution.Ack.{ Continue, Stop }
 import monix.execution.cancelables.CompositeCancelable
 import scala.util.control.NonFatal
@@ -145,7 +145,7 @@ private[reactive] final class Zip3Observable[A1, A2, A3, +R](
     val composite = CompositeCancelable()
 
     composite += obsA1.unsafeSubscribeFn(new Subscriber[A1] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A1): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -168,7 +168,7 @@ private[reactive] final class Zip3Observable[A1, A2, A3, +R](
     })
 
     composite += obsA2.unsafeSubscribeFn(new Subscriber[A2] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A2): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -191,7 +191,7 @@ private[reactive] final class Zip3Observable[A1, A2, A3, +R](
     })
 
     composite += obsA3.unsafeSubscribeFn(new Subscriber[A3] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A3): Future[Ack] = lock.synchronized {
         if (isDone) Stop

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip4Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip4Observable.scala
@@ -17,7 +17,7 @@
 
 package monix.reactive.internal.builders
 
-import monix.execution.{ Ack, Cancelable }
+import monix.execution.{ Ack, Cancelable, Scheduler }
 import monix.execution.Ack.{ Continue, Stop }
 import monix.execution.cancelables.CompositeCancelable
 import scala.util.control.NonFatal
@@ -151,7 +151,7 @@ private[reactive] final class Zip4Observable[A1, A2, A3, A4, +R](
     val composite = CompositeCancelable()
 
     composite += obsA1.unsafeSubscribeFn(new Subscriber[A1] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A1): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -174,7 +174,7 @@ private[reactive] final class Zip4Observable[A1, A2, A3, A4, +R](
     })
 
     composite += obsA2.unsafeSubscribeFn(new Subscriber[A2] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A2): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -197,7 +197,7 @@ private[reactive] final class Zip4Observable[A1, A2, A3, A4, +R](
     })
 
     composite += obsA3.unsafeSubscribeFn(new Subscriber[A3] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A3): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -220,7 +220,7 @@ private[reactive] final class Zip4Observable[A1, A2, A3, A4, +R](
     })
 
     composite += obsA4.unsafeSubscribeFn(new Subscriber[A4] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A4): Future[Ack] = lock.synchronized {
         if (isDone) Stop

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip5Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip5Observable.scala
@@ -18,7 +18,7 @@
 package monix.reactive.internal.builders
 
 import monix.execution.cancelables.CompositeCancelable
-import monix.execution.{ Ack, Cancelable }
+import monix.execution.{ Ack, Cancelable, Scheduler }
 import monix.execution.Ack.{ Continue, Stop }
 import scala.util.control.NonFatal
 import monix.reactive.Observable
@@ -157,7 +157,7 @@ private[reactive] final class Zip5Observable[A1, A2, A3, A4, A5, +R](
     val composite = CompositeCancelable()
 
     composite += obsA1.unsafeSubscribeFn(new Subscriber[A1] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A1): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -180,7 +180,7 @@ private[reactive] final class Zip5Observable[A1, A2, A3, A4, A5, +R](
     })
 
     composite += obsA2.unsafeSubscribeFn(new Subscriber[A2] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A2): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -203,7 +203,7 @@ private[reactive] final class Zip5Observable[A1, A2, A3, A4, A5, +R](
     })
 
     composite += obsA3.unsafeSubscribeFn(new Subscriber[A3] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A3): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -226,7 +226,7 @@ private[reactive] final class Zip5Observable[A1, A2, A3, A4, A5, +R](
     })
 
     composite += obsA4.unsafeSubscribeFn(new Subscriber[A4] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A4): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -249,7 +249,7 @@ private[reactive] final class Zip5Observable[A1, A2, A3, A4, A5, +R](
     })
 
     composite += obsA5.unsafeSubscribeFn(new Subscriber[A5] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A5): Future[Ack] = lock.synchronized {
         if (isDone) Stop

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip6Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip6Observable.scala
@@ -18,7 +18,7 @@
 package monix.reactive.internal.builders
 
 import monix.execution.cancelables.CompositeCancelable
-import monix.execution.{ Ack, Cancelable }
+import monix.execution.{ Ack, Cancelable, Scheduler }
 import monix.execution.Ack.{ Continue, Stop }
 import scala.util.control.NonFatal
 import monix.reactive.Observable
@@ -163,7 +163,7 @@ private[reactive] final class Zip6Observable[A1, A2, A3, A4, A5, A6, +R](
     val composite = CompositeCancelable()
 
     composite += obsA1.unsafeSubscribeFn(new Subscriber[A1] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A1): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -186,7 +186,7 @@ private[reactive] final class Zip6Observable[A1, A2, A3, A4, A5, A6, +R](
     })
 
     composite += obsA2.unsafeSubscribeFn(new Subscriber[A2] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A2): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -209,7 +209,7 @@ private[reactive] final class Zip6Observable[A1, A2, A3, A4, A5, A6, +R](
     })
 
     composite += obsA3.unsafeSubscribeFn(new Subscriber[A3] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A3): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -232,7 +232,7 @@ private[reactive] final class Zip6Observable[A1, A2, A3, A4, A5, A6, +R](
     })
 
     composite += obsA4.unsafeSubscribeFn(new Subscriber[A4] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A4): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -255,7 +255,7 @@ private[reactive] final class Zip6Observable[A1, A2, A3, A4, A5, A6, +R](
     })
 
     composite += obsA5.unsafeSubscribeFn(new Subscriber[A5] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A5): Future[Ack] = lock.synchronized {
         if (isDone) Stop
@@ -278,7 +278,7 @@ private[reactive] final class Zip6Observable[A1, A2, A3, A4, A5, A6, +R](
     })
 
     composite += obsA6.unsafeSubscribeFn(new Subscriber[A6] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A6): Future[Ack] = lock.synchronized {
         if (isDone) Stop

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/CancelledConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/CancelledConsumer.scala
@@ -28,7 +28,7 @@ import monix.reactive.observers.Subscriber
 private[reactive] object CancelledConsumer extends Consumer.Sync[Any, Unit] {
   def createSubscriber(cb: Callback[Throwable, Unit], s: Scheduler): (Subscriber.Sync[Any], AssignableCancelable) = {
     val out = new Subscriber.Sync[Any] {
-      implicit val scheduler = s
+      implicit val scheduler: Scheduler = s
       def onNext(elem: Any): Ack = Stop
       def onComplete(): Unit = ()
       def onError(ex: Throwable): Unit = scheduler.reportFailure(ex)

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/CompleteConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/CompleteConsumer.scala
@@ -31,7 +31,7 @@ private[reactive] object CompleteConsumer extends Consumer.Sync[Any, Unit] {
     s: Scheduler
   ): (Subscriber.Sync[Any], AssignableCancelable) = {
     val out = new Subscriber.Sync[Any] {
-      implicit val scheduler = s
+      implicit val scheduler: Scheduler = s
       def onNext(elem: Any): Ack = Continue
       def onComplete(): Unit = cb.onSuccess(())
       def onError(ex: Throwable): Unit = cb.onError(ex)

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/ContraMapConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/ContraMapConsumer.scala
@@ -35,7 +35,7 @@ private[reactive] final class ContraMapConsumer[In2, -In, +R](source: Consumer[I
     val (out, c) = source.createSubscriber(cb, s)
 
     val out2 = new Subscriber[In2] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       // For protecting the contract
       private[this] var isDone = false
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/FirstNotificationConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/FirstNotificationConsumer.scala
@@ -31,7 +31,7 @@ private[reactive] final class FirstNotificationConsumer[A] extends Consumer.Sync
     s: Scheduler
   ): (Subscriber.Sync[A], AssignableCancelable) = {
     val out = new Subscriber.Sync[A] {
-      implicit val scheduler = s
+      implicit val scheduler: Scheduler = s
       private[this] var isDone = false
 
       def onNext(elem: A): Ack = {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/FoldLeftConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/FoldLeftConsumer.scala
@@ -30,7 +30,7 @@ private[reactive] final class FoldLeftConsumer[A, R](initial: () => R, f: (R, A)
 
   def createSubscriber(cb: Callback[Throwable, R], s: Scheduler): (Subscriber.Sync[A], AssignableCancelable) = {
     val out = new Subscriber.Sync[A] {
-      implicit val scheduler = s
+      implicit val scheduler: Scheduler = s
       private[this] var isDone = false
       private[this] var state = initial()
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/FoldLeftTaskConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/FoldLeftTaskConsumer.scala
@@ -36,7 +36,7 @@ private[reactive] final class FoldLeftTaskConsumer[A, R](initial: () => R, f: (R
     var lastCancelable = Cancelable.empty
 
     val out = new Subscriber[A] {
-      implicit val scheduler = s
+      implicit val scheduler: Scheduler = s
 
       private[this] var state = initial()
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/ForeachAsyncConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/ForeachAsyncConsumer.scala
@@ -35,7 +35,7 @@ private[reactive] final class ForeachAsyncConsumer[A](f: A => Task[Unit]) extend
     var lastCancelable = Cancelable.empty
 
     val out = new Subscriber[A] {
-      implicit val scheduler = s
+      implicit val scheduler: Scheduler = s
 
       def onNext(elem: A): Future[Ack] = {
         try {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/ForeachConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/ForeachConsumer.scala
@@ -30,7 +30,7 @@ private[reactive] final class ForeachConsumer[A](f: A => Unit) extends Consumer.
 
   def createSubscriber(cb: Callback[Throwable, Unit], s: Scheduler): (Subscriber.Sync[A], AssignableCancelable) = {
     val out = new Subscriber.Sync[A] {
-      implicit val scheduler = s
+      implicit val scheduler: Scheduler = s
       private[this] var isDone = false
 
       def onNext(elem: A): Ack = {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/FromObserverConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/FromObserverConsumer.scala
@@ -39,7 +39,7 @@ private[reactive] final class FromObserverConsumer[In](f: Scheduler => Observer[
 
       case Success(out) =>
         val sub = new Subscriber[In] { self =>
-          implicit val scheduler = s
+          implicit val scheduler: Scheduler = s
 
           private[this] val isDone = Atomic(false)
           private def signal(ex: Throwable): Unit =

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/HeadConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/HeadConsumer.scala
@@ -31,7 +31,7 @@ private[reactive] final class HeadConsumer[A] extends Consumer.Sync[A, A] {
     s: Scheduler
   ): (Subscriber.Sync[A], AssignableCancelable) = {
     val out = new Subscriber.Sync[A] {
-      implicit val scheduler = s
+      implicit val scheduler: Scheduler = s
       private[this] var isDone = false
 
       def onNext(elem: A): Ack = {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/HeadOptionConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/HeadOptionConsumer.scala
@@ -31,7 +31,7 @@ private[reactive] final class HeadOptionConsumer[A] extends Consumer.Sync[A, Opt
     s: Scheduler
   ): (Subscriber.Sync[A], AssignableCancelable) = {
     val out = new Subscriber.Sync[A] {
-      implicit val scheduler = s
+      implicit val scheduler: Scheduler = s
       private[this] var isDone = false
 
       def onNext(elem: A): Ack = {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/LoadBalanceConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/LoadBalanceConsumer.scala
@@ -48,7 +48,7 @@ private[reactive] final class LoadBalanceConsumer[-In, R](parallelism: Int, cons
     val mainCancelable = SingleAssignCancelable()
 
     val balanced = new Subscriber[In] { self =>
-      implicit val scheduler = s
+      implicit val scheduler: Scheduler = s
 
       // Trying to prevent contract violations, once this turns
       // true, then no final events are allowed to happen.

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/RaiseErrorConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/RaiseErrorConsumer.scala
@@ -29,7 +29,7 @@ private[reactive] final class RaiseErrorConsumer(ex: Throwable) extends Consumer
 
   def createSubscriber(cb: Callback[Throwable, Nothing], s: Scheduler): (Subscriber.Sync[Any], AssignableCancelable) = {
     val out = new Subscriber.Sync[Any] {
-      implicit val scheduler = s
+      implicit val scheduler: Scheduler = s
       def onNext(elem: Any): Ack = Stop
       def onComplete(): Unit = ()
       def onError(ex: Throwable): Unit = scheduler.reportFailure(ex)

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferSlidingOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferSlidingOperator.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
 import scala.concurrent.Future
@@ -31,7 +32,7 @@ private[reactive] final class BufferSlidingOperator[A](count: Int, skip: Int) ex
 
   def apply(out: Subscriber[Seq[A]]): Subscriber[A] =
     new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       private[this] var isDone = false
       private[this] var ack: Future[Ack] = _

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferTimedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferTimedObservable.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit
 
 import monix.execution.Ack.{ Continue, Stop }
 import monix.execution.cancelables.{ CompositeCancelable, MultiAssignCancelable }
-import monix.execution.{ Ack, Cancelable }
+import monix.execution.{ Ack, Cancelable, Scheduler }
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 
@@ -39,7 +39,7 @@ private[reactive] final class BufferTimedObservable[+A](source: Observable[A], t
     val periodicTask = MultiAssignCancelable()
 
     val connection = source.unsafeSubscribeFn(new Subscriber[A] with Runnable { self =>
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       private[this] val timespanMillis = timespan.toMillis
       // MUST BE synchronized by `self`

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferWhileOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferWhileOperator.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
 
@@ -29,7 +30,7 @@ import scala.util.control.NonFatal
 private[reactive] final class BufferWhileOperator[A](p: A => Boolean, inclusive: Boolean) extends Operator[A, Seq[A]] {
   def apply(out: Subscriber[Seq[A]]): Subscriber[A] =
     new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       private[this] var isDone = false
       private[this] var ack: Future[Ack] = Continue

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferWithSelectorObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/BufferWithSelectorObservable.scala
@@ -18,6 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.execution.cancelables.{ CompositeCancelable, SingleAssignCancelable }
 import monix.execution.{ Ack, Cancelable }
 import monix.reactive.Observable
@@ -38,7 +39,7 @@ private[reactive] final class BufferWithSelectorObservable[+A, S](
     val composite = CompositeCancelable(upstreamSubscription, samplerSubscription)
 
     upstreamSubscription := source.unsafeSubscribeFn(new Subscriber[A] { upstreamSubscriber =>
-      implicit val scheduler = downstream.scheduler
+      implicit val scheduler: Scheduler = downstream.scheduler
 
       // MUST BE synchronized by `self`
       private[this] var buffer = ListBuffer.empty[A]
@@ -82,7 +83,7 @@ private[reactive] final class BufferWithSelectorObservable[+A, S](
         }
 
       samplerSubscription := sampler.unsafeSubscribeFn(new Subscriber[S] {
-        implicit val scheduler = downstream.scheduler
+        implicit val scheduler: Scheduler = downstream.scheduler
 
         def onNext(elem: S): Future[Ack] =
           upstreamSubscriber.synchronized(signalNext())

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/CollectOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/CollectOperator.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import scala.util.control.NonFatal
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
@@ -30,7 +31,7 @@ private[reactive] final class CollectOperator[-A, +B](pf: PartialFunction[A, B])
 
   def apply(out: Subscriber[B]): Subscriber[A] = {
     new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       private[this] var isDone = false
 
       def onNext(elem: A): Future[Ack] = {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/CollectWhileOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/CollectWhileOperator.scala
@@ -19,7 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack
 import monix.execution.Ack.Stop
-
+import monix.execution.Scheduler
 import scala.util.control.NonFatal
 import monix.reactive.Observable.Operator
 import monix.reactive.internal.operators.CollectOperator.{ checkFallback, isDefined }
@@ -31,7 +31,7 @@ private[reactive] final class CollectWhileOperator[-A, +B](pf: PartialFunction[A
 
   def apply(out: Subscriber[B]): Subscriber[A] =
     new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       private[this] var isActive = true
 
       def onNext(elem: A): Future[Ack] = {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/CompletedOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/CompletedOperator.scala
@@ -18,13 +18,14 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.Continue
+import monix.execution.Scheduler
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
 
 private[reactive] object CompletedOperator extends Operator[Any, Nothing] {
   def apply(out: Subscriber[Nothing]): Subscriber[Any] =
     new Subscriber.Sync[Any] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       def onNext(elem: Any) = Continue
       def onError(ex: Throwable): Unit = out.onError(ex)
       def onComplete(): Unit = out.onComplete()

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ConcatMapIterableOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ConcatMapIterableOperator.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
 
@@ -30,7 +31,7 @@ private[reactive] final class ConcatMapIterableOperator[-A, +B](f: A => immutabl
 
   def apply(out: Subscriber[B]): Subscriber[A] = {
     new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       private[this] var isDone = false
       private[this] var ack: Future[Ack] = Continue
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ConcatMapObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ConcatMapObservable.scala
@@ -20,6 +20,7 @@ package monix.reactive.internal.operators
 import cats.effect.ExitCase
 import monix.eval.Task
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.execution.atomic.Atomic
 import monix.execution.atomic.PaddingStrategy.LeftRight128
 
@@ -86,7 +87,7 @@ private[reactive] final class ConcatMapObservable[A, B](
     import ConcatMapObservable.FlatMapState
     import ConcatMapObservable.FlatMapState._
 
-    implicit val scheduler = out.scheduler
+    implicit val scheduler: Scheduler = out.scheduler
 
     // For gathering errors
     private[this] val errors =
@@ -340,7 +341,7 @@ private[reactive] final class ConcatMapObservable[A, B](
 
     private final class ChildSubscriber(out: Subscriber[B], asyncUpstreamAck: Promise[Ack]) extends Subscriber[B] {
 
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       private[this] var ack: Future[Ack] = Continue
 
       // Reusable reference to stop creating function references for each `onNext`

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ConcatObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ConcatObservable.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack
 import monix.execution.Ack.Continue
+import monix.execution.Scheduler
 import monix.execution.cancelables.AssignableCancelable
 import monix.reactive.Observable
 import monix.reactive.observables.ChainedObservable
@@ -36,7 +37,7 @@ private[reactive] final class ConcatObservable[A](lh: Observable[A], rh: Observa
       conn,
       new Subscriber[A] {
         private[this] var ack: Future[Ack] = Continue
-        implicit val scheduler = out.scheduler
+        implicit val scheduler: Scheduler = out.scheduler
 
         def onNext(elem: A): Future[Ack] = {
           ack = out.onNext(elem)

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/CountOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/CountOperator.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack
 import monix.execution.Ack.Continue
+import monix.execution.Scheduler
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
 import scala.concurrent.Future
@@ -26,7 +27,7 @@ import scala.concurrent.Future
 private[reactive] object CountOperator extends Operator[Any, Long] {
   def apply(out: Subscriber[Long]): Subscriber[Any] =
     new Subscriber[Any] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       private[this] var count = 0L
 
       def onNext(elem: Any): Future[Ack] = {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DebounceObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DebounceObservable.scala
@@ -20,6 +20,7 @@ package monix.reactive.internal.operators
 import java.util.concurrent.TimeUnit
 
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.execution.cancelables.{ CompositeCancelable, MultiAssignCancelable, SingleAssignCancelable }
 import monix.execution.{ Ack, Cancelable }
 import monix.reactive.Observable
@@ -36,7 +37,7 @@ private[reactive] final class DebounceObservable[A](source: Observable[A], timeo
     val composite = CompositeCancelable(mainTask, task)
 
     mainTask := source.unsafeSubscribeFn(new Subscriber.Sync[A] with Runnable { self =>
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       private[this] val timeoutMillis = timeout.toMillis
       private[this] var isDone = false

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DefaultIfEmptyOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DefaultIfEmptyOperator.scala
@@ -18,6 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack
+import monix.execution.Scheduler
 import scala.util.control.NonFatal
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
@@ -28,7 +29,7 @@ private[reactive] final class DefaultIfEmptyOperator[A](default: () => A) extend
 
   def apply(out: Subscriber[A]): Subscriber[A] =
     new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       private[this] var isEmpty = true
 
       def onNext(elem: A): Future[Ack] = {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayBySelectorObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayBySelectorObservable.scala
@@ -18,6 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.execution.cancelables.{ CompositeCancelable, MultiAssignCancelable }
 import scala.util.control.NonFatal
 import monix.execution.{ Ack, Cancelable }
@@ -34,7 +35,7 @@ private[reactive] final class DelayBySelectorObservable[A, S](source: Observable
     val composite = CompositeCancelable(task)
 
     composite += source.unsafeSubscribeFn(new Subscriber[A] { self =>
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       private[this] var completeTriggered = false
       private[this] var isDone = false
@@ -42,7 +43,7 @@ private[reactive] final class DelayBySelectorObservable[A, S](source: Observable
       private[this] var ack: Promise[Ack] = _
 
       private[this] val trigger = new Subscriber.Sync[Any] {
-        implicit val scheduler = out.scheduler
+        implicit val scheduler: Scheduler = out.scheduler
         def onNext(elem: Any): Ack = throw new IllegalStateException
         def onError(ex: Throwable): Unit = self.onError(ex)
         def onComplete(): Unit = self.sendOnNext()

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayByTimespanObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayByTimespanObservable.scala
@@ -20,6 +20,7 @@ package monix.reactive.internal.operators
 import java.util.concurrent.TimeUnit
 
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.execution.cancelables.{ CompositeCancelable, MultiAssignCancelable }
 import monix.execution.{ Ack, Cancelable }
 import monix.reactive.Observable
@@ -36,7 +37,7 @@ private[reactive] final class DelayByTimespanObservable[A](source: Observable[A]
     val composite = CompositeCancelable(task)
 
     composite += source.unsafeSubscribeFn(new Subscriber[A] with Runnable { self =>
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       private[this] var hasError = false
       private[this] val isDone = Atomic(false)
       private[this] var completeTriggered = false

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayExecutionWithTriggerObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DelayExecutionWithTriggerObservable.scala
@@ -18,6 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.Stop
+import monix.execution.Scheduler
 import monix.execution.cancelables.OrderedCancelable
 import monix.execution.{ Ack, Cancelable }
 import monix.reactive.Observable
@@ -33,7 +34,7 @@ private[reactive] final class DelayExecutionWithTriggerObservable[A](source: Obs
     val main = trigger
       .asInstanceOf[Observable[Any]]
       .unsafeSubscribeFn(new Subscriber[Any] {
-        implicit val scheduler = subscriber.scheduler
+        implicit val scheduler: Scheduler = subscriber.scheduler
         private[this] var isDone = false
 
         def onNext(elem: Any): Future[Ack] = {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DematerializeOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DematerializeOperator.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack
 import monix.execution.Ack.Stop
+import monix.execution.Scheduler
 import monix.reactive.Notification
 import monix.reactive.Notification.{ OnComplete, OnError, OnNext }
 import monix.reactive.Observable.Operator
@@ -29,7 +30,7 @@ private[reactive] final class DematerializeOperator[A] extends Operator[Notifica
 
   def apply(out: Subscriber[A]): Subscriber[Notification[A]] =
     new Subscriber[Notification[A]] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       private[this] var isDone = false
 
       def onNext(elem: Notification[A]): Future[Ack] = {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DistinctUntilChangedByKeyOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DistinctUntilChangedByKeyOperator.scala
@@ -20,6 +20,7 @@ package monix.reactive.internal.operators
 import cats.Eq
 import monix.execution.Ack
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.reactive.Observable.Operator
 
 import scala.util.control.NonFatal
@@ -32,7 +33,7 @@ private[reactive] final class DistinctUntilChangedByKeyOperator[A, K](key: A => 
 
   def apply(out: Subscriber[A]): Subscriber[A] =
     new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       private[this] var isDone = false
       private[this] var isFirst = true

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DistinctUntilChangedOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DistinctUntilChangedOperator.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import cats.Eq
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 
 import scala.util.control.NonFatal
 import monix.reactive.Observable.Operator
@@ -29,7 +30,7 @@ private[reactive] final class DistinctUntilChangedOperator[A](implicit A: Eq[A])
   /** Implementation for `Observable.distinctUntilChanged`. */
   def apply(out: Subscriber[A]): Subscriber[A] =
     new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       private[this] var isFirst = true
       private[this] var lastElem: A = _
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnCompleteOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnCompleteOperator.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.eval.Task
 import monix.execution.Ack
+import monix.execution.Scheduler
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
 import scala.concurrent.Future
@@ -27,7 +28,7 @@ private[reactive] final class DoOnCompleteOperator[A](task: Task[Unit]) extends 
 
   def apply(out: Subscriber[A]): Subscriber[A] =
     new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A): Future[Ack] = out.onNext(elem)
       def onError(ex: Throwable): Unit = out.onError(ex)

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnEarlyStopOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnEarlyStopOperator.scala
@@ -20,6 +20,7 @@ package monix.reactive.internal.operators
 import monix.eval.Task
 import monix.execution.Ack
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.execution.atomic.Atomic
 import scala.util.control.NonFatal
 import monix.reactive.Observable.Operator
@@ -33,7 +34,7 @@ private[reactive] final class DoOnEarlyStopOperator[A](onStop: Task[Unit]) exten
 
   def apply(out: Subscriber[A]): Subscriber[A] =
     new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       private[this] val isActive = Atomic(true)
 
       def onNext(elem: A): Future[Ack] = {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnErrorOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnErrorOperator.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.eval.Task
 import monix.execution.Ack
+import monix.execution.Scheduler
 import scala.util.control.NonFatal
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
@@ -28,7 +29,7 @@ private[reactive] final class DoOnErrorOperator[A](cb: Throwable => Task[Unit]) 
 
   def apply(out: Subscriber[A]): Subscriber[A] =
     new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A): Future[Ack] = out.onNext(elem)
       def onComplete(): Unit = out.onComplete()

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnNextAckOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnNextAckOperator.scala
@@ -20,6 +20,7 @@ package monix.reactive.internal.operators
 import monix.eval.Task
 import monix.execution.Ack
 import monix.execution.Ack.Stop
+import monix.execution.Scheduler
 import monix.execution.atomic.Atomic
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
@@ -31,7 +32,7 @@ private[reactive] final class DoOnNextAckOperator[A](cb: (A, Ack) => Task[Unit])
 
   def apply(out: Subscriber[A]): Subscriber[A] =
     new Subscriber[A] { self =>
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       private[this] val isActive = Atomic(true)
 
       def onNext(elem: A): Future[Ack] = {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnStartOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnStartOperator.scala
@@ -20,6 +20,7 @@ package monix.reactive.internal.operators
 import monix.eval.Task
 import monix.execution.Ack
 import monix.execution.Ack.Stop
+import monix.execution.Scheduler
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
 
@@ -30,7 +31,7 @@ private[reactive] final class DoOnStartOperator[A](cb: A => Task[Unit]) extends 
 
   def apply(out: Subscriber[A]): Subscriber[A] =
     new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       private[this] var isDone = false
       private[this] var isStart = true

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnSubscribeObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnSubscribeObservable.scala
@@ -20,6 +20,7 @@ package monix.reactive.internal.operators
 import monix.execution.Callback
 import monix.eval.Task
 import monix.execution.Ack.Stop
+import monix.execution.Scheduler
 import monix.execution.atomic.Atomic
 import monix.execution.cancelables.{ OrderedCancelable, SingleAssignCancelable, StackedCancelable }
 import monix.execution.schedulers.TrampolineExecutionContext.immediate
@@ -61,7 +62,7 @@ private[reactive] object DoOnSubscribeObservable {
 
       val cancelable = source.unsafeSubscribeFn(
         new Subscriber[A] {
-          implicit val scheduler = out.scheduler
+          implicit val scheduler: Scheduler = out.scheduler
           private[this] val completeGuard = Atomic(true)
           private[this] var isActive = false
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnTerminateOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DoOnTerminateOperator.scala
@@ -21,6 +21,7 @@ import monix.execution.Callback
 import monix.eval.Task
 import monix.execution.Ack
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.execution.atomic.Atomic
 import scala.util.control.NonFatal
 import monix.reactive.internal.util.Instances._
@@ -39,7 +40,7 @@ private[reactive] final class DoOnTerminateOperator[A](
       // Wrapping in a cancelable in order to protect it from
       // being called multiple times
       private[this] val active = Atomic(true)
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A): Future[Ack] = {
         val result =

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropByPredicateOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropByPredicateOperator.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import scala.util.control.NonFatal
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
@@ -28,7 +29,7 @@ private[reactive] final class DropByPredicateOperator[A](p: A => Boolean, inclus
 
   def apply(out: Subscriber[A]): Subscriber[A] =
     new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       private[this] var continueDropping = true
       private[this] var isDone = false
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropByPredicateWithIndexOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropByPredicateWithIndexOperator.scala
@@ -18,6 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import scala.util.control.NonFatal
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
@@ -26,7 +27,7 @@ private[reactive] final class DropByPredicateWithIndexOperator[A](p: (A, Int) =>
 
   def apply(out: Subscriber[A]): Subscriber[A] =
     new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       private[this] var continueDropping = true
       private[this] var index = 0
       private[this] var isDone = false

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropByTimespanObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropByTimespanObservable.scala
@@ -18,6 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.Continue
+import monix.execution.Scheduler
 import monix.execution.cancelables.{ CompositeCancelable, SingleAssignCancelable }
 import monix.execution.{ Ack, Cancelable }
 import monix.reactive.Observable
@@ -33,7 +34,7 @@ private[reactive] final class DropByTimespanObservable[A](source: Observable[A],
     val composite = CompositeCancelable(trigger)
 
     composite += source.unsafeSubscribeFn(new Subscriber[A] with Runnable { self =>
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       @volatile private[this] var shouldDrop = true
 
       locally {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropFirstOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropFirstOperator.scala
@@ -18,6 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.Continue
+import monix.execution.Scheduler
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
 
@@ -25,7 +26,7 @@ private[reactive] final class DropFirstOperator[A](nr: Long) extends Operator[A,
 
   def apply(out: Subscriber[A]): Subscriber[A] =
     new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       private[this] var count = 0L
 
       def onNext(elem: A) = {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropLastOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropLastOperator.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack
 import monix.execution.Ack.Continue
+import monix.execution.Scheduler
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
 import scala.collection.mutable
@@ -30,7 +31,7 @@ private[reactive] final class DropLastOperator[A](n: Int) extends Operator[A, A]
 
   def apply(out: Subscriber[A]): Subscriber[A] =
     new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       private[this] var queue = mutable.Queue.empty[A]
       private[this] var length = 0
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropUntilObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DropUntilObservable.scala
@@ -18,6 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.execution.cancelables.{ CompositeCancelable, SingleAssignCancelable }
 import monix.execution.{ Ack, Cancelable }
 import monix.reactive.Observable
@@ -32,7 +33,7 @@ private[reactive] final class DropUntilObservable[A](source: Observable[A], trig
     val composite = CompositeCancelable(task)
 
     composite += source.unsafeSubscribeFn(new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       private[this] var isActive = true
       private[this] var errorThrown: Throwable = null
@@ -47,7 +48,7 @@ private[reactive] final class DropUntilObservable[A](source: Observable[A], trig
 
       locally {
         task := trigger.unsafeSubscribeFn(new Subscriber.Sync[Any] {
-          implicit val scheduler = out.scheduler
+          implicit val scheduler: Scheduler = out.scheduler
           def onNext(elem: Any) = interruptDropMode(null)
           def onComplete(): Unit = { interruptDropMode(null); () }
           def onError(ex: Throwable): Unit = { interruptDropMode(ex); () }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DumpObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/DumpObservable.scala
@@ -20,7 +20,7 @@ package monix.reactive.internal.operators
 import java.io.PrintStream
 
 import scala.util.control.NonFatal
-import monix.execution.{ Ack, Cancelable }
+import monix.execution.{ Ack, Cancelable, Scheduler }
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 
@@ -33,7 +33,7 @@ private[reactive] final class DumpObservable[A](source: Observable[A], prefix: S
     var pos = 0
 
     val upstream = source.unsafeSubscribeFn(new Subscriber[A] {
-      implicit val scheduler = subscriber.scheduler
+      implicit val scheduler: Scheduler = subscriber.scheduler
 
       private[this] val downstreamActive = Cancelable { () =>
         pos += 1

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EchoObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EchoObservable.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit
 
 import monix.execution.Ack.{ Continue, Stop }
 import monix.execution.cancelables.{ CompositeCancelable, MultiAssignCancelable, SingleAssignCancelable }
-import monix.execution.{ Ack, Cancelable }
+import monix.execution.{ Ack, Cancelable, Scheduler }
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 
@@ -40,7 +40,7 @@ private[reactive] final class EchoObservable[+A](source: Observable[A], timeout:
     val composite = CompositeCancelable(mainTask, task)
 
     mainTask := source.unsafeSubscribeFn(new Subscriber[A] with Runnable { self =>
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       private[this] var ack: Future[Ack] = Continue
       private[this] var lastEvent: A = _

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EndWithErrorOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/EndWithErrorOperator.scala
@@ -18,6 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack
+import monix.execution.Scheduler
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
 import scala.concurrent.Future
@@ -26,7 +27,7 @@ private[reactive] final class EndWithErrorOperator[A](error: Throwable) extends 
 
   def apply(out: Subscriber[A]): Subscriber[A] =
     new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       def onNext(elem: A): Future[Ack] = out.onNext(elem)
       def onError(ex: Throwable): Unit = out.onError(ex)
       def onComplete(): Unit = out.onError(error)

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FailedOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FailedOperator.scala
@@ -18,13 +18,14 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.Continue
+import monix.execution.Scheduler
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
 
 private[reactive] object FailedOperator extends Operator[Any, Throwable] {
   def apply(out: Subscriber[Throwable]): Subscriber[Any] =
     new Subscriber.Sync[Any] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       def onNext(elem: Any) = Continue
       def onComplete(): Unit = out.onComplete()
       def onError(ex: Throwable): Unit = {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FilterOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FilterOperator.scala
@@ -18,6 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import scala.util.control.NonFatal
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
@@ -26,7 +27,7 @@ private[reactive] final class FilterOperator[A](p: A => Boolean) extends Operato
 
   def apply(out: Subscriber[A]): Subscriber[A] =
     new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       private[this] var isDone = false
 
       def onNext(elem: A) = {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FlatScanObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FlatScanObservable.scala
@@ -21,7 +21,7 @@ import monix.execution.Ack.{ Continue, Stop }
 import monix.execution.atomic.Atomic
 import monix.execution.atomic.PaddingStrategy.LeftRight128
 import scala.util.control.NonFatal
-import monix.execution.{ Ack, Cancelable }
+import monix.execution.{ Ack, Cancelable, Scheduler }
 import monix.execution.exceptions.CompositeException
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
@@ -71,7 +71,7 @@ private[reactive] final class FlatScanObservable[A, R](
     import ConcatMapObservable.FlatMapState
     import ConcatMapObservable.FlatMapState._
 
-    implicit val scheduler = out.scheduler
+    implicit val scheduler: Scheduler = out.scheduler
 
     // For gathering errors
     private[this] val errors =
@@ -314,7 +314,7 @@ private[reactive] final class FlatScanObservable[A, R](
 
     private final class ChildSubscriber(out: Subscriber[R], asyncUpstreamAck: Promise[Ack]) extends Subscriber[R] {
 
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       private[this] var ack: Future[Ack] = Continue
 
       // Reusable reference to stop creating function references for each `onNext`

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FoldLeftObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FoldLeftObservable.scala
@@ -19,7 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack.{ Continue, Stop }
 import scala.util.control.NonFatal
-import monix.execution.{ Ack, Cancelable }
+import monix.execution.{ Ack, Cancelable, Scheduler }
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 
@@ -33,7 +33,7 @@ private[reactive] final class FoldLeftObservable[A, R](source: Observable[A], in
       streamErrors = false
 
       source.unsafeSubscribeFn(new Subscriber.Sync[A] {
-        implicit val scheduler = out.scheduler
+        implicit val scheduler: Scheduler = out.scheduler
         private[this] var isDone = false
         private[this] var state: R = initialState
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FoldWhileLeftObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/FoldWhileLeftObservable.scala
@@ -19,7 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack.{ Continue, Stop }
 import scala.util.control.NonFatal
-import monix.execution.{ Ack, Cancelable }
+import monix.execution.{ Ack, Cancelable, Scheduler }
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 
@@ -38,7 +38,7 @@ private[reactive] final class FoldWhileLeftObservable[A, S](
       streamErrors = false
 
       source.unsafeSubscribeFn(new Subscriber[A] {
-        implicit val scheduler = out.scheduler
+        implicit val scheduler: Scheduler = out.scheduler
         private[this] var isDone = false
         private[this] var state = initialState
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/IntersperseObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/IntersperseObservable.scala
@@ -18,7 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.Continue
-import monix.execution.{ Ack, Cancelable }
+import monix.execution.{ Ack, Cancelable, Scheduler }
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 
@@ -33,7 +33,7 @@ private[reactive] final class IntersperseObservable[+A](
 
   override def unsafeSubscribeFn(out: Subscriber[A]): Cancelable = {
     val upstream = source.unsafeSubscribeFn(new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       private[this] var atLeastOne = false
       private[this] var downstreamAck = Continue: Future[Ack]

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/IsEmptyOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/IsEmptyOperator.scala
@@ -19,13 +19,14 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack
 import monix.execution.Ack.Stop
+import monix.execution.Scheduler
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
 
 private[reactive] object IsEmptyOperator extends Operator[Any, Boolean] {
   def apply(out: Subscriber[Boolean]): Subscriber[Any] =
     new Subscriber[Any] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       private[this] var isDone = false
       private[this] var isEmpty = true
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapOperator.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack
 import monix.execution.Ack.Stop
+import monix.execution.Scheduler
 import scala.util.control.NonFatal
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
@@ -28,7 +29,7 @@ private[reactive] final class MapOperator[-A, +B](f: A => B) extends Operator[A,
 
   def apply(out: Subscriber[B]): Subscriber[A] = {
     new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       private[this] var isDone = false
 
       def onNext(elem: A): Future[Ack] = {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapParallelOrderedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapParallelOrderedObservable.scala
@@ -24,7 +24,7 @@ import monix.execution.Ack.{ Continue, Stop }
 import monix.execution.cancelables.CompositeCancelable
 import monix.execution.AsyncSemaphore
 import monix.execution.ChannelType.MultiProducer
-import monix.execution.{ Ack, Cancelable, CancelableFuture }
+import monix.execution.{ Ack, Cancelable, CancelableFuture, Scheduler }
 import monix.reactive.observers.{ BufferedSubscriber, Subscriber }
 import monix.reactive.{ Observable, OverflowStrategy }
 
@@ -57,7 +57,7 @@ private[reactive] final class MapParallelOrderedObservable[A, B](
   private final class MapAsyncParallelSubscription(out: Subscriber[B], composite: CompositeCancelable)
     extends Subscriber[A] with Cancelable { self =>
 
-    implicit val scheduler = out.scheduler
+    implicit val scheduler: Scheduler = out.scheduler
     // Ensures we don't execute more than a maximum number of tasks in parallel
     private[this] val semaphore = AsyncSemaphore(parallelism.toLong)
     // Buffer with the supplied  overflow strategy.

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapParallelUnorderedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapParallelUnorderedObservable.scala
@@ -17,7 +17,7 @@
 
 package monix.reactive.internal.operators
 
-import monix.execution.{ Ack, AsyncSemaphore, Callback, Cancelable }
+import monix.execution.{ Ack, AsyncSemaphore, Callback, Cancelable, Scheduler }
 import monix.eval.Task
 import monix.execution.Ack.{ Continue, Stop }
 import monix.execution.ChannelType.MultiProducer
@@ -66,7 +66,7 @@ private[reactive] final class MapParallelUnorderedObservable[A, B](
   private final class MapAsyncParallelSubscription(out: Subscriber[B], composite: CompositeCancelable)
     extends Subscriber[A] with Cancelable { self =>
 
-    implicit val scheduler = out.scheduler
+    implicit val scheduler: Scheduler = out.scheduler
     // Ensures we don't execute more than a maximum number of tasks in parallel
     private[this] val semaphore = AsyncSemaphore(parallelism.toLong)
     // Buffer with the supplied  overflow strategy.

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapTaskObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapTaskObservable.scala
@@ -22,7 +22,7 @@ import monix.execution.Ack.Stop
 import monix.execution.atomic.Atomic
 import monix.execution.atomic.PaddingStrategy.LeftRight128
 import scala.util.control.NonFatal
-import monix.execution.{ Ack, Cancelable }
+import monix.execution.{ Ack, Cancelable, Scheduler }
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 
@@ -79,7 +79,7 @@ private[reactive] final class MapTaskObservable[A, B](source: Observable[A], f: 
     import MapTaskObservable.MapTaskState
     import MapTaskObservable.MapTaskState._
 
-    implicit val scheduler = out.scheduler
+    implicit val scheduler: Scheduler = out.scheduler
 
     // For synchronizing our internal state machine, padded
     // in order to avoid the false sharing problem

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MaterializeOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MaterializeOperator.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack
 import monix.execution.Ack.Continue
+import monix.execution.Scheduler
 import monix.reactive.Notification
 import monix.reactive.Notification.{ OnComplete, OnError, OnNext }
 import monix.reactive.Observable.Operator
@@ -29,7 +30,7 @@ private[reactive] final class MaterializeOperator[A] extends Operator[A, Notific
 
   def apply(out: Subscriber[Notification[A]]): Subscriber[A] =
     new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       private[this] var isDone = false
       private[this] var ack: Future[Ack] = Continue
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MergeMapObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MergeMapObservable.scala
@@ -19,7 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack.{ Continue, Stop }
 import monix.execution.ChannelType.MultiProducer
-import monix.execution.{ Ack, Cancelable }
+import monix.execution.{ Ack, Cancelable, Scheduler }
 import monix.execution.cancelables._
 import monix.execution.exceptions.CompositeException
 import monix.reactive.observers.{ BufferedSubscriber, Subscriber }
@@ -39,7 +39,7 @@ private[reactive] final class MergeMapObservable[A, B](
     val composite = CompositeCancelable()
 
     composite += source.unsafeSubscribeFn(new Subscriber[A] {
-      implicit val scheduler = downstream.scheduler
+      implicit val scheduler: Scheduler = downstream.scheduler
       private[this] val subscriberB: Subscriber[B] =
         BufferedSubscriber(downstream, overflowStrategy, MultiProducer)
 
@@ -84,7 +84,7 @@ private[reactive] final class MergeMapObservable[A, B](
           composite += childTask
 
           childTask := fb.unsafeSubscribeFn(new Subscriber[B] {
-            implicit val scheduler = downstream.scheduler
+            implicit val scheduler: Scheduler = downstream.scheduler
 
             def onNext(elem: B) = {
               subscriberB.onNext(elem).syncOnStopOrFailure { _ => cancelUpstream(); () }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ObserveOnObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ObserveOnObservable.scala
@@ -33,7 +33,7 @@ private[reactive] final class ObserveOnObservable[+A](source: Observable[A], alt
     // will be listened on that specified `Scheduler`
     val buffer = {
       val ref: Subscriber[A] = new Subscriber[A] {
-        implicit val scheduler = altS
+        implicit val scheduler: Scheduler = altS
         def onNext(a: A) = out.onNext(a)
         def onError(ex: Throwable) = out.onError(ex)
         def onComplete() = out.onComplete()
@@ -46,7 +46,7 @@ private[reactive] final class ObserveOnObservable[+A](source: Observable[A], alt
     // because we only want to listen to events on the specified Scheduler,
     // but we don't want to override the Observable's default Scheduler
     source.unsafeSubscribeFn(new Subscriber[A] {
-      implicit val scheduler =
+      implicit val scheduler: Scheduler =
         out.scheduler
       def onNext(elem: A): Future[Ack] =
         buffer.onNext(elem)

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/OnCancelTriggerErrorObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/OnCancelTriggerErrorObservable.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack.{ Continue, Stop }
 import monix.execution.{ Ack, Cancelable }
+import monix.execution.Scheduler
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 import scala.concurrent.Future
@@ -28,7 +29,7 @@ private[reactive] final class OnCancelTriggerErrorObservable[A](source: Observab
 
   def unsafeSubscribeFn(downstream: Subscriber[A]): Cancelable = {
     val out: Subscriber[A] = new Subscriber[A] { self =>
-      implicit val scheduler = downstream.scheduler
+      implicit val scheduler: Scheduler = downstream.scheduler
       private[this] var isDone = false
 
       def onNext(elem: A): Future[Ack] =

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/OnErrorRecoverWithObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/OnErrorRecoverWithObservable.scala
@@ -18,6 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.Continue
+import monix.execution.Scheduler
 import monix.execution.cancelables.OrderedCancelable
 import scala.util.control.NonFatal
 import monix.execution.{ Ack, Cancelable }
@@ -33,7 +34,7 @@ private[reactive] final class OnErrorRecoverWithObservable[A](source: Observable
     val cancelable = OrderedCancelable()
 
     val main = source.unsafeSubscribeFn(new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       private[this] var ack: Future[Ack] = Continue
 
       def onNext(elem: A) = {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/PipeThroughObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/PipeThroughObservable.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.cancelables.SingleAssignCancelable
 import monix.execution.{ Ack, Cancelable }
+import monix.execution.Scheduler
 import monix.reactive.observers.Subscriber
 import monix.reactive.{ Observable, Pipe }
 import scala.concurrent.Future
@@ -32,7 +33,7 @@ private[reactive] final class PipeThroughObservable[A, B](source: Observable[A],
     val upstream = SingleAssignCancelable()
 
     val downstream = output.unsafeSubscribeFn(new Subscriber[B] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       def onError(ex: Throwable) = out.onError(ex)
       def onComplete() = out.onComplete()
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ReduceOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ReduceOperator.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import scala.util.control.NonFatal
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
@@ -28,7 +29,7 @@ private[reactive] final class ReduceOperator[A](op: (A, A) => A) extends Operato
 
   def apply(out: Subscriber[A]): Subscriber[A] =
     new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       private[this] var isDone = false
       private[this] var state: A = _

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/RepeatSourceObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/RepeatSourceObservable.scala
@@ -20,6 +20,7 @@ package monix.reactive.internal.operators
 import monix.execution.Ack.Continue
 import monix.execution.cancelables.{ CompositeCancelable, OrderedCancelable }
 import monix.execution.{ Ack, Cancelable }
+import monix.execution.Scheduler
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 import monix.reactive.subjects.{ ReplaySubject, Subject }
@@ -33,7 +34,7 @@ private[reactive] final class RepeatSourceObservable[A](source: Observable[A]) e
   def loop(subject: Subject[A, A], out: Subscriber[A], task: OrderedCancelable, index: Long): Unit = {
 
     val cancelable = subject.unsafeSubscribeFn(new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       private[this] var isEmpty = true
       private[this] var isDone = false
       private[this] var ack: Future[Ack] = Continue

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ScanObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ScanObservable.scala
@@ -18,6 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.Stop
+import monix.execution.Scheduler
 import scala.util.control.NonFatal
 import monix.execution.{ Ack, Cancelable }
 import monix.reactive.Observable
@@ -36,7 +37,7 @@ private[reactive] final class ScanObservable[A, R](source: Observable[A], initia
 
       // Initial state was evaluated, subscribing to source
       source.unsafeSubscribeFn(new Subscriber[A] {
-        implicit val scheduler = out.scheduler
+        implicit val scheduler: Scheduler = out.scheduler
         private[this] var isDone = false
         private[this] var state = initialState
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ScanTaskObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ScanTaskObservable.scala
@@ -20,6 +20,7 @@ package monix.reactive.internal.operators
 import monix.execution.Callback
 import monix.eval.Task
 import monix.execution.Ack.Stop
+import monix.execution.Scheduler
 import monix.execution.atomic.Atomic
 import monix.execution.atomic.PaddingStrategy.LeftRight128
 import monix.execution.cancelables.OrderedCancelable
@@ -66,7 +67,7 @@ private[reactive] final class ScanTaskObservable[A, S](source: Observable[A], se
     import MapTaskObservable.MapTaskState
     import MapTaskObservable.MapTaskState._
 
-    implicit val scheduler = out.scheduler
+    implicit val scheduler: Scheduler = out.scheduler
 
     // For synchronizing our internal state machine, padded
     // in order to avoid the false sharing problem

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/SearchByOrderOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/SearchByOrderOperator.scala
@@ -20,6 +20,7 @@ package monix.reactive.internal.operators
 import cats.Order
 import monix.execution.Ack
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 
 import scala.util.control.NonFatal
 import monix.reactive.Observable.Operator
@@ -35,7 +36,7 @@ private[reactive] abstract class SearchByOrderOperator[A, K](key: A => K)
 
   final def apply(out: Subscriber[A]): Subscriber.Sync[A] =
     new Subscriber.Sync[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       private[this] var isDone = false
       private[this] var minValue: A = _

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/SwitchIfEmptyObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/SwitchIfEmptyObservable.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.cancelables.OrderedCancelable
 import monix.execution.{ Ack, Cancelable }
+import monix.execution.Scheduler
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 import scala.concurrent.Future
@@ -30,7 +31,7 @@ private[reactive] final class SwitchIfEmptyObservable[+A](source: Observable[A],
     val cancelable = OrderedCancelable()
 
     val mainSub = source.unsafeSubscribeFn(new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       private[this] var isEmpty = true
 
       def onNext(elem: A): Future[Ack] = {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/SwitchMapObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/SwitchMapObservable.scala
@@ -18,6 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.execution.cancelables.{ CompositeCancelable, SerialCancelable, SingleAssignCancelable }
 import scala.util.control.NonFatal
 import monix.execution.{ Ack, Cancelable }
@@ -35,7 +36,7 @@ private[reactive] final class SwitchMapObservable[A, B](source: Observable[A], f
     val composite = CompositeCancelable(activeChild, mainTask)
 
     mainTask := source.unsafeSubscribeFn(new Subscriber.Sync[A] { self =>
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       // MUST BE synchronized by `self`
       private[this] var ack: Future[Ack] = Continue
       // MUST BE synchronized by `self`

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeByPredicateOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeByPredicateOperator.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack
 import monix.execution.Ack.Stop
+import monix.execution.Scheduler
 import scala.util.control.NonFatal
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
@@ -28,7 +29,7 @@ private[reactive] final class TakeByPredicateOperator[A](p: A => Boolean, inclus
 
   def apply(out: Subscriber[A]): Subscriber[A] =
     new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       private[this] var isActive = true
 
       def onNext(elem: A): Future[Ack] = {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeEveryNthOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeEveryNthOperator.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack
 import monix.execution.Ack.Continue
+import monix.execution.Scheduler
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
 import scala.concurrent.Future
@@ -29,7 +30,7 @@ private[reactive] final class TakeEveryNthOperator[A](n: Int) extends Operator[A
 
   def apply(out: Subscriber[A]): Subscriber[A] =
     new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       private[this] var index = n
 
       def onNext(elem: A): Future[Ack] = {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeLastObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeLastObservable.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack
 import monix.execution.Ack.Continue
+import monix.execution.Scheduler
 import monix.execution.cancelables.AssignableCancelable
 import monix.reactive.Observable
 import monix.reactive.observables.ChainedObservable
@@ -33,7 +34,7 @@ private[reactive] final class TakeLastObservable[A](source: Observable[A], n: In
       source,
       conn,
       new Subscriber[A] {
-        implicit val scheduler = out.scheduler
+        implicit val scheduler: Scheduler = out.scheduler
         private[this] val queue = mutable.Queue.empty[A]
         private[this] var queued = 0
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeLeftByTimespanObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeLeftByTimespanObservable.scala
@@ -18,6 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.Stop
+import monix.execution.Scheduler
 import monix.execution.cancelables.CompositeCancelable
 import monix.execution.{ Ack, Cancelable }
 import monix.reactive.Observable
@@ -32,7 +33,7 @@ private[reactive] final class TakeLeftByTimespanObservable[A](source: Observable
     val composite = CompositeCancelable()
 
     composite += source.unsafeSubscribeFn(new Subscriber[A] with Runnable {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       private[this] var isActive = true
       // triggers completion

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeLeftOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeLeftOperator.scala
@@ -18,6 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.Stop
+import monix.execution.Scheduler
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
 
@@ -26,7 +27,7 @@ private[reactive] final class TakeLeftOperator[A](n: Long) extends Operator[A, A
   def apply(out: Subscriber[A]): Subscriber[A] = {
     require(n > 0, "n should be strictly positive")
     new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       private[this] var counter = 0L
       private[this] var isActive = true

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeUntilObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeUntilObservable.scala
@@ -18,6 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.Stop
+import monix.execution.Scheduler
 import monix.execution.cancelables.{ CompositeCancelable, SingleAssignCancelable }
 import monix.execution.{ Ack, Cancelable }
 import monix.reactive.Observable
@@ -33,7 +34,7 @@ private[reactive] final class TakeUntilObservable[+A](source: Observable[A], tri
     var isComplete = false
 
     val selectorConn = trigger.unsafeSubscribeFn(new Subscriber.Sync[Any] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: Any): Ack = {
         signalComplete(null)
@@ -57,7 +58,7 @@ private[reactive] final class TakeUntilObservable[+A](source: Observable[A], tri
     })
 
     mainConn := source.unsafeSubscribeFn(new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       def onNext(elem: A): Future[Ack] =
         mainConn.synchronized {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeWhileNotCanceledOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/TakeWhileNotCanceledOperator.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack
 import monix.execution.Ack.Stop
+import monix.execution.Scheduler
 import monix.execution.cancelables.BooleanCancelable
 import scala.util.control.NonFatal
 import monix.reactive.Observable.Operator
@@ -29,7 +30,7 @@ private[reactive] final class TakeWhileNotCanceledOperator[A](c: BooleanCancelab
 
   def apply(out: Subscriber[A]): Subscriber[A] =
     new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       private[this] var isActive = true
 
       def onNext(elem: A): Future[Ack] =

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ThrottleFirstOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ThrottleFirstOperator.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack
 import monix.execution.Ack.Continue
+import monix.execution.Scheduler
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
 
@@ -29,7 +30,7 @@ private[reactive] final class ThrottleFirstOperator[A](interval: FiniteDuration)
 
   def apply(out: Subscriber[A]): Subscriber[A] =
     new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       private[this] val intervalMs = interval.toMillis
       private[this] var nextChange = 0L

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ThrottleLastObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ThrottleLastObservable.scala
@@ -18,6 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.execution.cancelables.{ CompositeCancelable, SingleAssignCancelable }
 import monix.execution.{ Ack, Cancelable }
 import monix.reactive.Observable
@@ -36,7 +37,7 @@ private[reactive] final class ThrottleLastObservable[+A, S](
     val composite = CompositeCancelable(upstreamSubscription, samplerSubscription)
 
     upstreamSubscription := source.unsafeSubscribeFn(new Subscriber.Sync[A] { upstreamSubscriber =>
-      implicit val scheduler = downstream.scheduler
+      implicit val scheduler: Scheduler = downstream.scheduler
 
       // Value is volatile to keep write to lastValue visible
       // after this one is seen as being true
@@ -71,7 +72,7 @@ private[reactive] final class ThrottleLastObservable[+A, S](
         }
 
       samplerSubscription := sampler.unsafeSubscribeFn(new Subscriber[S] { self =>
-        implicit val scheduler = downstream.scheduler
+        implicit val scheduler: Scheduler = downstream.scheduler
 
         def onNext(elem: S): Future[Ack] =
           upstreamSubscriber.synchronized(signalNext())

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ThrottleLatestObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ThrottleLatestObservable.scala
@@ -18,6 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.execution.cancelables.{ CompositeCancelable, MultiAssignCancelable, SingleAssignCancelable }
 import monix.execution.{ Ack, Cancelable }
 import monix.reactive.Observable
@@ -40,7 +41,7 @@ private[reactive] final class ThrottleLatestObservable[A](
 
     mainTask := source.unsafeSubscribeFn(new Subscriber[A] with Runnable {
       self =>
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       private[this] val durationMilis = duration.toMillis
       private[this] var isDone = false

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/WhileBusyAggregateEventsOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/WhileBusyAggregateEventsOperator.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
 
@@ -32,7 +33,7 @@ private[reactive] final class WhileBusyAggregateEventsOperator[A, S](seed: A => 
   def apply(downstream: Subscriber[S]): Subscriber.Sync[A] = {
     new Subscriber.Sync[A] {
       upstreamSubscriber =>
-      implicit val scheduler = downstream.scheduler
+      implicit val scheduler: Scheduler = downstream.scheduler
 
       private[this] var aggregated: Option[S] = None
       private[this] var lastAck: Future[Ack] = Continue

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/WhileBusyDropEventsAndSignalOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/WhileBusyDropEventsAndSignalOperator.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import scala.util.control.NonFatal
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
@@ -29,7 +30,7 @@ private[reactive] final class WhileBusyDropEventsAndSignalOperator[A](onOverflow
 
   def apply(out: Subscriber[A]): Subscriber.Sync[A] =
     new Subscriber.Sync[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       private[this] var ack = Continue: Future[Ack]
       private[this] var eventsDropped = 0L

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/WhileBusyDropEventsOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/WhileBusyDropEventsOperator.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
 import scala.concurrent.Future
@@ -27,7 +28,7 @@ private[reactive] final class WhileBusyDropEventsOperator[A] extends Operator[A,
 
   def apply(out: Subscriber[A]): Subscriber.Sync[A] =
     new Subscriber.Sync[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       private[this] var ack = Continue: Future[Ack]
       private[this] var isDone = false

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/WithLatestFromObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/WithLatestFromObservable.scala
@@ -18,6 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.execution.cancelables.CompositeCancelable
 import scala.util.control.NonFatal
 import monix.execution.{ Ack, Cancelable }
@@ -36,7 +37,7 @@ private[reactive] final class WithLatestFromObservable[A, B, +R](
     val connection = CompositeCancelable()
 
     connection += source.unsafeSubscribeFn(new Subscriber[A] { self =>
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
 
       private[this] var isDone = false
       private[this] var otherStarted = false
@@ -44,7 +45,7 @@ private[reactive] final class WithLatestFromObservable[A, B, +R](
 
       private[this] val otherConnection = {
         val ref = other.unsafeSubscribeFn(new Subscriber.Sync[B] {
-          implicit val scheduler = out.scheduler
+          implicit val scheduler: Scheduler = out.scheduler
 
           def onNext(elem: B): Ack =
             self.synchronized {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ZipWithIndexOperator.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/ZipWithIndexOperator.scala
@@ -18,6 +18,7 @@
 package monix.reactive.internal.operators
 
 import monix.execution.Ack
+import monix.execution.Scheduler
 import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
 import scala.concurrent.Future
@@ -26,7 +27,7 @@ private[reactive] final class ZipWithIndexOperator[A] extends Operator[A, (A, Lo
 
   def apply(out: Subscriber[(A, Long)]): Subscriber[A] =
     new Subscriber[A] {
-      implicit val scheduler = out.scheduler
+      implicit val scheduler: Scheduler = out.scheduler
       private[this] var index = 0L
 
       def onNext(elem: A): Future[Ack] = {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/rstreams/SubscriberAsReactiveSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/rstreams/SubscriberAsReactiveSubscriber.scala
@@ -20,6 +20,7 @@ package monix.reactive.internal.rstreams
 import monix.execution.Ack
 import monix.execution.Ack.{ Continue, Stop }
 import monix.execution.ChannelType.SingleProducer
+import monix.execution.Scheduler
 import monix.execution.rstreams.SingleAssignSubscription
 import monix.execution.schedulers.TrampolineExecutionContext.immediate
 import monix.reactive.OverflowStrategy.Unbounded
@@ -93,7 +94,7 @@ private[reactive] final class AsyncSubscriberAsReactiveSubscriber[A](target: Sub
   private[this] val subscription = SingleAssignSubscription()
   private[this] val downstream: Subscriber[A] =
     new Subscriber[A] {
-      implicit val scheduler = target.scheduler
+      implicit val scheduler: Scheduler = target.scheduler
 
       private[this] val isFinite = requestCount < Int.MaxValue
       private[this] var isActive = true

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observables/GroupedObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observables/GroupedObservable.scala
@@ -56,7 +56,7 @@ object GroupedObservable {
     private[this] var ref: Subscriber[V] = _
     private[this] val underlying = {
       val o = new Subscriber[V] {
-        implicit val scheduler = self.scheduler
+        implicit val scheduler: Scheduler = self.scheduler
         private[this] var isDone = false
 
         def onNext(elem: V) = {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observables/RefCountObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observables/RefCountObservable.scala
@@ -18,6 +18,7 @@
 package monix.reactive.observables
 
 import monix.execution.{ Ack, Cancelable }
+import monix.execution.Scheduler
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 import monix.execution.atomic.Atomic
@@ -68,7 +69,7 @@ final class RefCountObservable[+A] private (source: ConnectableObservable[A]) ex
 
   private def wrap[U >: A](downstream: Subscriber[U], subscription: Cancelable): Subscriber[U] =
     new Subscriber[U] {
-      implicit val scheduler = downstream.scheduler
+      implicit val scheduler: Scheduler = downstream.scheduler
 
       def onNext(elem: U): Future[Ack] = {
         downstream

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observers/CacheUntilConnectSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observers/CacheUntilConnectSubscriber.scala
@@ -19,6 +19,7 @@ package monix.reactive.observers
 
 import monix.execution.Ack.{ Continue, Stop }
 import monix.execution.{ Ack, CancelableFuture }
+import monix.execution.Scheduler
 import monix.reactive.Observable
 import scala.collection.mutable
 import scala.concurrent.{ Future, Promise }
@@ -30,7 +31,7 @@ import scala.util.{ Failure, Success }
   * subsequent events are pushed directly.
   */
 final class CacheUntilConnectSubscriber[-A] private (downstream: Subscriber[A]) extends Subscriber[A] { self =>
-  implicit val scheduler = downstream.scheduler
+  implicit val scheduler: Scheduler = downstream.scheduler
   // MUST BE synchronized by `self`, only available if isConnected == false
   private[this] var queue = mutable.ArrayBuffer.empty[A]
   // MUST BE synchronized by `self`
@@ -72,7 +73,7 @@ final class CacheUntilConnectSubscriber[-A] private (downstream: Subscriber[A]) 
       val cancelable = Observable
         .fromIterable(queue)
         .unsafeSubscribeFn(new Subscriber[A] {
-          implicit val scheduler = downstream.scheduler
+          implicit val scheduler: Scheduler = downstream.scheduler
           private[this] var ack: Future[Ack] = Continue
 
           bufferWasDrained.future.onComplete {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observers/ConnectableSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observers/ConnectableSubscriber.scala
@@ -125,7 +125,7 @@ final class ConnectableSubscriber[-A] private (underlying: Subscriber[A]) extend
         val cancelable = Observable
           .fromIterable(queue)
           .unsafeSubscribeFn(new Subscriber[A] {
-            implicit val scheduler = underlying.scheduler
+            implicit val scheduler: Scheduler = underlying.scheduler
             private[this] var ack: Future[Ack] = Continue
 
             bufferWasDrained.future.onComplete {

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observers/SafeSubscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observers/SafeSubscriber.scala
@@ -19,6 +19,7 @@ package monix.reactive.observers
 
 import monix.execution.Ack
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import scala.util.control.NonFatal
 
 import scala.concurrent.{ Future, Promise }
@@ -36,7 +37,7 @@ import scala.util.Try
   */
 final class SafeSubscriber[-A] private (subscriber: Subscriber[A]) extends Subscriber[A] {
 
-  implicit val scheduler = subscriber.scheduler
+  implicit val scheduler: Scheduler = subscriber.scheduler
   private[this] var isDone = false
   private[this] var ack: Future[Ack] = Continue
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/observers/Subscriber.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/observers/Subscriber.scala
@@ -71,7 +71,7 @@ object Subscriber {
     */
   def empty[A](implicit s: Scheduler): Subscriber.Sync[A] =
     new Subscriber.Sync[A] {
-      implicit val scheduler = s
+      implicit val scheduler: Scheduler = s
       def onNext(elem: A): Ack = Continue
       def onError(ex: Throwable): Unit = s.reportFailure(ex)
       def onComplete(): Unit = ()

--- a/monix-reactive/shared/src/main/scala/monix/reactive/subjects/ReplaySubject.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/subjects/ReplaySubject.scala
@@ -19,6 +19,7 @@ package monix.reactive.subjects
 
 import monix.execution.Ack.{ Continue, Stop }
 import monix.execution.{ Ack, Cancelable }
+import monix.execution.Scheduler
 import monix.reactive.Observable
 import monix.reactive.internal.util.PromiseCounter
 import monix.reactive.observers.{ ConnectableSubscriber, Subscriber }
@@ -44,7 +45,7 @@ final class ReplaySubject[A] private (initialState: ReplaySubject.State[A]) exte
       Observable
         .fromIterable(buffer)
         .unsafeSubscribeFn(new Subscriber[A] {
-          implicit val scheduler = subscriber.scheduler
+          implicit val scheduler: Scheduler = subscriber.scheduler
 
           def onNext(elem: A) =
             subscriber.onNext(elem)

--- a/monix-reactive/shared/src/test/scala/monix/reactive/consumers/LoadBalanceConsumerSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/consumers/LoadBalanceConsumerSuite.scala
@@ -257,7 +257,7 @@ object LoadBalanceConsumerSuite extends BaseTestSuite {
         }
 
         val sub = new Subscriber[Int] {
-          implicit val scheduler = s
+          implicit val scheduler: Scheduler = s
           def onNext(elem: Int) = {
             sum.increment(elem + 1)
             Continue
@@ -318,7 +318,7 @@ object LoadBalanceConsumerSuite extends BaseTestSuite {
     new Consumer[Int, Unit] {
       def createSubscriber(cb: Callback[Throwable, Unit], s: Scheduler): (Subscriber[Int], AssignableCancelable) = {
         val sub = new Subscriber[Int] {
-          implicit val scheduler = s
+          implicit val scheduler: Scheduler = s
 
           def onNext(elem: Int) =
             ack.future.map { _ =>

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/AsyncStateActionObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/AsyncStateActionObservableSuite.scala
@@ -23,6 +23,7 @@ import monix.eval.Task
 import monix.execution.Ack.Continue
 import monix.execution.internal.Platform
 import monix.execution.ExecutionModel.AlwaysAsyncExecution
+import monix.execution.Scheduler
 import monix.execution.exceptions.DummyException
 import monix.execution.schedulers.TestScheduler
 import monix.reactive.Observable
@@ -84,7 +85,7 @@ object AsyncStateActionObservableSuite extends TestSuite[TestScheduler] {
     val cancelable = Observable
       .fromAsyncStateAction(intNow)(s.clockMonotonic(MILLISECONDS))
       .unsafeSubscribeFn(new Subscriber[Int] {
-        implicit val scheduler = s
+        implicit val scheduler: Scheduler = s
         def onNext(elem: Int) = {
           sum += 1
           Continue

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/BracketObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/BracketObservableSuite.scala
@@ -22,6 +22,7 @@ import cats.effect.ExitCase
 import cats.effect.concurrent.Deferred
 import monix.eval.Task
 import monix.execution.Ack.Continue
+import monix.execution.Scheduler
 import monix.reactive.observers.Subscriber
 import monix.reactive.{ BaseTestSuite, Observable }
 
@@ -86,7 +87,7 @@ object BracketObservableSuite extends BaseTestSuite {
     val cancelable = obs
       .flatMap(_ => Observable.never)
       .unsafeSubscribeFn(new Subscriber[Handle] {
-        implicit val scheduler = s
+        implicit val scheduler: Scheduler = s
         def onNext(elem: Handle) =
           Continue
         def onComplete() =

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/BufferedIteratorAsObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/BufferedIteratorAsObservableSuite.scala
@@ -43,7 +43,7 @@ object BufferedIteratorAsObservableSuite extends TestSuite[TestScheduler] {
     obs.unsafeSubscribeFn(Subscriber.empty(s))
 
     obs.unsafeSubscribeFn(new Subscriber[Seq[Int]] {
-      implicit val scheduler = s
+      implicit val scheduler: Scheduler = s
 
       def onNext(elem: Seq[Int]): Ack =
         throw new IllegalStateException("onNext")

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/CharsReaderObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/CharsReaderObservableSuite.scala
@@ -26,6 +26,7 @@ import monix.eval.Task
 import monix.execution.Ack
 import monix.execution.Ack.Continue
 import monix.execution.ExecutionModel.{ AlwaysAsyncExecution, BatchedExecution, SynchronousExecution }
+import monix.execution.Scheduler
 import monix.execution.exceptions.APIContractViolationException
 import monix.execution.schedulers.TestScheduler
 import monix.reactive.Observable
@@ -45,7 +46,7 @@ object CharsReaderObservableSuite extends SimpleTestSuite with Checkers {
     s.tick()
 
     obs.unsafeSubscribeFn(new Subscriber[Array[Char]] {
-      implicit val scheduler = s
+      implicit val scheduler: Scheduler = s
 
       def onNext(elem: Array[Char]): Ack =
         throw new IllegalStateException("onNext")
@@ -126,7 +127,7 @@ object CharsReaderObservableSuite extends SimpleTestSuite with Checkers {
       .foldLeft(Array.empty[Char])(_ ++ _)
 
     obs.unsafeSubscribeFn(new Subscriber[Array[Char]] {
-      implicit val scheduler = s
+      implicit val scheduler: Scheduler = s
 
       def onError(ex: Throwable): Unit =
         throw new IllegalStateException("onError")

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/InputStreamObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/InputStreamObservableSuite.scala
@@ -25,6 +25,7 @@ import monix.eval.Task
 import monix.execution.Ack
 import monix.execution.Ack.Continue
 import monix.execution.ExecutionModel.{ AlwaysAsyncExecution, BatchedExecution, SynchronousExecution }
+import monix.execution.Scheduler
 import monix.execution.exceptions.{ APIContractViolationException, DummyException }
 import monix.execution.schedulers.TestScheduler
 import monix.reactive.Observable
@@ -43,7 +44,7 @@ object InputStreamObservableSuite extends SimpleTestSuite with Checkers {
     s.tick()
 
     obs.unsafeSubscribeFn(new Subscriber[Array[Byte]] {
-      implicit val scheduler = s
+      implicit val scheduler: Scheduler = s
 
       def onNext(elem: Array[Byte]): Ack =
         throw new IllegalStateException("onNext")
@@ -122,7 +123,7 @@ object InputStreamObservableSuite extends SimpleTestSuite with Checkers {
       .foldLeft(Array.empty[Byte])(_ ++ _)
 
     obs.unsafeSubscribeFn(new Subscriber[Array[Byte]] {
-      implicit val scheduler = s
+      implicit val scheduler: Scheduler = s
 
       def onError(ex: Throwable): Unit =
         throw new IllegalStateException("onError")

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/IterableAsObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/IterableAsObservableSuite.scala
@@ -20,6 +20,7 @@ package monix.reactive.internal.builders
 import minitest.TestSuite
 import monix.execution.Ack.{ Continue, Stop }
 import monix.execution.FutureUtils.extensions._
+import monix.execution.Scheduler
 import monix.execution.internal.Platform
 import monix.execution.schedulers.TestScheduler
 import monix.execution.exceptions.DummyException
@@ -317,7 +318,7 @@ object IterableAsObservableSuite extends TestSuite[TestScheduler] {
     val cancelable = Observable
       .fromIterable(seq)
       .unsafeSubscribeFn(new Subscriber[Int] {
-        implicit val scheduler = s
+        implicit val scheduler: Scheduler = s
         def onNext(elem: Int) = {
           sum += 1
           Continue

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/IteratorAsObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/IteratorAsObservableSuite.scala
@@ -42,7 +42,7 @@ object IteratorAsObservableSuite extends TestSuite[TestScheduler] {
     obs.unsafeSubscribeFn(Subscriber.empty(s))
 
     obs.unsafeSubscribeFn(new Subscriber[Int] {
-      implicit val scheduler = s
+      implicit val scheduler: Scheduler = s
 
       def onNext(elem: Int): Ack =
         throw new IllegalStateException("onNext")

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/LinesReaderObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/LinesReaderObservableSuite.scala
@@ -23,6 +23,7 @@ import minitest.SimpleTestSuite
 import monix.eval.Task
 import monix.execution.Ack
 import monix.execution.Ack.Continue
+import monix.execution.Scheduler
 import monix.execution.ExecutionModel.{ AlwaysAsyncExecution, BatchedExecution, SynchronousExecution }
 import monix.execution.exceptions.APIContractViolationException
 import monix.execution.schedulers.TestScheduler
@@ -41,7 +42,7 @@ object LinesReaderObservableSuite extends SimpleTestSuite {
     s.tick()
 
     obs.unsafeSubscribeFn(new Subscriber[String] {
-      implicit val scheduler = s
+      implicit val scheduler: Scheduler = s
 
       def onNext(elem: String): Ack =
         throw new IllegalStateException("onNext")
@@ -101,7 +102,7 @@ object LinesReaderObservableSuite extends SimpleTestSuite {
       .map(_.trim)
 
     obs.unsafeSubscribeFn(new Subscriber[String] {
-      implicit val scheduler = s
+      implicit val scheduler: Scheduler = s
 
       def onError(ex: Throwable): Unit =
         throw new IllegalStateException("onError")

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/PaginateEvalObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/PaginateEvalObservableSuite.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.builders
 
 import monix.eval.Task
 import monix.execution.Ack.Continue
+import monix.execution.Scheduler
 import monix.execution.exceptions.DummyException
 import monix.reactive.observers.Subscriber
 import monix.reactive.{ BaseTestSuite, Observable }
@@ -58,7 +59,7 @@ object PaginateEvalObservableSuite extends BaseTestSuite {
     val cancelable = Observable
       .paginateEval(s.clockMonotonic(MILLISECONDS))(intNowOption)
       .unsafeSubscribeFn(new Subscriber[Int] {
-        implicit val scheduler = s
+        implicit val scheduler: Scheduler = s
 
         def onNext(elem: Int) = {
           sum += 1

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/PaginateObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/PaginateObservableSuite.scala
@@ -18,6 +18,7 @@
 package monix.reactive.internal.builders
 
 import monix.execution.Ack.Continue
+import monix.execution.Scheduler
 import monix.reactive.observers.Subscriber
 import monix.reactive.{ BaseTestSuite, Observable }
 import scala.concurrent.duration.MILLISECONDS
@@ -55,7 +56,7 @@ object PaginateObservableSuite extends BaseTestSuite {
     val cancelable = Observable
       .paginate(s.clockMonotonic(MILLISECONDS))(intOption)
       .unsafeSubscribeFn(new Subscriber[Int] {
-        implicit val scheduler = s
+        implicit val scheduler: Scheduler = s
 
         def onNext(elem: Int) = {
           sum += 1

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/RangeObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/RangeObservableSuite.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.builders
 
 import minitest.TestSuite
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.execution.FutureUtils.extensions._
 import monix.execution.internal.Platform
 import monix.execution.schedulers.TestScheduler
@@ -129,7 +130,7 @@ object RangeObservableSuite extends TestSuite[TestScheduler] {
     val source = Observable.range(0L, Platform.recommendedBatchSize.toLong * 10)
 
     val cancelable = source.unsafeSubscribeFn(new Subscriber[Long] {
-      implicit val scheduler = s
+      implicit val scheduler: Scheduler = s
 
       def onNext(elem: Long) = {
         received += 1

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/RepeatEvalObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/RepeatEvalObservableSuite.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.builders
 
 import minitest.TestSuite
 import monix.execution.Ack.Continue
+import monix.execution.Scheduler
 import monix.execution.internal.Platform
 import monix.execution.schedulers.TestScheduler
 import monix.reactive.Observable
@@ -59,7 +60,7 @@ object RepeatEvalObservableSuite extends TestSuite[TestScheduler] {
     val cancelable = Observable
       .repeatEval(1)
       .unsafeSubscribeFn(new Subscriber[Int] {
-        implicit val scheduler = s
+        implicit val scheduler: Scheduler = s
         def onNext(elem: Int) = {
           sum += elem
           Continue

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/RepeatOneObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/RepeatOneObservableSuite.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.builders
 
 import minitest.TestSuite
 import monix.execution.Ack.Continue
+import monix.execution.Scheduler
 import monix.execution.internal.Platform
 import monix.execution.schedulers.TestScheduler
 import monix.reactive.Observable
@@ -58,7 +59,7 @@ object RepeatOneObservableSuite extends TestSuite[TestScheduler] {
     val cancelable = Observable
       .repeat(1)
       .unsafeSubscribeFn(new Subscriber[Int] {
-        implicit val scheduler = s
+        implicit val scheduler: Scheduler = s
         def onNext(elem: Int) = {
           sum += elem
           Continue

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/ResourceCaseObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/ResourceCaseObservableSuite.scala
@@ -23,6 +23,7 @@ import cats.laws._
 import cats.laws.discipline._
 import monix.eval.Task
 import monix.execution.Ack.Continue
+import monix.execution.Scheduler
 import monix.execution.exceptions.DummyException
 import monix.reactive.observers.Subscriber
 import monix.reactive.{ BaseTestSuite, Consumer, Observable }
@@ -138,7 +139,7 @@ object ResourceCaseObservableSuite extends BaseTestSuite {
     val cancelable = obs
       .flatMap(_ => Observable.never)
       .unsafeSubscribeFn(new Subscriber[Handle] {
-        implicit val scheduler = s
+        implicit val scheduler: Scheduler = s
         def onNext(elem: Handle) =
           Continue
         def onComplete() =

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/StateActionObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/StateActionObservableSuite.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.builders
 
 import minitest.TestSuite
 import monix.execution.Ack.Continue
+import monix.execution.Scheduler
 import monix.execution.internal.Platform
 import monix.execution.schedulers.TestScheduler
 import monix.reactive.Observable
@@ -66,7 +67,7 @@ object StateActionObservableSuite extends TestSuite[TestScheduler] {
     val cancelable = Observable
       .fromStateAction(int)(s.clockMonotonic(MILLISECONDS))
       .unsafeSubscribeFn(new Subscriber[Int] {
-        implicit val scheduler = s
+        implicit val scheduler: Scheduler = s
         def onNext(elem: Int) = {
           sum += 1
           Continue

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/UnfoldEvalObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/UnfoldEvalObservableSuite.scala
@@ -22,6 +22,7 @@ import cats.laws._
 import cats.laws.discipline._
 import monix.eval.Task
 import monix.execution.Ack.Continue
+import monix.execution.Scheduler
 import monix.execution.exceptions.DummyException
 import monix.execution.internal.Platform.recommendedBatchSize
 import monix.reactive.observers.Subscriber
@@ -63,7 +64,7 @@ object UnfoldEvalObservableSuite extends BaseTestSuite {
     val cancelable = Observable
       .unfoldEval(s.clockMonotonic(MILLISECONDS))(intNowOption)
       .unsafeSubscribeFn(new Subscriber[Int] {
-        implicit val scheduler = s
+        implicit val scheduler: Scheduler = s
 
         def onNext(elem: Int) = {
           sum += 1
@@ -115,7 +116,7 @@ object UnfoldEvalObservableSuite extends BaseTestSuite {
     val cancelable = Observable
       .unfoldEvalF(s.clockMonotonic(MILLISECONDS))(intOptionIO)
       .unsafeSubscribeFn(new Subscriber[Int] {
-        implicit val scheduler = s
+        implicit val scheduler: Scheduler = s
 
         def onNext(elem: Int) = {
           sum += 1

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/UnfoldObservableSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/builders/UnfoldObservableSuite.scala
@@ -20,6 +20,7 @@ package monix.reactive.internal.builders
 import cats.laws._
 import cats.laws.discipline._
 import monix.execution.Ack.Continue
+import monix.execution.Scheduler
 import monix.execution.internal.Platform.recommendedBatchSize
 import monix.reactive.observers.Subscriber
 import monix.reactive.{ BaseTestSuite, Observable }
@@ -59,7 +60,7 @@ object UnfoldObservableSuite extends BaseTestSuite {
     val cancelable = Observable
       .unfold(s.clockMonotonic(MILLISECONDS))(intOption)
       .unsafeSubscribeFn(new Subscriber[Int] {
-        implicit val scheduler = s
+        implicit val scheduler: Scheduler = s
 
         def onNext(elem: Int) = {
           sum += 1

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BaseOperatorSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BaseOperatorSuite.scala
@@ -20,6 +20,7 @@ package monix.reactive.internal.operators
 import monix.execution.Ack
 import monix.execution.Ack.{ Continue, Stop }
 import monix.execution.FutureUtils.extensions._
+import monix.execution.Scheduler
 import monix.execution.exceptions.DummyException
 import monix.reactive.observers.Subscriber
 import monix.reactive.{ BaseTestSuite, Observable, Observer }
@@ -361,7 +362,7 @@ abstract class BaseOperatorSuite extends BaseTestSuite {
       var received = 0L
 
       val cancelable = obs.unsafeSubscribeFn(new Subscriber[Long] {
-        implicit val scheduler = s
+        implicit val scheduler: Scheduler = s
 
         def onError(ex: Throwable) = wasCompleted += 1
         def onComplete() = wasCompleted += 1

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferIntrospectiveSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferIntrospectiveSuite.scala
@@ -21,6 +21,7 @@ import minitest.TestSuite
 import monix.eval.Task
 import monix.execution.Ack
 import monix.execution.Ack.Continue
+import monix.execution.Scheduler
 import monix.execution.schedulers.TestScheduler
 import monix.reactive.observers.Subscriber
 import monix.reactive.subjects.PublishSubject
@@ -46,7 +47,7 @@ object BufferIntrospectiveSuite extends TestSuite[TestScheduler] {
     subject
       .bufferIntrospective(maxSize = 10)
       .unsafeSubscribeFn(new Subscriber[List[Long]] {
-        implicit val scheduler = s
+        implicit val scheduler: Scheduler = s
 
         def onNext(elem: List[Long]): Future[Ack] = {
           sum += elem.sum

--- a/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferTimedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/internal/operators/BufferTimedSuite.scala
@@ -19,6 +19,7 @@ package monix.reactive.internal.operators
 
 import monix.execution.Ack
 import monix.execution.Ack.Continue
+import monix.execution.Scheduler
 import monix.execution.internal.Platform
 import monix.reactive.observers.Subscriber
 import monix.reactive.{ Observable, Observer }
@@ -168,7 +169,7 @@ object BufferTimedSuite extends BaseOperatorSuite {
       .map(_.sum)
 
     obs.unsafeSubscribeFn(new Subscriber[Long] {
-      implicit val scheduler = s
+      implicit val scheduler: Scheduler = s
 
       def onNext(elem: Long): Future[Ack] = {
         received += elem

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/SubscriberFeedSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/SubscriberFeedSuite.scala
@@ -18,6 +18,7 @@
 package monix.reactive.observers
 
 import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.Scheduler
 import monix.execution.cancelables.BooleanCancelable
 import monix.execution.compat.internal.toIterator
 import monix.reactive.BaseTestSuite
@@ -28,7 +29,7 @@ object SubscriberFeedSuite extends BaseTestSuite {
     check1 { (xs: List[Int]) =>
       var sum = 0
       val downstream = new Subscriber.Sync[Int] {
-        implicit val scheduler = s
+        implicit val scheduler: Scheduler = s
         def onError(ex: Throwable): Unit = ()
         def onComplete(): Unit = sum += 100
         def onNext(elem: Int) = {
@@ -48,7 +49,7 @@ object SubscriberFeedSuite extends BaseTestSuite {
     check1 { (xs: List[Int]) =>
       var sum = 0
       val downstream = new Subscriber[Int] {
-        implicit val scheduler = s
+        implicit val scheduler: Scheduler = s
         def onError(ex: Throwable): Unit = ()
         def onComplete(): Unit = sum += 100
         def onNext(elem: Int) = Future {
@@ -68,7 +69,7 @@ object SubscriberFeedSuite extends BaseTestSuite {
     check1 { (xs: List[Int]) =>
       var sum = 0
       val downstream = new Subscriber.Sync[Int] {
-        implicit val scheduler = s
+        implicit val scheduler: Scheduler = s
         def onError(ex: Throwable): Unit = ()
         def onComplete(): Unit = sum += 100
         def onNext(elem: Int) = {
@@ -88,7 +89,7 @@ object SubscriberFeedSuite extends BaseTestSuite {
     check1 { (xs: List[Int]) =>
       var sum = 0
       val downstream = new Subscriber[Int] {
-        implicit val scheduler = s
+        implicit val scheduler: Scheduler = s
         def onError(ex: Throwable): Unit = ()
         def onComplete(): Unit = sum += 100
         def onNext(elem: Int) = Future {
@@ -108,7 +109,7 @@ object SubscriberFeedSuite extends BaseTestSuite {
     check1 { (xs: List[Int]) =>
       var sum = 0
       val downstream = new Subscriber.Sync[Int] {
-        implicit val scheduler = s
+        implicit val scheduler: Scheduler = s
         def onError(ex: Throwable): Unit = ()
         def onComplete(): Unit = sum += 100
         def onNext(elem: Int) = {
@@ -126,7 +127,7 @@ object SubscriberFeedSuite extends BaseTestSuite {
     check1 { (xs: List[Int]) =>
       var sum = 0
       val downstream = new Subscriber[Int] {
-        implicit val scheduler = s
+        implicit val scheduler: Scheduler = s
         def onError(ex: Throwable): Unit = ()
         def onComplete(): Unit = sum += 100
         def onNext(elem: Int) = Future {
@@ -144,7 +145,7 @@ object SubscriberFeedSuite extends BaseTestSuite {
     check1 { (xs: List[Int]) =>
       var sum = 0
       val downstream = new Subscriber[Int] {
-        implicit val scheduler = s
+        implicit val scheduler: Scheduler = s
         def onError(ex: Throwable): Unit = ()
         def onComplete(): Unit = sum += 100
         def onNext(elem: Int) = Future {


### PR DESCRIPTION
prepare update to latest Scala 2.13.x

avoid latest Scala 2.13 warning

```
Welcome to Scala 2.13.12 (OpenJDK 64-Bit Server VM, Java 11.0.20.1).
Type in expressions for evaluation. Or try :help.

scala> implicit val x = 3
                    ^
       warning: Implicit definition should have explicit type (inferred Int) [quickfixable]
val x: Int = 3
```

```
Welcome to Scala 2.13.8 (OpenJDK 64-Bit Server VM, Java 11.0.20.1).
Type in expressions for evaluation. Or try :help.

scala> implicit val x = 3
val x: Int = 3
```