### PR TITLE
Downgrade Scala 3 to LTS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         java: [ 17, 21 ]
         # WARN: build.sbt depends on this key path, as scalaVersion and
         # crossScalaVersions is determined from it
-        scala: [ 2.13.18, 3.8.3 ]
+        scala: [ 2.13.18, 3.3.7 ]
 
     env:
       CI: true
@@ -76,7 +76,7 @@ jobs:
         # crossScalaVersions is determined from it
         include:
           - { java: 17, scala: 2.13.18 }
-          - { java: 17, scala: 3.8.3 }
+          - { java: 17, scala: 3.3.7 }
 
     env:
       CI: true
@@ -136,7 +136,7 @@ jobs:
       matrix:
         include:
           - { java: 17, scala: 2.13.18 }
-          - { java: 17, scala: 3.8.3 }
+          - { java: 17, scala: 3.3.7 }
 
     steps:
       - uses: actions/checkout@v6
@@ -187,7 +187,7 @@ jobs:
       matrix:
         include:
           - { java: 17, scala: 2.13.18 }
-          - { java: 17, scala: 3.8.3 }
+          - { java: 17, scala: 3.3.7 }
 
     steps:
       - uses: actions/checkout@v6

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ Breaking changes:
 - JDK `17` is now the minimum supported runtime and build target.
 - JDK `21` is now part of the validated support matrix.
 - Scala `2.12` support is dropped.
-- Scala `3` is upgraded to `3.8.3`.
+- Scala `3` is upgraded to `3.3.7`.
 - Legacy `sun.misc.Unsafe`-based internals were removed in favor of JDK `VarHandle`-based implementations.
 
 This release was made possible by the work and feedback of:

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ a project exemplifying Monix used both on the server and on the client.
 Compatibility baseline:
 
 - JDK `17` minimum (`21` validated)
-- Scala `2.13.18` and Scala `3.8.3`
+- Scala `2.13.18` and Scala `3.3.7`
 
 For the stable release (compatible with Cats, and Cats-Effect 2.x):
  

--- a/build.sbt
+++ b/build.sbt
@@ -206,7 +206,6 @@ lazy val sharedSettings = pgpSettings ++ Def.settings(
         )
       case Some((3, _)) =>
         Seq(
-          "-Werror",
           "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
         )
       case _ =>
@@ -221,7 +220,7 @@ lazy val sharedSettings = pgpSettings ++ Def.settings(
         )
       case Some((3, _)) =>
         Seq(
-          // Scala 3.8.x surfaces a very large warning volume in legacy tests and doctests.
+          // Scala 3 surfaces a very large warning volume in legacy tests and doctests.
           // Keep -Werror for main sources, but silence test warnings to preserve CI signal.
           "-Wconf:any:silent"
         )

--- a/monix-catnap/shared/src/main/scala/monix/catnap/Semaphore.scala
+++ b/monix-catnap/shared/src/main/scala/monix/catnap/Semaphore.scala
@@ -25,6 +25,7 @@ import monix.execution.atomic.PaddingStrategy
 import monix.execution.atomic.PaddingStrategy.NoPadding
 import monix.execution.internal.GenericSemaphore
 import monix.execution.internal.GenericSemaphore.Listener
+import scala.annotation.unused
 import scala.concurrent.Promise
 
 /** The `Semaphore` is an asynchronous semaphore implementation that
@@ -277,6 +278,7 @@ object Semaphore {
     def greenLight[A](fa: F[A]): F[A] = source.withPermit(fa)
   }
 
+  @unused
   private final class Impl[F[_]](provisioned: Long, ps: PaddingStrategy)(
     implicit
     F: OrElse[Concurrent[F], Async[F]],

--- a/monix-eval/shared/src/main/scala/monix/eval/Coeval.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Coeval.scala
@@ -28,6 +28,7 @@ import monix.execution.annotations.UnsafeBecauseImpure
 import monix.execution.compat.BuildFrom
 import monix.execution.compat.internal.newBuilder
 
+import scala.annotation.unused
 import scala.annotation.unchecked.{ uncheckedVariance => uV }
 import scala.collection.mutable
 import scala.util.control.NonFatal
@@ -1612,6 +1613,7 @@ object Coeval extends CoevalInstancesLevel0 {
   }
 
   /** Used as optimization by [[Coeval.redeem]]. */
+  @unused
   private final class Redeem[A, B](fe: Throwable => B, fs: A => B) extends StackFrame[A, Coeval[B]] {
 
     def apply(a: A): Coeval[B] = Coeval.Now(fs(a))

--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -4845,6 +4845,7 @@ object Task extends TaskInstancesLevel1 {
   }
 
   /** Used as optimization by [[Task.redeem]]. */
+  @unused
   private final class Redeem[A, B](fe: Throwable => B, fs: A => B) extends StackFrame[A, Task[B]] {
     def apply(a: A): Task[B] = new Now(fs(a))
     def recover(e: Throwable): Task[B] = new Now(fe(e))

--- a/monix-execution/shared/src/main/scala/monix/execution/Callback.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/Callback.scala
@@ -20,6 +20,7 @@ package monix.execution
 import monix.execution.exceptions.{ CallbackCalledMultipleTimesException, UncaughtErrorException }
 import monix.execution.schedulers.{ TrampolineExecutionContext, TrampolinedRunnable }
 import monix.execution.compat.uninitialized
+import scala.annotation.unused
 import scala.concurrent.{ ExecutionContext, Promise }
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
@@ -491,10 +492,12 @@ object Callback {
     }
   }
 
+  @unused
   private final class Contramap[-E, -A, -B](underlying: Callback[E, A], f: B => A) extends Callback[E, B] {
     def onSuccess(value: B): Unit =
       underlying.onSuccess(f(value))
     def onError(error: E): Unit =
       underlying.onError(error)
   }
+
 }

--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/LoadBalanceConsumer.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/consumers/LoadBalanceConsumer.scala
@@ -27,7 +27,7 @@ import monix.reactive.Consumer
 import monix.reactive.internal.consumers.LoadBalanceConsumer.IndexedSubscriber
 import monix.reactive.observers.Subscriber
 
-import scala.annotation.tailrec
+import scala.annotation.{ tailrec, unused }
 import scala.collection.immutable.{ BitSet, Queue }
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.{ Future, Promise }
@@ -294,6 +294,7 @@ private[reactive] object LoadBalanceConsumer {
     */
   private[reactive] final case class IndexedSubscriber[-In](id: Int, out: Subscriber[In])
 
+  @unused
   private final class AsyncQueue[In](initialQueue: Queue[IndexedSubscriber[In]], parallelism: Int) {
 
     private val stateRef = {


### PR DESCRIPTION
Upgrading to Scala 3.8.x was premature, Monix should stay on the LTS versions.