### PR TITLE
Synchronize ZipObservable onComplete implementations

### DIFF
--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip2Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip2Observable.scala
@@ -156,7 +156,7 @@ private[reactive] final class Zip2Observable[A1, A2, +R](obsA1: Observable[A1], 
       def onError(ex: Throwable): Unit =
         signalOnError(ex)
       def onComplete(): Unit =
-        signalOnComplete(hasElemA1)
+        lock.synchronized(signalOnComplete(hasElemA1))
     })
 
     composite += obsA2.unsafeSubscribeFn(new Subscriber[A2] {
@@ -178,7 +178,7 @@ private[reactive] final class Zip2Observable[A1, A2, +R](obsA1: Observable[A1], 
       def onError(ex: Throwable): Unit =
         signalOnError(ex)
       def onComplete(): Unit =
-        signalOnComplete(hasElemA2)
+        lock.synchronized(signalOnComplete(hasElemA2))
     })
 
     composite

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip3Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip3Observable.scala
@@ -166,7 +166,7 @@ private[reactive] final class Zip3Observable[A1, A2, A3, +R](
         signalOnError(ex)
 
       def onComplete(): Unit =
-        signalOnComplete(hasElemA1)
+        lock.synchronized(signalOnComplete(hasElemA1))
     })
 
     composite += obsA2.unsafeSubscribeFn(new Subscriber[A2] {
@@ -189,7 +189,7 @@ private[reactive] final class Zip3Observable[A1, A2, A3, +R](
         signalOnError(ex)
 
       def onComplete(): Unit =
-        signalOnComplete(hasElemA2)
+        lock.synchronized(signalOnComplete(hasElemA2))
     })
 
     composite += obsA3.unsafeSubscribeFn(new Subscriber[A3] {
@@ -212,7 +212,7 @@ private[reactive] final class Zip3Observable[A1, A2, A3, +R](
         signalOnError(ex)
 
       def onComplete(): Unit =
-        signalOnComplete(hasElemA3)
+        lock.synchronized(signalOnComplete(hasElemA3))
     })
 
     composite

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip4Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip4Observable.scala
@@ -172,7 +172,7 @@ private[reactive] final class Zip4Observable[A1, A2, A3, A4, +R](
         signalOnError(ex)
 
       def onComplete(): Unit =
-        signalOnComplete(hasElemA1)
+        lock.synchronized(signalOnComplete(hasElemA1))
     })
 
     composite += obsA2.unsafeSubscribeFn(new Subscriber[A2] {
@@ -195,7 +195,7 @@ private[reactive] final class Zip4Observable[A1, A2, A3, A4, +R](
         signalOnError(ex)
 
       def onComplete(): Unit =
-        signalOnComplete(hasElemA2)
+        lock.synchronized(signalOnComplete(hasElemA2))
     })
 
     composite += obsA3.unsafeSubscribeFn(new Subscriber[A3] {
@@ -218,7 +218,7 @@ private[reactive] final class Zip4Observable[A1, A2, A3, A4, +R](
         signalOnError(ex)
 
       def onComplete(): Unit =
-        signalOnComplete(hasElemA3)
+        lock.synchronized(signalOnComplete(hasElemA3))
     })
 
     composite += obsA4.unsafeSubscribeFn(new Subscriber[A4] {
@@ -241,7 +241,7 @@ private[reactive] final class Zip4Observable[A1, A2, A3, A4, +R](
         signalOnError(ex)
 
       def onComplete(): Unit =
-        signalOnComplete(hasElemA4)
+        lock.synchronized(signalOnComplete(hasElemA4))
     })
 
     composite

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip5Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip5Observable.scala
@@ -178,7 +178,7 @@ private[reactive] final class Zip5Observable[A1, A2, A3, A4, A5, +R](
         signalOnError(ex)
 
       def onComplete(): Unit =
-        signalOnComplete(hasElemA1)
+        lock.synchronized(signalOnComplete(hasElemA1))
     })
 
     composite += obsA2.unsafeSubscribeFn(new Subscriber[A2] {
@@ -201,7 +201,7 @@ private[reactive] final class Zip5Observable[A1, A2, A3, A4, A5, +R](
         signalOnError(ex)
 
       def onComplete(): Unit =
-        signalOnComplete(hasElemA2)
+        lock.synchronized(signalOnComplete(hasElemA2))
     })
 
     composite += obsA3.unsafeSubscribeFn(new Subscriber[A3] {
@@ -224,7 +224,7 @@ private[reactive] final class Zip5Observable[A1, A2, A3, A4, A5, +R](
         signalOnError(ex)
 
       def onComplete(): Unit =
-        signalOnComplete(hasElemA3)
+        lock.synchronized(signalOnComplete(hasElemA3))
     })
 
     composite += obsA4.unsafeSubscribeFn(new Subscriber[A4] {
@@ -247,7 +247,7 @@ private[reactive] final class Zip5Observable[A1, A2, A3, A4, A5, +R](
         signalOnError(ex)
 
       def onComplete(): Unit =
-        signalOnComplete(hasElemA4)
+        lock.synchronized(signalOnComplete(hasElemA4))
     })
 
     composite += obsA5.unsafeSubscribeFn(new Subscriber[A5] {
@@ -270,7 +270,7 @@ private[reactive] final class Zip5Observable[A1, A2, A3, A4, A5, +R](
         signalOnError(ex)
 
       def onComplete(): Unit =
-        signalOnComplete(hasElemA5)
+        lock.synchronized(signalOnComplete(hasElemA5))
     })
 
     composite

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip6Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/builders/Zip6Observable.scala
@@ -184,7 +184,7 @@ private[reactive] final class Zip6Observable[A1, A2, A3, A4, A5, A6, +R](
         signalOnError(ex)
 
       def onComplete(): Unit =
-        signalOnComplete(hasElemA1)
+        lock.synchronized(signalOnComplete(hasElemA1))
     })
 
     composite += obsA2.unsafeSubscribeFn(new Subscriber[A2] {
@@ -207,7 +207,7 @@ private[reactive] final class Zip6Observable[A1, A2, A3, A4, A5, A6, +R](
         signalOnError(ex)
 
       def onComplete(): Unit =
-        signalOnComplete(hasElemA2)
+        lock.synchronized(signalOnComplete(hasElemA2))
     })
 
     composite += obsA3.unsafeSubscribeFn(new Subscriber[A3] {
@@ -230,7 +230,7 @@ private[reactive] final class Zip6Observable[A1, A2, A3, A4, A5, A6, +R](
         signalOnError(ex)
 
       def onComplete(): Unit =
-        signalOnComplete(hasElemA3)
+        lock.synchronized(signalOnComplete(hasElemA3))
     })
 
     composite += obsA4.unsafeSubscribeFn(new Subscriber[A4] {
@@ -253,7 +253,7 @@ private[reactive] final class Zip6Observable[A1, A2, A3, A4, A5, A6, +R](
         signalOnError(ex)
 
       def onComplete(): Unit =
-        signalOnComplete(hasElemA4)
+        lock.synchronized(signalOnComplete(hasElemA4))
     })
 
     composite += obsA5.unsafeSubscribeFn(new Subscriber[A5] {
@@ -276,7 +276,7 @@ private[reactive] final class Zip6Observable[A1, A2, A3, A4, A5, A6, +R](
         signalOnError(ex)
 
       def onComplete(): Unit =
-        signalOnComplete(hasElemA5)
+        lock.synchronized(signalOnComplete(hasElemA5))
     })
 
     composite += obsA6.unsafeSubscribeFn(new Subscriber[A6] {
@@ -299,7 +299,7 @@ private[reactive] final class Zip6Observable[A1, A2, A3, A4, A5, A6, +R](
         signalOnError(ex)
 
       def onComplete(): Unit =
-        signalOnComplete(hasElemA6)
+        lock.synchronized(signalOnComplete(hasElemA6))
     })
 
     composite


### PR DESCRIPTION
Original contribution from the AVSystem's fork made by @lpetka
https://github.com/AVSystem/monix/pull/1

> ZipObservable implementations (all flavors Zip{2,3,4,5,6}Observable) uses shared state in multithreaded environment. > ZipObservable implementations (all flavors `Zip{2,3,4,5,6}Observable`) uses shared state in multithreaded environment. There was a problem with underterministically non completing observables which was induced by the read of a non-volatile shared boolean without prior memory barrier.
> 
> I wasn't able to reproduce the problem on a current monix fork and the reason behind it is still unknown to me, although the major contributors might be:
> 
> * different java / scala version
> * custom test executor with sophisticated ticking implementation
> 
> The problem is reproducing kinda well for a current DHCP implementation both in testing suites and production code (the executor provided for the observable is irrelevant there).
> 
> Playground: https://gitlab.avsystem.com/csp/dslam/dhcp/-/commit/ca08ccb46078c6f8e8cde3f1261d51527e2f39d1
